### PR TITLE
For #466: Changes to get post retry DiskQueues working.

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1354,6 +1354,13 @@ the reception cache is also discarded.
 The AMQP protocol defines other queue options which are not exposed
 via sarracenia, because sarracenia itself picks appropriate values.
 
+
+retryEmptyBeforeExit: <boolean> (default: False)
+------------------------------------------------
+
+Used for sr_insects flow tests. Prevents Sarracenia from exiting while there are messages remaining in the retry queue(s). By default, a post will cleanly exit once it has created and attempted to publish messages for all files in the specified directory. If any messages are not successfully published, they will be saved to disk to retry later. If a post is only run once, as in the flow tests, these messages will never be retried unless retryEmptyBeforeExit is set to True.
+
+
 retry_ttl <duration> (default: same as expire)
 ----------------------------------------------
 

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -81,6 +81,7 @@ default_options = {
     'post_baseUrl': None,
     'realpath_post': False,
     'report': False,
+    'retryEmptyBeforeExit': False,
     'sourceFromExchange': False
 }
 
@@ -95,7 +96,7 @@ flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'baseUrl_relPath', 'cache
     'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logStdout', 'logReject', 'restore', \
     'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \
     'permCopy', 'pump_flag', 'queueBind', 'queueDeclare', 'randomize', 'realpath_post', 'reconnect', \
-    'report', 'reset', 'retry_mode', 'save', 'set_passwords', 'sourceFromExchange', \
+    'report', 'reset', 'retry_mode', 'retryEmptyBeforeExit', 'save', 'set_passwords', 'sourceFromExchange', \
     'statehost', 'users'
                 ]
 

--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -249,7 +249,6 @@ class DiskQueue():
                 #logger.error("MG invalid %s" % message)
                 continue
 
-            message['isRetry'] = True
             if 'ack_id' in message:
                 del message['ack_id']
                 message['_deleteOnPost'].remove('ack_id')

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -427,7 +427,13 @@ class Flow:
             elapsed = now - last_time
 
             if (last_gather_len == 0) and (self.o.sleep < 0):
-                self.please_stop()
+                if (self.o.retryEmptyBeforeExit and "Retry" in self.metrics
+                    and self.metrics['Retry']['msgs_in_post_retry'] > 0):
+                    logger.info("Not exiting because there are still messages in the post retry queue.")
+                    # Sleep for a while. Messages can't be retried before housekeeping has run...
+                    current_sleep = 60
+                else:
+                    self.please_stop()
 
             if spamming and (current_sleep < 5):
                 current_sleep *= 2

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -15,7 +15,7 @@ entry_points = [
 
     'ack', 'do_poll', 'download', 'gather', 'after_accept', 'after_post',
     'after_work', 'on_housekeeping', 'on_report', 'on_start', 'on_stop',
-    'poll', 'post', 'send', 'please_stop'
+    'poll', 'post', 'send', 'please_stop', 'metrics_report',
 
 ]
 
@@ -133,6 +133,9 @@ class FlowCB:
          return Boolean success indicator.  if False, download  will be attempted again and/or
          appended to retry queue.
 
+    def metrics_report(self) -> dict:
+
+        Return a dictionary of metrics. Example: number of messages remaining in retry queues.
 
     def on_housekeeping(self) -> None::
 

--- a/sarracenia/flowcb/accept/delete.py
+++ b/sarracenia/flowcb/accept/delete.py
@@ -32,7 +32,6 @@ class Delete(FlowCB):
                 logger.debug("Exception details:", exc_info=True)
                 self.o.consumer.sleep_now = self.o.consumer.sleep_min
                 self.o.consumer.msg_to_retry()
-                message['isRetry'] = False
                 worklist.rejected.append(message)
 
             new_incoming.append(message)

--- a/sarracenia/flowcb/accept/testretry.py
+++ b/sarracenia/flowcb/accept/testretry.py
@@ -37,7 +37,9 @@ class TestRetry(FlowCB):
             # retry message : recover it
             # update: this is set somewhere as true in /diskqueue.py, should think about initializing first so we
             # dont have to test for existence
