### PR TITLE
Issue245 - reduce overhead of poll when they don´t have the vip.

### DIFF
--- a/doc/fr/sr_poll.1.rst
+++ b/doc/fr/sr_poll.1.rst
@@ -155,10 +155,11 @@ la destination qui est *pollé* (*sondé*) même quand ce n´est pas ce noeud qu
 va annoncer les nouveaux arrivés.
 
 Si les noeuds qui n´ont pas le vip peuvent être réélement entièrement passifs,
-on peut setté **poll_without_vip** à *False* (or *off*). Ceci peut réduire
-la charge sur les noeuds de facon significative (mésure à vingt fois moins
-de charge dans un cas.)  C´est donc utile de le choisir quand l´efficacité
-de la configuration global est une enjeu.
+comme si les *sarra* corréspondants on *delete* actif, alors il n´ont pas besoin
+de se maintenir à jour, on peut setter **poll_without_vip** à *False* (or *off*). 
+Ceci peut réduire la charge sur les noeuds de facon significative (mésuré à vingt fois 
+moins de charge dans un cas exemplaire.)  C´est donc utile de le choisir quand 
+l´efficacité de la configuration global est une enjeu.
 
 
 

--- a/doc/fr/sr_poll.1.rst
+++ b/doc/fr/sr_poll.1.rst
@@ -91,10 +91,11 @@ Ces options définissent les fichiers pour lesquels l'utilisateur veut être
 notifié et où il doit être notifié il sera placé, et sous quel nom.
  
 - **filename  <option>         (optionnel)**
-- **directory <path>           (defaut: .)**
-- **accept    <patron regexp> [rename=] (must be set)**
+- **directory <path>           (défaut: .)**
+- **accept    <patron regexp> [rename=] (mandatoire)**
 - **reject    <patron regexp> (optionnel)**
-- **chmod     <integer>        (defaut: 0o400)**
+- **chmod     <integer>        (défaut: 0o400)**
+- **poll_without_vip <on|off>  (défaut: on)**
 
 L'option *filename* peut être utilisée pour définir un renommage global des produits.
 Ex.. :
@@ -146,6 +147,19 @@ ce qui signifie qu'un fichier ne sera pas publié à moins que le groupe n'ait l
 (sur une sortie ls qui ressemble à : ---r-----, comme un chmod 040 <fichier <fichier>commande).
 L'option **chmod** spécifie un masque, c'est à dire que les permissions doivent être
 au moins ce qui est spécifié.
+
+Comme tout les componsants, l'option **vip** signale que plusieurs noeuds
+dans une grappe participent et que le composant devraient être actif uniquement
+sur un noeud à la fois.  Souvent le *poll* doit se garder à jour de l´état sur
+la destination qui est *pollé* (*sondé*) même quand ce n´est pas ce noeud qui
+va annoncer les nouveaux arrivés.
+
+Si les noeuds qui n´ont pas le vip peuvent être réélement entièrement passifs,
+on peut setté **poll_without_vip** à *False* (or *off*). Ceci peut réduire
+la charge sur les noeuds de facon significative (mésure à vingt fois moins
+de charge dans un cas.)  C´est donc utile de le choisir quand l´efficacité
+de la configuration global est une enjeu.
+
 
 
 

--- a/doc/sr_poll.1.rst
+++ b/doc/sr_poll.1.rst
@@ -92,6 +92,7 @@ These options set what files the user wants to be notified for and where
 - **accept    <regexp pattern> [rename=] (must be set)**
 - **reject    <regexp pattern> (optional)**
 - **chmod     <integer>        (default: 0o400)**
+- **poll_without_vip  <boolean> (default: True)**
 
 The option *filename* can be used to set a global rename to the products.
 Ex.:
@@ -149,6 +150,16 @@ means that a file will not be posted unless the group has read permission
 The **chmod** options specifies a mask, that is the permissions must be 
 at least what is specified.  
 
+As with all other components, the **vip** option can be used to indicate
+that a poll should be active on only a single node in a cluster. Note that
+as the poll will maintain state (such as the list of files that exist on the
+remote hosts), by default, the vip will only keep the component from posting, 
+but the actual poll will still happen, which can involve a high an unnecessary
+load on the nodes that do not have the vip.
+
+To have the nodes which do not have the vip perform no work, set the
+**poll_without_vip** option to *False* (or *off*).  This may reduce overhead
+forty-fold in some measured cases.
 
 
 POSTING SPECIFICATIONS

