### PR TITLE
Fix dateparser detection bug

### DIFF
--- a/sarra/sr_poll.py
+++ b/sarra/sr_poll.py
@@ -72,7 +72,7 @@ import datetime
 dateparser_available=False
 try:
     from dateparser import parse
-    dateparser_available=False
+    dateparser_available=True
 
 except:
    print( 'Warning: dateparser not available')   


### PR DESCRIPTION
`dateparser_available` is set to False whether it's successfully imported or not. 

Any time the poll fails to list the remote directory, it will log a misleading error saying that dateparser is not available, even if it is. When a directory fails to be listed for a non-dateparser related reason, it will still log this error message: https://github.com/MetPX/sarracenia/blob/v2_dev/sarra/sr_poll.py#L366-L367