### PR TITLE
Fix Issue #513: cleanly shutdown subprocesses when a signal is received

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -566,8 +566,9 @@ class AMQP(Moth):
 
     def close(self) -> None:
         try:
-            self.connection.collect()
-            self.connection.close()
+            if self.connection:
+                self.connection.collect()
+                self.connection.close()
 
         except Exception as err:
             logger.error("sr_amqp/close 2: {}".format(err))

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -962,6 +962,9 @@ class sr_GlobalState:
         self.users = opt.users
         self.declared_users = opt.declared_users
 
+        signal.signal(signal.SIGTERM, self._stop_signal)
+        signal.signal(signal.SIGINT, self._stop_signal)
+
         if self.appname is None:
             self.appname = 'sr3'
         else:
@@ -1017,6 +1020,11 @@ class sr_GlobalState:
             if component_path == '':
                 continue
             self._launch_instance(component_path, c, cfg, i)
+
+    def _stop_signal(self, signum, stack):
+        logging.info('signal %d received' % signum)
+        logging.info("Stopping config...")
+        # Signal is also sent to subprocesses. Once they exit, subprocess.run returns and sr.py should terminate.
 
     def run_command(self, cmd_list):
         sr_path = os.environ.get('SARRA_LIB')


### PR DESCRIPTION
When Ctrl+C is pressed, the parent process (sr.py) and it's children (instance.py) receive SIGINT. instance.py had a handler that would cleanly stop the flow loop, but sr.py didn't. The `subprocess.run()` call in sr.py normally blocks until instance.py terminates, but because it is in a try...except block, Ctrl+C would interrupt subprocess.run and cause the `except KeyboardError` code to run. 

This PR adds a signal handler (that does nothing except log messages) to instance.py, so when SIGINT is received, the signal handler runs and then returns control back to subprocess.run, allowing the child process to stop cleanly.

---

During flakey tests I also noticed that a message was logged `[ERROR] sarracenia.moth.amqp close sr_amqp/close 2: 'NoneType' object has no attribute 'collect'`. It's not really a problem if moth.amqp's close method is called on a connection that is `None` (already closed), so I think it makes sense to add the if to avoid the message being logged...