### PR TITLE
Reworked `sr3 stop` to use dangerWillRobinson

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -68,8 +68,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          sr3 stop
-          sr3 stop post/* cpost/*
+          sr3 stop --dangerWillRobinson
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *
       


### PR DESCRIPTION
`sr3 stop` will never stop foreground instances, even if you specify `component/config`. A message is printed to let the user know about running foreground configs that were not stopped, and that they can use `--dangerWillRobinson` to stop them.

`sr3 stop --dangerWillRobinson` will always stop running foreground instances (in addition to daemon instances).

Also found that there was a piece missing from previous changes that I made to `sr3 stop`'s behavior. If the stop method started attempting to SIGKILL processes, it would report that foreground instances were not responding to SIGKILL, even though it was not trying to SIGKILL them. Now the processes that are not responding to SIGKILL are correctly reported (only daemone