### PR TITLE
Issue276: Regression Fix, missing partstr support

### DIFF
--- a/sarra/sr_message.py
+++ b/sarra/sr_message.py
@@ -92,6 +92,9 @@ class sr_message():
         self.offset = None
         self.filesize = None
 
+        # Setting default length
+        self.length = 0
+
         self.inline = parent.inline
         self.inline_max = parent.inline_max
         self.post_base_dir = parent.post_base_dir

--- a/sarra/sr_message.py
+++ b/sarra/sr_message.py
@@ -82,6 +82,7 @@ class sr_message():
         self.sumflg        = None
 
         # Default value for parts attributes
+        self.partflg = None
         self.chunksize = None
         self.length = None
         self.block_count = None
@@ -123,7 +124,6 @@ class sr_message():
         self.to_clusters = []
         self.tbegin = nowflt()
         self.pubtime = None
-        self.partflg       =  None
 
     def change_partflg(self, partflg ):
         self.partflg       =  partflg


### PR DESCRIPTION
Issue #276 

Tested fix by using a plugin that doesn't include a partstr in message headers, and observing subscriber behaviour. Looking good here, no more TypeErrors.
Flow test passing as well.
