### PR TITLE
Issue54: Fixes header evaluation options in sr_config

### DIFF
--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -1805,16 +1805,15 @@ class sr_config:
 
                      if supports_extended_attributes:
                         if key.lower() == "sum":
-                           n = len(words[2:]) + 2
-                           for xfile in words[2:]:
+                           glob_lst = []
+                           glob_lst.extend(glob.glob(word) for word in words[2:] if word != [])
+                           file_lst = [f for sub_lst in glob_lst for f in sub_lst]  
+                           for xfile in file_lst:
                               xattr.setxattr(xfile, 'user.sr_sum', bytes(value,"utf-8"))
                               xmtime = timeflt2str(time.time())
                               xattr.setxattr(xfile, 'user.sr_mtime', bytes(xmtime,"utf-8"))
                               self.logger.debug("xattr sum set for file: {0} => {1}".format(xfile, value))
-                        else:
-                           n = 2
-                     else:
-                        n = 2
+                     n = 2
 
                 elif words0 in ['gateway_for','gf']: # See: sr_config.7, sr_sarra.8, sr_sender.1 
                      self.gateway_for = words1.split(',')


### PR DESCRIPTION
Addresses commandline usage for setting sums as discussed in #121. Doesn't necessarily assume the files to set xattrs for are right after the `-header sum=a,sum` option. 