### PR TITLE
Fix confusing asterisks in documentation

### DIFF
--- a/doc/dd_subscribe.1.rst
+++ b/doc/dd_subscribe.1.rst
@@ -42,11 +42,11 @@ CONFIGURATION
 
 Options are placed in the configuration file, one per line, of the form:: 
 
-  **option <value>** 
+    option <value>
 
 Comment lines begins with **#**. For example::
 
-  **debug true**
+    debug true
 
 would be a demonstration of setting the option to enable more verbose logging. 
 

--- a/doc/dd_subscribe.1.rst
+++ b/doc/dd_subscribe.1.rst
@@ -44,12 +44,15 @@ Options are placed in the configuration file, one per line, of the form::
 
     option <value>
 
-Comment lines begins with **#**. For example::
+For example::
 
     debug true
 
 would be a demonstration of setting the option to enable more verbose logging. 
 
+Comment lines begins with **#**. For example::
+
+    # This is a comment
 
 RABBITMQ CREDENTIAL OPTIONS
 ---------------------------

--- a/doc/fr/Concepts.rst
+++ b/doc/fr/Concepts.rst
@@ -417,7 +417,7 @@ Note : Sur de tels clusters, tous les nœuds qui exécutent un composant avec
 l'option le même fichier de configuration crée par défaut un ***queue** 
 identique. Cibler les même courtier, il force la file d'attente à être 
 partagée. S'il faut l'éviter, l'utilisateur peut écraser la valeur par 
-défaut **queue_name**** en y rajoutant **${HOSTNAME}**.  Chaque nœud aura 
+défaut **queue_name** en y rajoutant **${HOSTNAME}**.  Chaque nœud aura 
 sa propre file d'attente, qui ne sera partagée que par les instances du nœud.
 ex : nom_de_files d'attente q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}. )
 

--- a/doc/fr/Dev.rst
+++ b/doc/fr/Dev.rst
@@ -975,7 +975,7 @@ Mise à jour du site Web du projet
 
 Avant mars 2018, le site Web principal du projet était metpx.sf.net.
 Ce site MetPX a été construit à partir de la documentation des différents modules.
-dans le projet. Il construit en utilisant tous les fichiers **.rst**** trouvés
+dans le projet. Il construit en utilisant tous les fichiers **.rst** trouvés
 dans le répertoire **sarracénie/doc** ainsi que *certains* des fichiers 
 **.rst** trouvés dans le fichier **Sundew/doc**. Au printemps 2018, le 
 développement a été transféré sur github.com.  Ce site rend .rst lors de 

--- a/doc/fr/sr_audit.8.rst
+++ b/doc/fr/sr_audit.8.rst
@@ -81,7 +81,7 @@ Il y a très peu d'options que **sr_audit** utilise :
 - **max_queue_size <int>     (default: 25000 nbr messages in queue)**
 
 L'option **admin** doit être définie, elle est normalement définie dans le fichier **default.conf**.
-et les détails de l'accréditation se trouveraient dans le fichier **credentials.conf****.
+et les détails de l'accréditation se trouveraient dans le fichier **credentials.conf**.
 Normalement, lors de la création des utilisateurs, les mots de passe 
 pour les communications avec le courtier sont définis par les valeurs 
 trouvées dans le fichier d'informations d'identification ( *credentials.conf* )

--- a/doc/fr/sr_sender.1.rst
+++ b/doc/fr/sr_sender.1.rst
@@ -102,7 +102,7 @@ un dans la notification sélectionnée donne le chemin absolu du fichier à envo
 La valeur par défaut est None, ce qui signifie que le chemin d'accès dans la notification est le chemin absolu.
 
 La **destination** définit le protocole et le serveur à utiliser pour livrer les produits.
