### PR TITLE
Fix double // on relPath download

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1491,11 +1491,12 @@ class Flow:
         else:
             logger.debug("%s_transport download relPath=%s" % (self.scheme, msg['relPath']))
 
-            # split the path to the file, and the file
-            pathname, remote_file = os.path.split(msg['relPath'])
+            # split the path to the file and the file
+            # if relPath is just the file remote_path will return empty
+            remote_path, remote_file = os.path.split(msg['relPath'])
             # relPath does not contain a prefix / , add it for cdir
-            cdir = '/' + pathname
-            urlstr = os.path.join(msg['baseUrl'], msg['relPath'])
+            cdir = '/' + remote_path
+            urlstr = msg['baseUrl'] + '/' + msg['relPath']
 
         istr =msg['integrity']  if ('integrity' in msg) else "None"
         fostr = msg['fileOp'] if ('fileOp' in msg ) else "None"

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1491,11 +1491,11 @@ class Flow:
         else:
             logger.debug("%s_transport download relPath=%s" % (self.scheme, msg['relPath']))
 
-            token = msg['relPath'].split('/')
-            u = urllib.parse.urlparse(msg['baseUrl'])
-            cdir = '/' + u.path[1:] + '/' + '/'.join(token[:-1])
-            remote_file = token[-1]
-            urlstr = msg['baseUrl'] + '/' + msg['relPath']
+            # split the path to the file, and the file
+            pathname, remote_file = os.path.split(msg['relPath'])
+            # relPath does not contain a prefix / , add it for cdir
+            cdir = '/' + pathname
+            urlstr = os.path.join(msg['baseUrl'], msg['relPath'])
 
         istr =msg['integrity']  if ('integrity' in msg) else "None"
         fostr = msg['fileOp'] if ('fileOp' in msg ) else "None"


### PR DESCRIPTION
Short relPath's were generating unnecessary /'s - not an issue on filesystem but causes issues on http(s) downloads.

Changed download to use os.path calls which will fix issues with short paths.

closes #619 