### PR TITLE
does what the issue #663 says, do not call expanduser when they are r…

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1825,7 +1825,8 @@ class Config:
                     'overriding batch for consistency with messageCountMax: %d'
                     % self.batch)
 
-        self.path = list(map( os.path.expanduser, self.path ))
+        if (component not in ['poll' ]):
+            self.path = list(map( os.path.expanduser, self.path ))
 
         if self.vip and not sarracenia.extras['vip']['present']:
             logger.critical( f"vip feature requested, but library: {' '.join(sarracenia.extras['vip']['modules_needed'])} " )


### PR DESCRIPTION
when you have a poll if the path to poll starts with ~ and there is a local user with the same name... it will get expanded locally, which is likely the wrong thing.
e.g.  http://somehost/~lala

Ran into this trying to make courseware.
