### PR TITLE
V03 issue617 (part of it.) "topic" depends more on payload format, than message protocol.

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -679,7 +679,9 @@ class Message(dict):
                 logger.error('missing post_baseUrl setting')
                 return
 
-        if options.post_topicPrefix:
+        if options.post_format:
+            msg['post_format'] = options.post_format
+        elif options.post_topicPrefix:
             msg['post_format'] = options.post_topicPrefix[0]
         elif options.topicPrefix != msg['_format']:
             logger.warning( f"received message in {msg['_format']} format, expected {options.post_topicPrefix} " )

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -91,7 +91,7 @@ default_options = {
     'post_documentRoot': None,
     'post_baseDir': None,
     'post_baseUrl': None,
-    'post_format': None,
+    'post_format': 'v03',
     'realpathPost': False,
     'recursive' : True,
     'report': False,

--- a/sarracenia/examples/moth_api_consumer.py
+++ b/sarracenia/examples/moth_api_consumer.py
@@ -39,8 +39,8 @@ while count < 5:
     m = h.getNewMessage()
     if m is not None:
         print("message: %s" % m)
-        content = m.getContent()
-        print("corresponding file: %s" % content)
+        #content = m.getContent()
+        #print("corresponding file: %s" % content)
         h.ack(m)
     time.sleep(0.1)
     count += 1
@@ -48,3 +48,4 @@ while count < 5:
 print(' got %d messages' % count)
 h.cleanup()
 h.close()
+exit( count )

--- a/sarracenia/examples/moth_api_producer.py
+++ b/sarracenia/examples/moth_api_producer.py
@@ -10,14 +10,25 @@ from sarracenia.config import default_config
 import os
 import time
 import socket
+import sys
+
+"""
+  supply broker argument as a command line argument.
+
+"""
+if len(sys.argv) > 1:
+    broker = sys.argv[1]
+else:
+    broker = 'amqp://tfeed:HungryCat@localhost'
 
 cfg = default_config()
 #cfg.logLevel = 'debug'
-cfg.broker = sarracenia.credentials.Credential(
-    'amqp://tfeed:HungryCat@localhost')
-cfg.exchange = 'xpublic'
+cfg.broker = sarracenia.credentials.Credential( broker )
+cfg.exchange = 'xsarra'
 cfg.post_baseUrl = 'http://host'
 cfg.post_baseDir = '/tmp'
+cfg.topicPrefix = [ 'v03', 'post' ]
+cfg.logLevel = 'debug'
 
 print('cfg: %s' % cfg)
 

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -128,6 +128,8 @@ class Message:
             h['parts'] = '%s,%d,%d,%d,%d' % (m, p['size'], p['count'],
                                              p['remainder'], p['number'])
 
+        h['topic'] = [ 'v02', 'post' ] + self.relpath.split('/')[0:-1]
+
         if 'parts' in h:
             self.partstr = h['parts']
         #else:

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -64,13 +64,14 @@ class PostFormat:
         pass
 
     @staticmethod
-    def exportAny(msg, post_format='v03') -> (str, dict, str):
+    def exportAny(msg, post_format='v03', topicPrefix=[ 'v03' ]) -> (str, dict, str):
         """
           return a tuple of the encoded message body, a headers dict, and content_type
+          and a completed topic as a list as one header.
        """
         for sc in PostFormat.__subclasses__():
             if post_format == sc.__name__.lower():
-                return sc.exportMine( msg ) 
+                return sc.exportMine( msg, topicPrefix ) 
 
         return None, None, self.mimetype
 

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -73,7 +73,7 @@ class PostFormat:
             if post_format == sc.__name__.lower():
                 return sc.exportMine( msg, topicPrefix ) 
 
-        return None, None, self.mimetype
+        return None, None, None
 
 # test for v04 first, because v03 may claim all other JSON.
 import sarracenia.postformat.wis

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -134,7 +134,7 @@ class V02(PostFormat):
         return msg
 
     @staticmethod
-    def exportMine(body) -> (str, dict, str):
+    def exportMine(body,topic_prefix) -> (str, dict, str):
         """
            given a v03 (internal) message, produce an encoded version.
        """

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -76,9 +76,15 @@ class V03(PostFormat):
         return msg
 
     @staticmethod
-    def exportMine(body) -> (str, dict, str):
+    def exportMine(body,topic_prefix) -> (str, dict, str):
         """
            given a v03 (internal) message, produce an encoded version.
        """
         raw_body = json.dumps(body)
-        return raw_body, None, V03.content_type()
+
+        if 'relPath' in body:
+            headers = { 'topic': topic_prefix + body['relPath'].split('/')[0:-1]  }
+        else:
+            headers = { 'topic': topic_prefix }
+
+        return raw_body, headers, V03.content_type()

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1066,10 +1066,11 @@ class sr_GlobalState:
 
         if self.appname is None:
             self.appname = 'sr3'
-        else:
-            print(
-                'DEVELOPMENT using alternate application name: %s, bindir=%s' %
-                (self.appname, self.bin_dir))
+        #else:
+        #    print(
+        #        'DEVELOPMENT using alternate application name: %s, bindir=%s' %
+        #        (self.appname, self.bin_dir))
+
 
         if not os.path.isdir(self.user_config_dir):
             print( f'INFO: No {self.appname} configuration found. creating an empty one {self.user_config_dir}' )


### PR DESCRIPTION
move topic generation away from message protocols and into the payload format code.
the WIS format has a different scheme for determining topic hierarchy, so need a way for the postformat/wis.py to return the "topic" for published messages.

I think the universal idea is that one should be able to determina an appropriate topic from the content of the message.