### PR TITLE
Stop foreground posts to fix artifact collection

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -69,6 +69,7 @@ jobs:
         continue-on-error: true
         run: |
           sr3 stop
+          sr3 stop post/* cpost/*
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *
       


### PR DESCRIPTION
I noticed a few actions runs failed to save artifacts because the log files changed. Since sr3 stop doesn't stop posts anymore, I added an explicit `sr3 stop post/* cpost/*`