### PR TITLE
feature added: config include directive support for globbing #31

### DIFF
--- a/doc/UPGRADING.rst
+++ b/doc/UPGRADING.rst
@@ -38,6 +38,10 @@ Installation Instructions
 git origin/master branch
 ------------------------
 
+*CHANGE*: sr_config include option now supports globbing. If your config filename
+          contains special regex characters (e.g. '?', '*' and '[' ']') then they
+          need to be escaped in the config or else it will attempt to interpret
+          them as regex.
 
 2.18.08b1
 ---------

--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -35,7 +35,7 @@
 import logging
 import inspect
 import netifaces
-import os,re,socket,sys,random
+import os,re,socket,sys,random,glob
 import urllib,urllib.parse, urllib.request, urllib.error
 from   appdirs import *
 import shutil
@@ -1542,8 +1542,13 @@ class sr_config:
                      n = 2
 
                 elif words0 in ['config','c','include']: # See: sr_config.7
-                     ok, include = self.config_path(self.config_dir,words1,mandatory=True,ctype='inc')
-                     self.config(include)
+                     confs = glob.glob(words1)
+                     for conf in confs:
+                         ok, include = self.config_path(self.config_dir,conf,mandatory=True,ctype='inc')
+                         self.config(include)
+                     if not confs:
+                         ok, include = self.config_path(self.config_dir,words1,mandatory=True,ctype='inc')
+                         self.config(include)
                      n = 2
 
                 elif words0 == 'debug': # See: sr_config.7


### PR DESCRIPTION
Config files can now interpret globbing arguments such as `include *.conf`. Any files that contain *, ?, [ or ] in their names need to be escaped.