### PR TITLE
Issue201

### DIFF
--- a/sarra/plugins/pxSender_log.py
+++ b/sarra/plugins/pxSender_log.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+
+"""
+This plugin should be used in a sr_sender 
+It registeres for ftp/sftp 
+and does nothing but logging the sending message
+as if it was a sundew pxSender process
+
+No files are actually being sent
+
+Sample usage:
+
+  plugin pxSender_log.py
+
+The purpose is to prepare sr_sender configurations
+and just log as a pxSender process to verify that
+the conversion was correct
+
+Bash scripds can be run on logs to make sure all products
+and renaming were addressed properly
+
+"""
+
+import os,stat,time,sys
+import calendar
+
+class PXSENDER_LOG(object): 
+
+   import urllib.parse
+
+   def __init__(self,parent):
+       self.registered_list = [ 'http', 'ftp','sftp' ]
+
+   def do_download(self,parent):
+       parent.on_file_list = []
+       msg    = parent.msg
+
+       src  = msg.baseurl + ':' + msg.relpath
+       src  = src.replace(' ','\ ')
+
+       dest = msg.new_dir + os.sep + msg.new_file
+
+       self.pxSender_print(parent,src,dest)
+
+       return True
+
+   def do_send(self,parent):
+       msg    = parent.msg
+
+       src  = parent.document_root + msg.relpath
+       src  = src.replace(' ','\ ')
+
+       dest = parent.destination + msg.new_dir + os.sep + msg.new_file
+
+       self.pxSender_print(parent,src,dest)
+
+       return True
+
+   def pxSender_print(self,parent,src,dest):
+       logger = parent.logger
+       msg    = parent.msg
+       
+       if msg.headers['sum'][0] == 'L' : return True
+       if msg.headers['sum'][0] == 'R' : return True
+
+       # file size
+       parts = msg.partstr.split(',')
+       if parts[0] == '1':
+           sz=int(parts[1])
+       else:
+           sz=int(parts[1])*int(parts[2])
+
+       logger.info("(%d Bytes) File %s delivered to %s (lat=0.1,speed=0.1)",sz,src,dest)
+
+   def registered_as(self) :
+       return self.registered_list
+
+self.plugin='PXSENDER_LOG'

--- a/sarra/sr_cache.py
+++ b/sarra/sr_cache.py
@@ -58,6 +58,7 @@ class sr_cache():
 
         self.cache_dict    = {}
         self.cache_file    = None
+        self.cache_hit     = None
         self.fp            = None
 
         self.cache_basis =  parent.cache_basis
@@ -67,6 +68,9 @@ class sr_cache():
 
     def check(self, key, path, part):
         self.logger.debug("sr_cache check basis=%s" % self.cache_basis )
+
+        # not found 
+        self.cache_hit = None
 
         # set time and value
         now   = time.time()
@@ -89,6 +93,7 @@ class sr_cache():
            self.cache_dict[key] = kdict
            self.fp.write("%s %f %s %s\n"%(key,now,qpath,part))
            self.count += 1
+           # new entry
            return True
 
         # key (sum) in cache ... 
@@ -100,13 +105,57 @@ class sr_cache():
         present = value in kdict
         kdict[value] = now
 
-        if not present : self.logger.debug("differ")
-
         # differ or newer, write to file
 
         self.fp.write("%s %f %s %s\n"%(key,now,qpath,part))
         self.count += 1
-        return not present
+
+        # present = old entry
+
+        if present :
+           self.cache_hit = value
+           return False
+
+        # if not present and not a part : it is a new entry
+
+        if not part[0] in "pi" :
+           self.logger.debug("differ")
+           return True
+
+        # if weird part ... its a new entry
+
+        ptoken = part.split(',')
+        if len(ptoken) < 4 :
+           self.logger.debug("differ")
+           return True
+
+        # build a wiser dict value without
+        # block_count and remainder (ptoken 2 and 3)
+
+        pvalue = value
+        pvalue = pvalue.replace(','+ptoken[2],'',10)
+        pvalue = pvalue.replace(','+ptoken[3],'',10)
+
+        # check every key in kdict
+        # build a similar value to compare with pvalue
+
+        for value in kdict :
+
+            kvalue = value
+            kvalue = kvalue.replace(','+ptoken[2],'',10)
+            kvalue = kvalue.replace(','+ptoken[3],'',10)
+
+            # if we find the value... its in cache... its old
+
+            if pvalue == kvalue :
+               self.cache_hit = value
+               return False
+
+        # did not find it... its new
+
+        self.logger.debug("differ")
+
+        return True
 
     def check_msg(self, msg):
         self.logger.debug("sr_cache check_msg")

--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -1315,6 +1315,13 @@ class sr_config:
 
              ndestDir += "/" + nddword 
 
+        # This code might add an unwanted '/' in front of ndestDir
+        # if destDir does not start with a substitution $ and
+        # if destDir does not start with a / ... it does not need one
+
+        if destDir[0] != '$' and destDir[0] != '/' :
+            if ndestDir[0] == '/' : ndestDir = ndestDir[1:]
+
         return ndestDir
 
     def sundew_getDestInfos(self, filename):
@@ -1397,10 +1404,17 @@ class sr_config:
                  self.msg.new_file  = saved_new_file
                  if destFileName == None : destFileName = old_destFileName
             elif spec == 'TIME':
-                if destFileName != filename :
-                   timeSuffix = ':' + time.strftime("%Y%m%d%H%M%S", time.gmtime())
-                   # check for PX or PDS behavior ... if file already had a time extension keep his...
-                   if parts[-1][0] == '2' : timeSuffix = ':' + parts[-1]
+                 timeSuffix = ':' + time.strftime("%Y%m%d%H%M%S",time.gmtime())
+                 if hasattr(self.msg,'time') :
+                    timeSuffix = ":" + self.msg.time.split('.')[0]
+                 if hasattr(self.msg,'pubtime') :
+                    timeSuffix = ":" + self.msg.pubtime.split('.')[0]
+                    timeSuffix = timeSuffix.replace('T','')
+                 # check for PX or PDS behavior ...
+                 # if file already had a time extension keep his...
+                 if len(parts[-1]) == 14 and parts[-1][0] == '2' :
+                    timeSuffix = ':' + parts[-1]
+
             else:
                 self.logger.error("Don't understand this DESTFN parameter: %s" % spec)
                 return (None, None) 


### PR DESCRIPTION
#201    in this branch there is a partial fix to the part file caching...
            it is enough to have Daniel Leveille continue his development of the logging  solution
            provided that his sarra processes and sender processes  use inplace True.

            There is a fix with sr_config sundew_getDestInfos because if an option like
            filename NONE:TIME  would be used...  the time suffix was never added

            There is a fix with sr_config  sundew_dirPattern  because if  an option like
            directory  dir1/dir2/.../dirN      would be given... the function would add a / in front
            even if no substitution would take place.

            The plugin pxSender_log.py  was added.  If used in a sr_sender, it logs as if it was
             a pxSender process without sending any products.  It can be used to double check
             a sr_sender config  in parallel with its sundew conterpart.   Once proven that the sarra
             side would deliver as many and as accurately as the sundew process... simply remove
             the plugin  and  stop the sundew side process will do the migration.