-Sa forme est une url partielle, par exemple :  **ftp://myuser@myhost****
+Sa forme est une url partielle, par exemple :  **ftp://myuser@myhost**
 Le programme utilise le fichier ~/.conf/sarra/credentials.conf pour obtenir les détails restants.
 (mot de passe et options de connexion).  Les protocoles supportés sont ftp, ftps et sftp. Si le
 l'utilisateur a besoin d'implémenter un autre mécanisme d'envoi, il fournirait le script du plugin.
@@ -112,7 +112,7 @@ Sur le site distant, le **post_base_dir** sert aux mêmes fins que le **base_dir
 La valeur par défaut est None, ce qui signifie que le chemin d'accès délivré est absolu.
 Maintenant, nous sommes prêts à envoyer le produit..... Par exemple, si la notification sélectionnée ressemble à ceci :
 
-**2015081316161959.854 http://this.pump.com/ relative/path/to/IMPORTANT_produit****.
+**2015081316161959.854 http://this.pump.com/ relative/path/to/IMPORTANT_produit**.
 
 **sr_sender** effectue la pseudo-livraison suivante :
 
@@ -126,7 +126,7 @@ A ce stade, un besoin de configuration de pompe à pompe doit envoyer la notific
 juste la réplication de produits)
 
 L´avis contient toutes les mêmes informations (attributs de thème et autres en-têtes), à 
-l'exception du champ url, dans notre exemple.. :  **http://this.pump.com/****
+l'exception du champ url, dans notre exemple.. :  **http://this.pump.com/**
 
 Par défaut, **sr_sender** met la **destination** dans ce champ.
 L'utilisateur peut écraser ceci en spécifiant l'option **post_base_url**. Par exemple :

--- a/doc/fr/sr_subscribe.1.rst
+++ b/doc/fr/sr_subscribe.1.rst
@@ -204,14 +204,14 @@ Que contiennent les fichiers ? Voir la section suivante :
 Syntaxe des options
 -------------------
 
-Les options sont placées dans les fichiers de configuration, une par ligne, ans le format suivant :
+Les options sont placées dans les fichiers de configuration, une par ligne, ans le format suivant::
 
-  option <valeur>******.
+    option <valeur>
 
 Par exemple::
 
-  **debug true****
-  **debug****
+    debug true
+    debug
 
 définit l'option *debug* pour activer une journalisation plus verbeuse.  Si aucune valeur n'est spécifiée,
 la valeur true est implicite. Les exemples ci-dessus sont donc équivalents.  Un deuxième exemple
@@ -239,8 +239,8 @@ Place les fichiers correspondant à X dans le répertoire de travail actuel,
 et le paramètre *directory A* ne fait rien par rapport à X.
 
 Pour fournir une description non fonctionnelle de la configuration ou des 
-commentaires, utilisez des lignes commençant par **#****.  Toutes les options
-sont sensibles aux majuscules et minuscules. ** **Debug** n'est pas le même
+commentaires, utilisez des lignes commençant par **#**.  Toutes les options
+sont sensibles aux majuscules et minuscules. **Debug** n'est pas le même
 que **debug** ou **DEBUG**. Il s'agit de trois options différentes (dont deux
 n'existent pas et n'auront aucun effet, mais devrait générer une 
 avertissement ´unknown option´).
@@ -427,7 +427,7 @@ Pour chaque url spécifié qui nécessite un mot de passe, on place une entrée
 correspondante dans *credentials.conf*. L'option broker définit toutes les 
 informations d'identification pour se connecter au serveur **RabbitMQ**.
 
-  broker amqp{s}://<utilisateur>:<pw>@<brokerhost>[:port]/<vhost>****.
+  broker amqp{s}://<utilisateur>:<pw>@<brokerhost>[:port]/<vhost>
 
 ::
 
@@ -447,7 +447,7 @@ et le courtier ainsi que les paramètres requis par les composants.  Une entrée
 - **ftp://user7:password7@host passive,binaire**
 - **ftp://user8:password8@host:2121 active,ascii**
 
