### PR TITLE
Issue54: Commandline config options for setting checksum xattr

### DIFF
--- a/doc/sr_post.1.rst
+++ b/doc/sr_post.1.rst
@@ -322,7 +322,18 @@ common settings, and methods of specifying them.
 
   Add a <name> header with the given value to advertisements. Used to pass strings as metadata.
 
+[-header sum=<flag,sum>]
+~~~~~~~~~~~~~~~~~~~~~~~~
 
+  Checksums can be attached to a file by specifying the sum string value in the header on startup with the 
+  'a' (application) scheme indicated::
+
+      sr_post -header sum=a,65537 <fileName(s)> <configName> start|foreground
+
+  where **fileName(s)** can be a list of space separated files or a value containing regex syntax (path must
+  be specified if not located in the current directory). The **user.sr_sum** and **user.sr_mtime** extended 
+  attributes of the files will be updated before being posted. These attributes can also be set using 
+  commandline utilities like xattr. 
 
 
 ADMINISTRATOR SPECIFIC

--- a/doc/sr_post.1.rst
+++ b/doc/sr_post.1.rst
@@ -4,7 +4,7 @@
 =========
 
 ------------------------------------------------
-Publish the Availability of a File to Subcribers
+Publish the Availability of a File to Subscribers
 ------------------------------------------------
 
 :Manual section: 1 

--- a/doc/sr_post.7.rst
+++ b/doc/sr_post.7.rst
@@ -457,6 +457,20 @@ represented by UTF-8 encoding (IETF RFC 3629).
 URL encoding, as per IETF RFC 1738, is used to escape unsafe characters where appropriate.
 
 
+EXTENDED FILE ATTRIBUTES
+------------------------
+
+Checksums can be attached to a file by specifying the sum string value in the header on startup with the
+'a' (application) scheme indicated::
+
+    sr_post -header sum=a,65537 <fileName(s)> <configName> start|foreground
+
+where **fileName(s)** can be a list of space separated files or a value containing regex syntax. The
+**user.sr_sum** and **user.sr_mtime** extended attributes of the files will be updated before being 
+posted. These attributes can also be set using commandline utilities like xattr. Likewise, the 
+optimization extends towards sarra instances that download the files as well, as outlined in the 
+`sr_subscribe(1) <sr_subscribe.1.rst>`_ documentation.
+
 FURTHER READING
 ---------------
 

--- a/doc/sr_post.7.rst
+++ b/doc/sr_post.7.rst
@@ -467,20 +467,6 @@ represented by UTF-8 encoding (IETF RFC 3629).
 URL encoding, as per IETF RFC 1738, is used to escape unsafe characters where appropriate.
 
 
-EXTENDED FILE ATTRIBUTES
-------------------------
-
-Checksums can be attached to a file by specifying the sum string value in the header on startup with the
-'a' (application) scheme indicated::
-
-    sr_post -header sum=a,65537 <fileName(s)> <configName> start|foreground
-
-where **fileName(s)** can be a list of space separated files or a value containing regex syntax. The
-**user.sr_sum** and **user.sr_mtime** extended attributes of the files will be updated before being 
-posted. These attributes can also be set using commandline utilities like xattr. Likewise, the 
-optimization extends towards sarra instances that download the files as well, as outlined in the 
-`sr_subscribe(1) <sr_subscribe.1.rst>`_ documentation.
-
 FURTHER READING
 ---------------
 

--- a/doc/sr_subscribe.1.rst
+++ b/doc/sr_subscribe.1.rst
@@ -2014,6 +2014,28 @@ look in the *plugins* directory in the users config tree, then in the site
 directory, then in the sarracenia package itself, and finally it will look remotely.
 
 
+EXTENDED FILE ATTRIBUTES
+========================
+
+Files can be posted with extended attributes containing their checksum data to prevent unneccessary file
+reads for checksum computation. This optimization can be useful when dealing with a lot of posted/downloaded
+files and for using application- or user-defined checksums.
+
+Extended file attributes are filesystem features that allow users to associate files with extra customized
+metadata in the form of name=value pairs (RFC 8276). This functionality is only available on certain Linux
+filesystems.
+
+Checksums can be attached to a file by specifying the sum string value in the header on startup with the 
+'a' (application) scheme indicated::
+
+    sr_subscribe -header sum=a,65537 <fileName(s)> <configName> start|foreground
+
+where **fileName(s)** can be a list of space separated files or a value containing regex syntax. The 
+**user.sr_sum** and **user.sr_mtime** extended attributes of the files will be updated before starting
+the sarra process. These attributes can also be set using commandline utilities like xattr. Likewise, 
+the optimization extends towards sarra instances that post the files as well, as outlined in the 
+`sr_post(7) <sr_post.7.rst>`_ documentation.
+
 
 
 SEE ALSO