--- a/doc/sr_poll.1.rst
+++ b/doc/sr_poll.1.rst
@@ -157,9 +157,11 @@ remote hosts), by default, the vip will only keep the component from posting,
 but the actual poll will still happen, which can involve a high an unnecessary
 load on the nodes that do not have the vip.
 
-To have the nodes which do not have the vip perform no work, set the
-**poll_without_vip** option to *False* (or *off*).  This may reduce overhead
-forty-fold in some measured cases.
+To have the nodes which do not have the vip perform no work, for example
+if the corresponding sarra components have *delete* set, so that no state
+persistence is needed in the poll, set the **poll_without_vip** option 
+to *False* (or *off*). This reduces overhead forty-fold in some measured 
+cases.  
 
 
 POSTING SPECIFICATIONS

--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -326,8 +326,8 @@ class sr_config:
            ( self.inflight, self.events, self.use_amqplib, self.topic_prefix) )
         self.logger.info( "\tsuppress_duplicates=%s basis=%s retry_mode=%s retry_ttl=%sms tls_rigour=%s" % \
            ( self.caching, self.cache_basis, self.retry_mode, self.retry_ttl, self.tls_rigour ) )
-        self.logger.info( "\texpire=%sms reset=%s message_ttl=%s prefetch=%s accept_unmatch=%s delete=%s" % \
-           ( self.expire, self.reset, self.message_ttl, self.prefetch, self.accept_unmatch, self.delete ) )
+        self.logger.info( "\texpire=%sms reset=%s message_ttl=%s prefetch=%s accept_unmatch=%s delete=%s poll_without_vip=%s" % \
+           ( self.expire, self.reset, self.message_ttl, self.prefetch, self.accept_unmatch, self.delete, self.poll_without_vip ) )
         self.logger.info( "\theartbeat=%s sanity_log_dead=%s default_mode=%03o default_mode_dir=%03o default_mode_log=%03o discard=%s durable=%s" % \
            ( self.heartbeat, self.sanity_log_dead, self.chmod, self.chmod_dir, self.chmod_log, self.discard, self.durable ) )
         self.logger.info( "\tpost_on_start=%s preserve_mode=%s preserve_time=%s realpath_post=%s base_dir=%s follow_symlinks=%s" % \
@@ -688,6 +688,7 @@ class sr_config:
         self.exchanges            = [ 'xlog', 'xpublic', 'xreport', 'xwinnow' ]
         self.topic_prefix         = 'v02.post'
         self.version              = 'v02'
+        self.poll_without_vip     = True
         self.post_topic_prefix    = None
         self.post_version         = 'v02'
         self.subtopic             = None
@@ -2331,6 +2332,14 @@ class sr_config:
                 elif words0 in ['post_exchange_split','pes', 'pxs']: # sr_config.7, sr_shovel.1
                      self.post_exchange_split = int(words1)
                      n = 2
+
+                elif words0 in ['poll_without_vip','pwv'] : # See: sr_config.7
+                     if (words1 is None) or words[0][0:1] == '-' : 
+                        self.poll_without_vip = True
+                        n = 1
+                     else :
+                        self.poll_without_vip = self.isTrue(words[1])
+                        n = 2
 
                 elif words0 == 'prefetch': # See: sr_consumer.1  (Nbr of prefetch message when queue is shared)
                      self.prefetch = int(words1)

--- a/sarra/sr_poll.py
+++ b/sarra/sr_poll.py
@@ -647,7 +647,8 @@ class sr_poll(sr_post):
                       start = nowflt()
 
                       #  do poll stuff
-                      ok = self.__do_poll__()
+                      if not self.sleeping or self.poll_without_vip :
+                          ok = self.__do_poll__()
 
                       #  check if sleep is to short
                       poll_time = nowflt() - start


### PR DESCRIPTION
We are seeing high load on ddsr nodes since moving the polls from pxatx there.  I think a big part of that is that the polls do not work the way people expect.  what the vip does for sr_poll is stop the nodes from posting, but they still poll. so you have N nodes in a cluster, they all poll, but only one posts.  In many cases, we only need one node to poll (and post) and the state doesn´t matter.  the option added here allows that case. 