### PR TITLE
Add `if_unused=True` to exchange delete for #382

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -345,8 +345,12 @@ class AMQP(Moth):
 
         try:
             for x in self.o['exchange']:
-                logger.info("deleting exchange: %s" % x )
-                self.channel.exchange_delete(x, if_unused=True)
+                try:
+                    self.channel.exchange_delete(x, if_unused=True)
+                    logger.info("deleted exchange: %s" % x)
+                except amqp.exceptions.PreconditionFailed as err:
+                    err_msg = str(err).replace("Exchange.delete: (406) PRECONDITION_FAILED - exchange ", "")
+                    logger.warning("failed to delete exchange: %s" % err_msg)
         except Exception as err:
             logger.error("failed on {} with {}".format(
                 self.o['broker'].url.hostname, err))

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -346,7 +346,7 @@ class AMQP(Moth):
         try:
             for x in self.o['exchange']:
                 logger.info("deleting exchange: %s" % x )
-                self.channel.exchange_delete(x)
+                self.channel.exchange_delete(x, if_unused=True)
         except Exception as err:
             logger.error("failed on {} with {}".format(
                 self.o['broker'].url.hostname, err))

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1344,8 +1344,8 @@ class sr_GlobalState:
                         print(' remove %s from %s subscribers: %s ' %
                               (qd[1], x, xx))
                         xx.remove(qd[1])
-                        if len(xx) < 1:
-                            print("no more queues, removing exchange %s" % x)
+                        if o.post_broker and len(xx) < 1:
+                            print("No local queues found for exchange %s, attemping to remove it..." % x)
                             qdc = sarracenia.moth.Moth.pubFactory(
                                 o.post_broker, {
                                     'declare': False,


### PR DESCRIPTION
Add `if_unused=True` to exchange delete for #382

Ensure that sr3 cleanup doesn't delete exchanges that have bindings.

@tysonkaufmann found the option in the documentation :)