--- a/doc/sr_subscribe.1.rst
+++ b/doc/sr_subscribe.1.rst
@@ -2014,30 +2014,6 @@ look in the *plugins* directory in the users config tree, then in the site
 directory, then in the sarracenia package itself, and finally it will look remotely.
 
 
-EXTENDED FILE ATTRIBUTES
-========================
-
-Files can be posted with extended attributes containing their checksum data to prevent unneccessary file
-reads for checksum computation. This optimization can be useful when dealing with a lot of posted/downloaded
-files and for using application- or user-defined checksums.
-
-Extended file attributes are filesystem features that allow users to associate files with extra customized
-metadata in the form of name=value pairs (RFC 8276). This functionality is only available on certain Linux
-filesystems.
-
-Checksums can be attached to a file by specifying the sum string value in the header on startup with the 
-'a' (application) scheme indicated::
-
-    sr_subscribe -header sum=a,65537 <fileName(s)> <configName> start|foreground
-
-where **fileName(s)** can be a list of space separated files or a value containing regex syntax. The 
-**user.sr_sum** and **user.sr_mtime** extended attributes of the files will be updated before starting
-the sarra process. These attributes can also be set using commandline utilities like xattr. Likewise, 
-the optimization extends towards sarra instances that post the files as well, as outlined in the 
-`sr_post(7) <sr_post.7.rst>`_ documentation.
-
-
-
 SEE ALSO
 ========
 

--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -35,7 +35,7 @@
 import logging
 import inspect
 import netifaces
-import os,re,socket,sys,random,glob
+import os,re,socket,sys,random,glob,time
 import urllib,urllib.parse, urllib.request, urllib.error
 from   appdirs import *
 import shutil
@@ -50,6 +50,13 @@ except: pass
 
 import paramiko
 from   paramiko import *
+
+try:
+    import xattr
+    supports_extended_attributes=True
+
+except:
+    supports_extended_attributes=False
 
 try :
          from sr_checksum          import *
@@ -1796,7 +1803,19 @@ class sr_config:
                         self.headers_to_del.append(key)
                      else :
                         self.headers_to_add [key] = value
-                     n = 2
+
+                     if supports_extended_attributes:
+                        if key.lower() == "sum":
+                           n = len(words[2:]) + 2
+                           for xfile in words[2:]:
+                              xattr.setxattr(xfile, 'user.sr_sum', bytes(value,"utf-8"))
+                              xmtime = timeflt2str(time.time())
+                              xattr.setxattr(xfile, 'user.sr_mtime', bytes(xmtime,"utf-8"))
+                              self.logger.debug("xattr sum set for file: {0} => {1}".format(xfile, value))
+                        else:
+                           n = 2
+                     else:
+                        n = 2
 
                 elif words0 in ['gateway_for','gf']: # See: sr_config.7, sr_sarra.8, sr_sender.1 
                      self.gateway_for = words1.split(',')

--- a/sarra/sr_post.py
+++ b/sarra/sr_post.py
@@ -569,7 +569,7 @@ class sr_post(sr_instances):
                attr = xattr.xattr(path)
                if 'user.sr_sum' in attr:
                   if 'user.sr_mtime' in attr:
-                     if attr['user.sr_mtime'].decode("utf-8") == self.msg.headers['mtime']:
+                     if attr['user.sr_mtime'].decode("utf-8") >= self.msg.headers['mtime']:
                         self.logger.debug("sum set by xattr")
                         sumstr = attr['user.sr_sum'].decode("utf-8")
                         return sumstr


### PR DESCRIPTION
Includes documentation for usage/background (I wasn't sure where to stick it, let me know if there's a better place or if there's anything that's missing). Continuation of #54, outline of logic in #119.

### Usage
#### Posting
`sr_post -header sum=a,65537 <fileName(s)> <configName> start|foreground`

#### Downloading
`sr_subscribe -header sum=a,65537 <fileName(s)> <configName> start|foreground`