### PR TITLE
Issue212

### DIFF
--- a/sarra/plugins/html_page.py
+++ b/sarra/plugins/html_page.py
@@ -12,6 +12,29 @@ class Html_parser():
         self.parser.handle_starttag = self.handle_starttag
         self.parser.handle_data     = self.handle_data
 
+    def file_size_fix(self):
+        try:
+               str_value = self.mysize
+
+               factor = 1
+               if   str_value[-1] in 'bB'   : str_value = str_value[:-1]
+               elif str_value[-1] in 'kK'   : factor = 1024
+               elif str_value[-1] in 'mM'   : factor = 1024 * 1024
+               elif str_value[-1] in 'gG'   : factor = 1024 * 1024 * 1024
+               elif str_value[-1] in 'tT'   : factor = 1024 * 1024 * 1024 * 1024
+               if str_value[-1].isalpha() : str_value = str_value[:-1]
+
+               fsize = (float(str_value) + 0.5) * factor
+               isize = int(fsize)
+
+               self.mysize = "%d" % isize
+
+        except:
+               self.logger.debug("bad size %s" % self.mysize)
+               return
+
+        return
+
     def handle_starttag(self, tag, attrs):
         for attr in attrs:
             c,n = attr
@@ -35,14 +58,16 @@ class Html_parser():
         except: t = time.strptime(sdate,'%Y-%m-%d %H:%M')
         mydate = time.strftime('%b %d %H:%M',t)
 
-        mysize = words[-1]
+        self.mysize = words[-1]
+        self.file_size_fix()
 
         if self.myfname[-1] != '/':
-              self.entries[self.myfname] = '-rwxr-xr-x 1 101 10 ' + mysize + ' ' + mydate + ' ' + self.myfname
+              self.entries[self.myfname] = '-rwxr-xr-x 1 101 10 ' + self.mysize + ' ' + mydate + ' ' + self.myfname
         else:
-              self.entries[self.myfname] = 'drwxr-xr-x 1 101 10 ' + mysize + ' ' + mydate + ' ' + self.myfname
+              self.entries[self.myfname] = 'drwxr-xr-x 1 101 10 ' + self.mysize + ' ' + mydate + ' ' + self.myfname
 
         self.myfname = None
+
 
     def parse(self,parent):
         self.logger.debug("Html_parser parse")

--- a/sarra/plugins/on_file_repair_size.py
+++ b/sarra/plugins/on_file_repair_size.py
@@ -1,0 +1,29 @@
+"""
+   http size was 4.1M an approximation
+   get the right size set in post message
+"""
+
+class Repair_Size(object):
+      def __init__(self,parent) :
+          pass
+
+      def on_file(self, parent ):
+          import os,stat
+
+          logger  = parent.logger
+          msg     = parent.msg
+          path    = msg.new_dir + '/' + msg.new_file
+          fsiz    = os.stat(path)[stat.ST_SIZE]
+          partstr = '1,%d,1,0,0' % fsiz
+
+          if partstr == msg.partstr : return True
+
+          msg.partstr          = partstr
+          msg.headers['parts'] = msg.partstr
+
+          parent.logger.debug("file size repaired in message %s" % partstr)
+
+          return True
+
+repair_size=Repair_Size(self)
+self.on_file=repair_size.on_file

--- a/sarra/sr_http.py
+++ b/sarra/sr_http.py
@@ -215,6 +215,15 @@ class sr_http(sr_proto):
         try:
                 # when credentials are needed.
                 if self.user != None :                          
+
+                   # takeaway credentials info from urlstr
+                   cred        = self.user + '@'
+                   self.urlstr = self.urlstr.replace(cred,'')
+                   if self.password != None :                          
+                      cred        = self.user + ':' + self.password +'@'
+                      self.urlstr = self.urlstr.replace(cred,'')
+
+                   # continue with authentication
                    password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
                    password_mgr.add_password(None, self.urlstr,self.user,self.password)
                    handler = urllib.request.HTTPBasicAuthHandler(password_mgr)


### PR DESCRIPTION
#212 

plugins/html_page.py

   there are a lot of web pages where the size of file is approximated 
   to value like 12K or  4.12M. What happened was that the post would not
   have a partflg and sarra would not use the message without it.

   So a fix to this for now, is to have the plugin html_page.py to
   compute from these values a size in bytes (rounding up necessary).

   plugins/on_file_repair_size.py

   When there is the situation previously described happen, the sr_sarra
   process downloading the file gives an error for the mismatched size.
   In order to propagate the right file size, this plugin fix it in the
   message that will be posted.

   sr_http.py

   sr_poll posts message with user in base_url. This is a good thing because
   there can be many users using the same protocol on the same server.
   The bug was that sr_http.py was leaving the user in the url for https
   message. This code implements the removal of any credentials in the url
   before using it. In the mean time, one can make a plugin like
   on_msg_remove_user.py on the sarra process'side but that works only
   for a single user case.
