### PR TITLE
Add program_name check for file_index creation

### DIFF
--- a/sarra/sr_sftp.py
+++ b/sarra/sr_sftp.py
@@ -233,8 +233,10 @@ class sr_sftp(sr_proto):
                 self.sftp        = sftp
 
                 self.file_index_cache = self.user_cache_dir + os.sep + '.dest_file_index'
-                if os.path.isfile(self.file_index_cache): self.load_file_index()
-                else: self.init_file_index()
+                # Prevent sr_senders from unnecessarily creating/loading a file index
+                if self.parent.program_name == 'sr_poll':
+                   if os.path.isfile(self.file_index_cache): self.load_file_index()
+                   else: self.init_file_index()
 
                 #alarm_cancel()
                 return True


### PR DESCRIPTION
Adding statement to prevent sr_senders from calling init_file_index.

sr_senders do not use the file_index, and calling it requires write permissions to be granted on the receiver else an error is thrown.

Fixes sends to hosts which do not have write permissions enabled on other files/directories.

Related to: #343 