### PR TITLE
Virtual Host Support in v3

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -180,9 +180,9 @@ class AMQP(Moth):
 
         # if needed, set the vhost using the broker URL's path
         vhost = self.o['vhost']
-        # if the URL path is '/' (no vhost specified), the default vhost from self.o will be used.
-        # Otherwise, strip off leading or trailing slashes.
-        if broker.path != '/':
+        # if the URL path is '/' or '', no vhost is specified and the default vhost from self.o
+        # will be used. Otherwise, strip off leading or trailing slashes.
+        if broker.path != '/' and broker.path != '':
             vhost = broker.path.strip('/')
 
         self.connection = amqp.Connection(host=host,


### PR DESCRIPTION
Adds support for using a virtual host other than the default `/` vhost.

For example:
```
broker amqp://anonymous@localhost/my_test_vhost/
```