### PR TITLE
Use the matrix to run on Ubuntu 18.04

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -24,8 +24,9 @@ jobs:
       matrix:
        which_test: [ static_flow, flakey_broker, dynamic_flow ]
        pyver: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+       osver: [ "ubuntu-18.04", "ubuntu-20.04"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.osver }}
   
     name: ${{ matrix.which_test }} test, using Python ${{ matrix.pyver }}
     timeout-minutes: 30
@@ -71,5 +72,5 @@ jobs:
         uses: actions/upload-artifact@v3
         continue-on-error: true
         with:
-          name: sr3_${{ matrix.which_test }}_python_${{ matrix.pyver }}_logs_${{ github.sha }}
+          name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_python_${{ matrix.pyver }}_logs_${{ github.sha }}
           path: ~/.cache/sr3/log/

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -28,7 +28,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test, using Python ${{ matrix.pyver }}
+    name: ${{ matrix.which_test }} test, using Python ${{ matrix.pyver }} on $${{ matrix.osver }}
     timeout-minutes: 30
     
     steps:

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip3 install .
           travis/flow_autoconfig.sh
           travis/ssh_localhost.sh
          

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -28,7 +28,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test, using Python ${{ matrix.pyver }} on $${{ matrix.osver }}
+    name: ${{ matrix.which_test }} test, using Python ${{ matrix.pyver }} on ${{ matrix.osver }}
     timeout-minutes: 30
     
     steps:

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -8,7 +8,7 @@
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx-daily
 sudo apt-get update
-sudo apt -y install openssh-server erlang-diameter erlang-eldap rabbitmq-server erlang-nox metpx-sr3c librabbitmq4 metpx-libsr3c metpx-libsr3c-dev git python3-pip net-tools findutils xattr
+sudo apt -y install openssh-server erlang-nox rabbitmq-server metpx-sr3c librabbitmq4 metpx-libsr3c metpx-libsr3c-dev git python3-pip net-tools findutils xattr
 
 pip3 install -U pip
 pip3 install -e .

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -8,7 +8,7 @@
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx-daily
 sudo apt-get update
-sudo apt -y install openssh-server rabbitmq-server erlang-nox metpx-sr3c librabbitmq4 metpx-libsr3c metpx-libsr3c-dev git python3-pip net-tools findutils xattr
+sudo apt -y install openssh-server erlang-diameter erlang-eldap rabbitmq-server erlang-nox metpx-sr3c librabbitmq4 metpx-libsr3c metpx-libsr3c-dev git python3-pip net-tools findutils xattr
 
 pip3 install -U pip
 pip3 install -e .

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -8,7 +8,7 @@
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx-daily
 sudo apt-get update
-sudo apt -y install openssh-server erlang-nox rabbitmq-server metpx-sr3c librabbitmq4 metpx-libsr3c metpx-libsr3c-dev git python3-pip net-tools findutils xattr
+sudo apt -y install openssh-server erlang-nox erlang-diameter erlang-eldap rabbitmq-server metpx-sr3c librabbitmq4 metpx-libsr3c metpx-libsr3c-dev git python3-pip net-tools findutils xattr
 
 pip3 install -U pip
 pip3 install -e .


### PR DESCRIPTION
... and Ubuntu 20.04. Ubuntu 22.04 isn't currently available. Ubuntu 18.04 fails due to missing sarrac package... 

```
OK, basic scripting environment is there
No Sarra C package available. Cannot test.
Error: Process completed with exit code 1.
```