### PR TITLE
sftp/ftp determines file_index on connection, doesn't need it explicitly set

### DIFF
--- a/doc/UPGRADING.rst
+++ b/doc/UPGRADING.rst
@@ -38,12 +38,6 @@ Installation Instructions
 git origin/master branch
 ------------------------
 
-*CHANGE*: sr_poll ls now takes the [8:]th index instead of the -1 index to be 
-          the name, resolves bug with names containing spaces. If SFTP/FTP server 
-          being polled is not an Open BSD variant, an *ls_file_index* might need 
-          to be specified in the poll config to get previous behaviour. See sr\_
-          poll.1.rst for more info.
-
 2.18.08b1
 ---------
 

--- a/doc/sr_poll.1.rst
+++ b/doc/sr_poll.1.rst
@@ -200,19 +200,7 @@ The **on_line** plugin gives scripts that can read each line of an 'ls' on the p
 site, to interpret it further. It returns True if the line should be further processed,
 or False to reject it.  By default, there is a line_mode plugin included with the package
 which implements the comparison of file permissions on the remote server against
-the **chmod** mask. The program assumes that the 8th index to the end of the line will 
-contain the filename, for example for the line::
-
-	drwxr-xr-x  2 aayla-secura root     4096 Jul 24 13:32 name with spaces
-
-it would take the name to be 'name with spaces'. If the SFTP/FTP server being connected to
-does not use the standard Open BSD version of ls and the name of the entry begins at a 
-different index, the option **ls_file_index** must be used. For example, in the case a Debian unstable
-derivative is used on the server and an ls line looks like this::
-
-	drwx------  2 ahsoka-tano root     4096 2018-08-20 11:44 name with spaces
-	
-**ls_file_index 7** should be used.
+the **chmod** mask.
 
 If the poll fetches using the http protocol, the 'ls' like entries must be derived from
 an html page. The default plugin **html_page** provided with the package, gives an idea of

--- a/sarra/sr_ftp.py
+++ b/sarra/sr_ftp.py
@@ -211,6 +211,8 @@ class sr_ftp(sr_proto):
 
                 self.ftp = ftp
 
+                self.init_ls()
+
                 alarm_cancel()
                 return True
 
@@ -295,6 +297,15 @@ class sr_ftp(sr_proto):
 
         self.batch       = 0
 
+    # init_ls
+    def init_ls(self):
+        self.logger.debug("sr_ftp init_ls")
+        self.init_nlst = sorted(self.ftp.nlst())
+        self.logger.debug("sr_ftp nlst: %s" % self.init_nlst)
+        self.init_nlst_index = 0
+        if self.init_nlst:
+            self.ftp.retrlines('LIST', self.ls_file_index )
+
     # ls
     def ls(self):
         self.logger.debug("sr_ftp ls")
@@ -321,12 +332,41 @@ class sr_ftp(sr_proto):
         for p in opart1 :
             if p == ''  : continue
             opart2.append(p)
-
-        fil  = ' '.join(opart2[8:])
+        # else case is in the event of unlikely race condition
+        if hasattr(self, 'file_index'): fil = ' '.join(opart2[self.file_index:])
+        else: fil = ' '.join(opart2[8:])
+        # next line is for backwards compatibility only
         if not self.parent.ls_file_index in [-1,len(opart2)-1] : fil =  ' '.join(opart2[self.parent.ls_file_index:])
         line = ' '.join(opart2)
 
         self.entries[fil] = line
+
+        alarm_set(self.iotime)
+
+    # ls_file_index
+    def ls_file_index(self,iline):
+        self.logger.debug("sr_ftp ls_file_index %s" % iline)
+
+        alarm_cancel()
+
+        oline = iline
+        oline = oline.strip('\n')
+        oline = oline.strip()
+        oline = oline.replace('\t',' ')
+        opart1 = oline.split(' ')
+        opart2 = []
+
+        for p in opart1 :
+            if p == ''  : continue
+            opart2.append(p)
+
+        try:
+            file_index = opart2.index(self.init_nlst[self.init_nlst_index])
+            self.file_index = file_index
+        except:
+            pass
+        finally:
+            self.init_nlst_index += 1
 
         alarm_set(self.iotime)
 


### PR DESCRIPTION
The file_index of an ls listing gets determined upon connection. Adds ~0.2s of overhead with every connection (every time sr_poll wakes up), but resolves any issues with whitespace characters in filenames and there is no longer a burden on the end user to determine where the file index is in the SFTP/FTP server they're connecting to. 

Still backwards compatible with the ls_file_index config option, but can now be safely phased out.