### PR TITLE
changed sftp/ftp default file index behaviour

### DIFF
--- a/doc/UPGRADING.rst
+++ b/doc/UPGRADING.rst
@@ -38,6 +38,12 @@ Installation Instructions
 git origin/master branch
 ------------------------
 
+*CHANGE*: sr_poll ls now takes the [8:]th index instead of the -1 index to be 
+          the name, resolves bug with names containing spaces. If SFTP/FTP server 
+          being polled is not an Open BSD variant, an *ls_file_index* might need 
+          to be specified in the poll config to get previous behaviour. See sr\_
+          poll.1.rst for more info.
+
 2.18.08b1
 ---------
 

--- a/doc/sr_poll.1.rst
+++ b/doc/sr_poll.1.rst
@@ -200,9 +200,19 @@ The **on_line** plugin gives scripts that can read each line of an 'ls' on the p
 site, to interpret it further. It returns True if the line should be further processed,
 or False to reject it.  By default, there is a line_mode plugin included with the package
 which implements the comparison of file permissions on the remote server against
-the **chmod** mask. The program assumes that the very last word of the ls line is the
-filename. This might not be the case if filenames contain spaces. For this purpose, 
-the option **ls_file_index** can be used to set the first word where the filename starts.
+the **chmod** mask. The program assumes that the 8th index to the end of the line will 
+contain the filename, for example for the line::
+
+	drwxr-xr-x  2 aayla-secura root     4096 Jul 24 13:32 name with spaces
+
+it would take the name to be 'name with spaces'. If the SFTP/FTP server being connected to
+does not use the standard Open BSD version of ls and the name of the entry begins at a 
+different index, the option **ls_file_index** must be used. For example, in the case a Debian unstable
+derivative is used on the server and an ls line looks like this::
+
+	drwx------  2 ahsoka-tano root     4096 2018-08-20 11:44 name with spaces
+	
+**ls_file_index 7** should be used.
 
 If the poll fetches using the http protocol, the 'ls' like entries must be derived from
 an html page. The default plugin **html_page** provided with the package, gives an idea of

--- a/sarra/sr_ftp.py
+++ b/sarra/sr_ftp.py
@@ -322,7 +322,7 @@ class sr_ftp(sr_proto):
             if p == ''  : continue
             opart2.append(p)
 
-        fil  = opart2[-1]
+        fil  = ' '.join(opart2[8:])
         if not self.parent.ls_file_index in [-1,len(opart2)-1] : fil =  ' '.join(opart2[self.parent.ls_file_index:])
         line = ' '.join(opart2)
 

--- a/sarra/sr_sftp.py
+++ b/sarra/sr_sftp.py
@@ -373,13 +373,17 @@ class sr_sftp(sr_proto):
         alarm_cancel()
         for index in range(len(dir_attr)):
             attr = dir_attr[index]
+            try:
+                fil = attr.filename
+            except:
+                fil = ''
             line = attr.__str__()
-            self.line_callback(line)
+            self.line_callback(fil,line)
         #self.logger.debug("sr_sftp ls = %s" % self.entries )
         return self.entries
 
     # line_callback: ls[filename] = 'stripped_file_description'
-    def line_callback(self,iline):
+    def line_callback(self,ifil,iline):
         #self.logger.debug("sr_sftp line_callback %s" % iline)
 
         oline  = iline
@@ -393,7 +397,10 @@ class sr_sftp(sr_proto):
             if p == ''  : continue
             opart2.append(p)
 
-        fil  = opart2[-1]
+        if ifil:
+            fil = ifil
+        else:
+            fil = ' '.join(opart2[8:])
         if not self.parent.ls_file_index in [-1,len(opart2)-1] : fil =  ' '.join(opart2[self.parent.ls_file_index:])
         line = ' '.join(opart2)
 


### PR DESCRIPTION
Changed ls implementations for SFTP/FTP to take ls index of [8:] to be the name of the listing, instead of the last entry by default. Updated corresponding documentation