### PR TITLE
fixes for #661 examples of python consumer failing.

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -767,7 +767,7 @@ class Message(dict):
         if 'retrievePath' in msg:
             retUrl = msg['baseUrl'] + '/' + msg['retrievePath']
         else:
-            retUrl = msg['baseUrl'] + '/' + msg['retrievePath']
+            retUrl = msg['baseUrl'] + '/' + msg['relPath']
 
         with urllib.request.urlopen(retUrl) as response:
             return response.read()

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -12,6 +12,7 @@ default_options = {
     'batch': 100,
     'bindings': [],
     'broker': None,
+    'dry_run': False,
     'exchange': 'xpublic',
     'expire': 300,
     'inline': False,


### PR DESCRIPTION
over time python3 api examples broke.  
quick fix.  I just put one reviewer because in the last pull request, I saw it wants approval from all before mergeing... 