-            if message['isRetry']:
+            # 2022-06-10: isRetry was removed. Maybe can check if the message has msg_baseUrl_bad?
+            #             see issues #466 and #527.
+            if 'isRetry' in message and message['isRetry']:
                 self.o.destination = self.destination
                 ok, self.o.details = self.o.credentials.get(self.destination)
 

--- a/sarracenia/flowcb/filter/fdelay.py
+++ b/sarracenia/flowcb/filter/fdelay.py
@@ -63,8 +63,6 @@ class FDelay(FlowCB):
                 dbg_msg = "message not old enough, sleeping for {:.3f} seconds"
                 logger.debug(
                     dbg_msg.format(elapsedtime, self.o.fdelay - elapsedtime))
-                m['isRetry'] = False
-                m['_deleteOnPost'] |= set(['isRetry'])
                 worklist.failed.append(m)
                 logger.debug('marked failed 1 (message not old enough)')
                 continue
@@ -88,8 +86,6 @@ class FDelay(FlowCB):
                 dbg_msg = "file not old enough, sleeping for {:.3f} seconds"
                 logger.debug(
                     dbg_msg.format(elapsedtime, self.o.fdelay - elapsedtime))
-                m['isRetry'] = False
-                m['_deleteOnPost'] |= set(['isRetry'])
                 worklist.failed.append(m)
                 logger.debug('marked failed 3 file not old enough')
                 continue

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -36,9 +36,8 @@ class Message(FlowCB):
 
     def ack(self, mlist):
         for m in mlist:
-            # see plugin/retry.py
-            if not (('isRetry' in m) and m['isRetry']):
-                self.consumer.ack(m)
+            # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
+            self.consumer.ack(m)
 
     def on_housekeeping(self):
         m = self.consumer.metricsReport()

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -104,6 +104,14 @@ class Retry(FlowCB):
         self.post_retry.put(worklist.failed)
         worklist.failed=[]
 
+    def metrics_report(self) -> dict:
+        """Returns the number of messages in the download_retry and post_retry queues.
+
+        Returns:
+            dict: containing metrics: ``{'msgs_in_download_retry': (int), 'msgs_in_post_retry': (int)}``
+        """
+        return {'msgs_in_download_retry': len(self.download_retry), 'msgs_in_post_retry': len(self.post_retry)}
+
     def on_housekeeping(self) -> None:
         logger.info("on_housekeeping")
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -543,8 +543,12 @@ class AMQP(Moth):
                 logger.debug('Exception details: ', exc_info=True)
 
             self.metrics['txBadCount'] += 1
-            if not self.o['message_strategy']['stubborn']:
-                return False
+            # Issue #466: commenting this out until message_strategy stubborn is working correctly (Issue #537)
+            # Always return False when an error occurs and use the DiskQueues to retry, instead of looping. This should
+            # eventually be configurable with message_strategy stubborn
+            # if True or not self.o['message_strategy']['stubborn']:
+            #     return False
+            return False # instead of looping
 
             self.close()
             self.__putSetup()


### PR DESCRIPTION
See details in #466.

- Adds `metrics_report` callback, to allow flow to receive information from plugins.
- Adds `retryEmptyBeforeExit` option, to prevent Sarracenia (particularly post) from exiting while there are still messages in the DiskQueue to be retried. Used in the flow tests, https://github.com/MetPX/sr_insects/pull/11 has already been merged.
- Adds message counting to the DiskQueue class.
- Removes `isRetry` from messages, because it caused a bug and wasn't used.

The use of the DiskQueues for retrying messages that failed to post is enabled by this: https://github.com/MetPX/sarracenia/blob/e1d5de42cf6d05ccd4a098c0f92d2fe988689f39/sarracenia/moth/amqp.py#L546-L551

But this is a temporary fix, and should be configurable by setting `message_strategy['stubborn']` to `False` when #537 is completed.