-- **ftp://user7:De%3Aolonize@host passive,binaire,tls***
+- **ftp://user7:De%3Aolonize@host passive,binaire,tls**
 - **ftps://user8:%2fdot8@host:2121 active,ascii,tls,prot_p**
 
 
@@ -463,7 +463,7 @@ Note: :
 
  Ces chaînes sont codées par URL, donc si un compte a un mot de passe avec un
  mot de passe spécial. Son équivalent URL encodé peut être fourni.  Dans le 
- dernier exemple ci-dessus, %2f**** signifie que le mot de passe actuel 
+ dernier exemple ci-dessus, %2f signifie que le mot de passe actuel 
  esti : **/dot8**
  L'avant-dernier mot de passe est :  **De:olonize**. ( %3a étant la valeur 
  codée en url d'un caractère deux-points. )
@@ -504,7 +504,7 @@ partie " consommateur " de les programmes de Sarracenia.
 Réglage du courtier 
 -------------------
 
-broker amqp{s}://<user>:<password>@<brokerhost>[:port]/<vhost>*****.
+broker amqp{s}://<user>:<password>@<brokerhost>[:port]/<vhost>
 
 Un URI AMQP est utilisé pour configurer une connexion à une pompe à messages 
 (AMQP broker). Certains composants de Sarracenia définissent une valeur par 
