### PR TITLE
issue207: MG les fix pour le sender inplace  

### DIFF
--- a/sarra/sr_message.py
+++ b/sarra/sr_message.py
@@ -126,6 +126,7 @@ class sr_message():
         self.partflg       =  partflg 
         self.partstr       = '%s,%d,%d,%d,%d' %\
                              (partflg,self.chunksize,self.block_count,self.remainder,self.current_block)
+        self.headers['parts'] = self.partstr
 
     def content_should_not_be_downloaded(self):
         """
@@ -793,6 +794,17 @@ class sr_message():
               self.target_relpath = self.new_relpath
               part_file           = self.new_file + self.suffix
               part_relpath        = self.new_relpath + self.suffix
+
+
+           # sparse file is tolerated in sr_sender
+           # so part inplace whatever the condition of the target_file
+
+           if self.parent.program_name == 'sr_sender' :  
+              self.new_file     = self.target_file
+              self.new_relpath  = self.target_relpath
+              self.local_offset = self.offset
+              self.in_partfile  = False
+              return
 
            # default setting : redirect to temporary part file
 

--- a/sarra/sr_util.py
+++ b/sarra/sr_util.py
@@ -672,6 +672,8 @@ class sr_transport():
 
                 offset = 0
                 if  msg.partflg == 'i': offset = msg.offset
+
+                new_offset = msg.local_offset
     
                 str_range = ''
                 if msg.partflg == 'i' :
@@ -680,9 +682,7 @@ class sr_transport():
                 #upload file
     
                 if inflight == None or msg.partflg == 'i' :
-                   #self.put(local_file, new_file, offset, offset, msg.length)
-                   # If remote offset is not 0 then partitions are prepender with all 0s...
-                   self.put(local_file, new_file, offset, 0, msg.length)
+                   self.put(local_file, new_file, offset, new_offset, msg.length)
                 elif inflight == '.' :
                    new_lock = '.'  + new_file
                    self.put(local_file, new_lock )


### PR DESCRIPTION
#207 
ok il y a des fixes dans cette branche pour corriger le "inplace true"  dans le sender.
Aussi dans la propagation d un sarra ...  message recu avec un partflg I  avec l option implace False
downloaded dans un fichier part  tout fonctionnait  ... mais le message etait reposter avec un I au lieu
d un P   ca aussi ete corriger