### PR TITLE
removed missing directory traceback from debug logs

### DIFF
--- a/sarra/sr_poll.py
+++ b/sarra/sr_poll.py
@@ -102,7 +102,6 @@ class sr_poll(sr_post):
                   return True
         except :
                   self.logger.warning("sr_poll/cd: could not cd to directory %s" % path )
-                  self.logger.debug('Exception details: ', exc_info=True)
         return False
 
     def check(self):


### PR DESCRIPTION
Issue #275 
sr_poll doesn't crash when attempting to enter an non-existent directory, as previously hypothesized. poll code catches the exception successfully, logs a stack trace, and continues working properly.  

changes: removed stack trace print on caught failed cd exception, purely esthetic, for analyst convenience