@@ -521,7 +521,7 @@ pour plus d'informations sur le format URI de l'AMQP : ( https://www.rabbitmq.co
 soit dans le fichier default.conf, soit dans chaque fichier de configuration spécifique.
 L'option courtier indique à chaque composante quel courtier contacter.
 
-broker amqp{s}://<user>:<pw>@<brokerhost>[:port]/<vhost>****.
+broker amqp{s}://<user>:<pw>@<brokerhost>[:port]/<vhost>
 
 ::
       (par défaut : Aucun et il est obligatoire de le définir) 
@@ -541,7 +541,7 @@ Mise en file d'attente sur broker :
 - **durable <booléen> (par défaut : False)**
 - **expire <durée> (par défaut : 5m == cinq minutes. À OUTREPASSER)**
 - **message-ttl <durée> (par défaut : Aucun)**
-- **prefetch <N> (par défaut : 1)****
+- **prefetch <N> (par défaut : 1)**
 - **reset <booléen> (par défaut : False)**
 - **restore <booléen> (par défaut : False)**
 - **restore_to_queue <queuename> (par défaut : Aucun)**
@@ -560,8 +560,8 @@ Par défaut, les composants créent un nom de file d'attente qui doit être uniq
 Le nom_de_la_files_d'attente par défaut composants créent suit.. :  
 **q_<brokerUser>.<programName>.<configName><configName>** . Les utilisateurs 
 peuvent remplacer la valeur par défaut à condition qu'elle commence par 
-**q_<brokerUser>****. Certaines variables peuvent aussi être utilisées dans 
-le nom_de_la_file d'attente comme **${BROKER_USER},${PROGRAMME},${CONFIG},${HOSTNAME}******
+**q_<brokerUser>**. Certaines variables peuvent aussi être utilisées dans 
+le nom_de_la_file d'attente comme **${BROKER_USER},${PROGRAMME},${CONFIG},${HOSTNAME}**
 
 Quand plusieurs processus (*instances*) roulent sur un même serveurs, ils 
 partagent le même *home* alors ils vont tous partager le même fil.  On peut
@@ -655,7 +655,7 @@ fois qu'une file d'attente existe sur le courtier, il doit être lié (*bound*) 
 une échange. Les liaisons (*bindings*) définissent ce que l'on entend par
 les avis que le programme reçoit. La racine du thème
 est fixe, indiquant la version du protocole et le type de l'arborescence.
-(mais les développeurs peuvent l'écraser avec le **topic_prefix****.
+(mais les développeurs peuvent l'écraser avec le **topic_prefix*.
 option.)
 
 Ces options définissent les messages (notifications URL) que le programme reçoit :
@@ -714,8 +714,8 @@ Pour utiliser le sous-thème pour filtrer les produits, faites correspondre la
 chaîne de sous-thèmes avec le chemin relatif dans l´arborescence de répertoires sur le serveur.
 
 Par exemple, en consommant à partir de DD, pour donner une valeur correcte au sous-thème, on peut
-Parcourez notre site Web **http://dd.weather.gc.ca**** et notez tous les annuaires.
-d'intérêt.  Pour chaque arborescence de répertoires d'intérêt, écrivez un **subtopic****.
+Parcourez notre site Web **http://dd.weather.gc.ca** et notez tous les annuaires.
+d'intérêt.  Pour chaque arborescence de répertoires d'intérêt, écrivez un **subtopic**.
 comme suit :
 
 
@@ -1010,7 +1010,7 @@ avec des options::
 se traduirait par la création des répertoires et du fichier
 /mylocaldirectory/radar/PRECIP/GIF/WGJ/20131214141900_WGJ_PRECIP_PRECIP_SNOW.gif
 
-Vous pouvez modifier les répertoires en miroir avec l'option **strip***.
+Vous pouvez modifier les répertoires en miroir avec l'option **strip**.
 S'il est réglé sur N (un entier), les premiers ´N´ répertoires sont retirés.
 Par exemple ::
 
@@ -1130,7 +1130,7 @@ l'affectation à un courtier. Les valeurs d'argument valables sont :
 
   poster des messages sur un post_exchange
 
-  amqp{s}://<user>:<pw>@<brokerhost>[:port]/<vhost>*****.
+  amqp{s}://<user>:<pw>@<brokerhost>[:port]/<vhost>
   post_exchange <nom> (OBLIGATOIRE)** **.
   on_post <script> (par défaut : Aucun)**.
 
@@ -1523,7 +1523,7 @@ QUEUES - FILES D´ATTENTES et EXECUTION MULTIPLE
 ===============================================
 
 Lorsqu'il est exécuté, **sr_subscribe** choisit un nom de file d'attente qu'il écrit
-à un fichier nommé d'après le fichier de configuration donné en argument à sr_subscribe****.
+à un fichier nommé d'après le fichier de configuration donné en argument à sr_subscribe
 avec un suffixe.queue ( ."nom de configuration".queue). 
 Si sr_subscribe est arrêté, les messages publiés continuent de s'accumuler sur 
 le courtier dans cette file d'attente (jusqu´a son *expire* -ation).  Lorsque le 
@@ -1631,7 +1631,7 @@ sont pas définies et sr_subscribe fonctionnera en mode 'standalone'.
 Dans le cas des courtiers en grappe, vous devez définir les options pour l'option
 vip en mouvement.
 
-**vip 153.14.126.126.3****
+**vip 153.14.126.126.3**
 
 Lorsque **sr_subscribe** ne trouve pas le vip, il dort pendant 5 secondes et réessaie.
 S´il possède le vip, il consomme et traite un message, puis revérifie le vip.
@@ -1648,7 +1648,7 @@ il faut indiquer un courtier on on enverra les avis.
 L'option **post_broker** définit toutes les informations d'authentification 
 pour se connecter à courtier sortie **AMQP**.
 
-amqp{s}://<user>:<pw>@<brokerhost>[:port]/<vhost>*****.
+amqp{s}://<user>:<pw>@<brokerhost>[:port]/<vhost>
 
 Une fois connecté au courtier AMQP source, le programme construit des notifications après que
 le téléchargement d'un fichier a eu lieu. Pour construire la notification et l'envoyer à
@@ -1736,13 +1736,13 @@ Configurations à distance
 
 On peut spécifier des URI comme fichiers de configuration, plutôt que des fichiers locaux. Exemple :
 
-  - **--config http://dd.weather.gc.ca/alerts/doc/cap.conf*****.
+  - **--config http://dd.weather.gc.ca/alerts/doc/cap.conf**
 
 Au démarrage, sr_subscribe vérifie si le fichier local cap.conf existe dans le répertoire 
 répertoire de configuration local.  Si c'est le cas, alors le fichier sera lu pour trouver
 une ligne comme ça :
 
-  **--remote_config_config_url http://dd.weather.gc.ca/alerts/doc/cap.conf*****.
+  **--remote_config_config_url http://dd.weather.gc.ca/alerts/doc/cap.conf**
 
 Dans ce cas, il vérifiera l'URL distante et comparera le temps de modification.
 du fichier distant contre le fichier local. Le fichier distant n'est pas plus récent ou ne peut pas être modifié.
@@ -1914,7 +1914,7 @@ structure contenant tous les paramètres, comme **parent.<setting>**, et
 le contenu du message en tant que **parent.msg** et les en-têtes.
 sont disponibles sous la forme **parent.msg[ <header> <header> ]**.  
 Le chemin d'accès pour écrire un fichier to est disponible car il y a 
-aussi **parent.msg.new_dir** / **parent.msg.new_file****.
+aussi **parent.msg.new_dir** / **parent.msg.new_file**.
 
 Il y a aussi des plugins enregistrés utilisés pour ajouter ou écraser des plugins intégrés. 
 scripts de protocole de transfert. Ils doivent être déclarés à l'aide de l'option **plugin**.
@@ -1933,7 +1933,7 @@ Le script pour les protocoles de transfert sont :
 - do_send - pour mettre en œuvre des protocoles et processus d'envoi supplémentaires.
 
 
-L'enregistrement se fait avec un module nommé **registered_as****... Il définit
+L'enregistrement se fait avec un module nommé **registered_as**... Il définit
 une liste des protocoles pris en charge par le module fourni.
 
 
@@ -2213,7 +2213,7 @@ le placement par défaut, ou bien Les fichiers de configuration individuels peuv
 Lorsque des composants sont invoqués, le fichier fourni est interprété comme un fichier 
 (avec un suffixe.conf conf supposé.) S'il n'est pas trouvé comme chemin d'accès au 
 fichier, alors l'option recherchera dans le répertoire de configuration du 
-composant ( **config_dir** / **component******) pour un fichier.conf correspondant.
+composant ( **config_dir** / **component**) pour un fichier.conf correspondant.
 
 S'il n'est toujours pas trouvé, il le recherchera dans le répertoire de configuration du site.
 (linux : /usr/share/default/sarra/**component**).
@@ -2328,8 +2328,8 @@ Ce mot-clé a priorité sur le mot-clé précédent **filename**.
 Le motif **regexp** peut être utilisé pour définir les parties du répertoire si 
 une partie du message est mise en place.  à la parenthèse. **sr_sender** peut utiliser 
 ces parties pour construire le nom du répertoire. Les premières chaînes de parenthèses 
-jointes remplaceront le mot-clé **${0}****$ dans le nom du répertoire
-le second **${1}**** etc.
+jointes remplaceront le mot-clé **${0}**$ dans le nom du répertoire
+le second **${1}** etc.
 
 exemple d'utilisation: :
 

--- a/doc/fr/sr_watch.1.rst
+++ b/doc/fr/sr_watch.1.rst
@@ -33,9 +33,9 @@ Les messages sont envoyés à un serveur AMQP, également appelé courtier, spé
 CREDENTIALS
 -----------
 
-L'option broker définit toutes les informations d'identification pour se connecter au serveur **RabbitMQ****.
+L'option broker définit toutes les informations d'identification pour se connecter au serveur **RabbitMQ**.
 
-Courtier amqp{s}://<utilisateur>:<pw>@<brokerhost>[:port]/<vhost>****.
+Courtier amqp{s}://<utilisateur>:<pw>@<brokerhost>[:port]/<vhost>.
 
       (par défaut : amqps://anonymous:anonymous@dd.weather.gc.ca/)
 
@@ -342,7 +342,7 @@ L'option **post_base_url** définit le protocole, les informations d'
 identification, l'hôte et le port sous que le produit peut être récupéré. 
 
 Le corps d´un avis contient trois champs : l'heure de l'avis,
-cette valeur **base_url** et le chemin****, relatif à *post_base_dir*, si nécessaire.
+cette valeur **base_url** et le chemin, relatif à *post_base_dir*, si nécessaire.
 
 la concaténation des deux derniers champs de l'avis définit l´URL complete que les abonnés 
 utiliseront pour télécharger le produit.

--- a/doc/fr/sr_watch.1.rst
+++ b/doc/fr/sr_watch.1.rst
@@ -378,7 +378,7 @@ disponibles pour être transférés. La stratégie appropriée varie en fonction
  le délai **minimum pour signaler les changements** aux fichiers qui est acceptable, et
  la **taille de chaque fichier** dans l'arbre.
 
-L'arbre le plus facile à surveiller est le plus petit ** Avec un seul répertoire à surveiller où l'on 
+**L'arbre le plus facile à surveiller est le plus petit** Avec un seul répertoire à surveiller où l'on 
 affiche un message pour un composant *sr_sarra*, alors l'utilisation de l'option *delete* gardera en tout temps
 le nombre minimale de fichiers dans le répertoire et minimisera le temps de remarquer les nouveaux. Dans ces 
 conditions optimales, l'observation des fichiers dans un centième de seconde, c'est raisonnable 

--- a/doc/fr/sr_winnow.8.rst
+++ b/doc/fr/sr_winnow.8.rst
@@ -24,7 +24,7 @@ DESCRIPTION
 ===========
 
 
-sr_winnow** est un programme qui s'abonne aux notifications de fichiers,
+**sr_winnow** est un programme qui s'abonne aux notifications de fichiers,
 et réenregistre les notifications, en supprimant les notifications redondantes en comparant leurs données
 L'en-tête **sum** mémorise l'empreinte digitale d'un fichier comme décrit ci-dessus.
 dans la page de manuel `sr_post(7) <sr_post.7.rst>`_ 

--- a/doc/fr/sr_winnow.8.rst
+++ b/doc/fr/sr_winnow.8.rst
@@ -26,7 +26,7 @@ DESCRIPTION
 
 sr_winnow** est un programme qui s'abonne aux notifications de fichiers,
 et réenregistre les notifications, en supprimant les notifications redondantes en comparant leurs données
-L'en-tête **sum**** mémorise l'empreinte digitale d'un fichier comme décrit ci-dessus.
+L'en-tête **sum** mémorise l'empreinte digitale d'un fichier comme décrit ci-dessus.
 dans la page de manuel `sr_post(7) <sr_post.7.rst>`_ 
 
 **sr_winnow** est un `sr_subscribe(1) <sr_subscribe.1.rst>`_ avec les options suivantes forcées::

--- a/doc/sr_subscribe.1.rst
+++ b/doc/sr_subscribe.1.rst
@@ -184,14 +184,14 @@ What goes into the files? See next section:
 Option Syntax
 -------------
 
-Options are placed in configuration files, one per line, in the form:
+Options are placed in configuration files, one per line, in the form::
 
-  **option <value>**
+    option <value>
 
 For example::
 
-  **debug true**
-  **debug**
+    debug true
+    debug
 
 sets the *debug* option to enable more verbose logging.  If no value is specified,
 the value true is implicit, so the above are equivalent.  A second example 


### PR DESCRIPTION
I found a few cases where there are extra asterisks in the French and English docs which get rendered instead of making the text bold. Makes some config options a bit easier to understand for new users.