### PR TITLE
V03 issue615 - WIS format messages, as proof of concept of using non-sarracenia ones.

### DIFF
--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.osver }}
   
     name: Maintenance test on ${{ matrix.osver }}
-    timeout-minutes: 30
+    timeout-minutes: 10
     
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.osver }}
   
     name: Maintenance test on ${{ matrix.osver }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened]
   push:
     branches:
-      - turned_off_for_now_always_fails
+      - v03_wip
 
   workflow_dispatch:
     inputs:
@@ -23,7 +23,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       which_test: [ static_flow ]
+       which_test: [ static_flow, dynamic_flow ]
        osver: [ "ubuntu-22.04" ]
 
     runs-on: ${{ matrix.osver }}

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.osver }}
   
     name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -49,10 +49,11 @@ jobs:
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       # https://github.com/marketplace/actions/debugging-with-tmate
       # 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event.inputs.debug_enabled }}
-        #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      # 2023/06/06 - pas - this ALWAYS enables... some weird bug. commenting out to be able
+      #              to run at all.
+      #- name: Setup tmate session
+      #  uses: mxschmitt/action-tmate@v3
+      #  if: ${{ github.event.inputs.debug_enabled }}
 
       - name: Limit ${{ matrix.which_test }} test.
         run: |

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.osver }}
   
     name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.osver }}
   
     name: Unit test on ${{ matrix.osver }}
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v3

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+metpx-sr3 (3.00.41) UNRELEASED; urgency=medium
+
+  * move aware from release. 
+
+ -- Peter <peter@bsqt.homeip.net>  Sat, 03 Jun 2023 01:43:49 -0400
+
 metpx-sr3 (3.00.40) unstable; urgency=medium
 
   * resolved #681, #661 python API broken 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,10 @@
+
+
+run sphinx::
+
+    make html   
+
+
+prerequisites::
+
+    apt install python3-sphinx python3-nbsphinx python3-sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx
+magic
 nbsphinx
 jupyter
 docutils

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1346,6 +1346,16 @@ post_on_start
 When starting watch, one can either have the program post all the files in the directories watched
 or not. (not implemented in sr3_cpost)
 
+post_topic <string> 
+---------------------
+
+Explicitly set a posting topic string, overriding the usual
+group of settings. For sarracenia data pumps, this should never be needed,
+as the use of post_exchange, post_topicPrefix, and relpath normally builds the right
+value for topics for both posting and binding.
+
+
+
 post_topicPrefix (default: topicPrefix)
 ---------------------------------------
 
@@ -1736,10 +1746,10 @@ the connection should succeed regardless.
 topic <string> 
 --------------
 
-Explicitly set a subscribing or posting topic string, overriding the usual
-group of settings. For sarracenia data pumps, this should never be needed,
-as the use of exchange, topicPrefix, and subtopic normally builds the right
-value for topics for both posting and binding.
+Explicitly set a subscribing topic string, overriding the value usually
+derived from a group of settings. For sarracenia data pumps, this should never be needed,
+as the use of *exchange*, *topicPrefix*, and *subtopic* normally builds the right
+value.
 
 
 topicPrefix (default: v03)

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1328,6 +1328,18 @@ will result in posting messages to five exchanges named: xwinnow00, xwinnow01,
 xwinnow02, xwinnow03 and xwinnow04, where each exchange will receive only one fifth
 of the total flow.
 
+post_format <name> (default: v03)
+---------------------------------
+
+Sets the message format for posted messages. the currently included values are:
+
+* v02 ... used by all existing data pumps for most cases.
+* v03 ... default in sr3 JSON format easier to work with.
+* wis ... a experimental geoJSON format in flux for the World Meteorological Organization
+
+When provided, this value overrides whatever can be deduced from the post_topicPrefix.
+
+
 post_on_start
 -------------
 
@@ -1719,6 +1731,15 @@ levels of compliance with whatever is currently defined as rigourous encryption.
 If a site being connected to, has, for example, and expired certificate, and
 it is nevertheless necessary to use it, then set tlsRigour to *lax* and
 the connection should succeed regardless.
+
+
+topic <string> 
+--------------
+
+Explicitly set a subscribing or posting topic string, overriding the usual
+group of settings. For sarracenia data pumps, this should never be needed,
+as the use of exchange, topicPrefix, and subtopic normally builds the right
+value for topics for both posting and binding.
 
 
 topicPrefix (default: v03)

--- a/docs/source/Reference/sr_post.7.rst
+++ b/docs/source/Reference/sr_post.7.rst
@@ -124,6 +124,7 @@ The headers are an array of name:value pairs::
               "encoding" : "utf-8" | "base64"  , 
               "value"    " "encoded file content"
           }
+          "contentType" : "string" - MIME-type information referring to the data.
 
           For "v03.report" topic notification messages the following addtional
           headers will be present:

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1312,11 +1312,32 @@ entraînera la publication de messages d'annonce sur cinq échanges nommés : xw
 xwinnow02, xwinnow03 et xwinnow04, où chaque échange ne recevra qu’un cinquième
 du flux total.
 
+post_format <name> (défaut: v03)
+--------------------------------
+
+Définit le format de message pour les messages publiés. les valeurs actuellement incluses sont :
+
+* v02 ... utilisé par toutes les pompes de données existantes dans la plupart des cas.
+* v03 ... par défaut au format sr3 JSON plus facile à utiliser.
+* wis ... un format expérimental geoJSON en flux pour l'Organisation météorologique mondiale
+
+Lorsqu'elle est fournie, cette valeur remplace tout ce qui peut être déduit de post_topicPrefix.
+
+
 post_on_start
 -------------
 
 Lors du démarrage de watch, on peut soit demander au programme de publier tous les fichiers dans les répertoires
 surveillés, ou pas. (pas implanté en sr3_cpost)
+
+post_topic <chaine>
+-------------------
+
+Définissez explicitement une chaîne de sujet de publication, en remplaçant l'habituel
+groupe de paramètres. Pour les pompes de données Sarracenia, cela ne devrait jamais être nécessaire,
+car l'utilisation de *post_exchange*, *post_topicPrefix* et le *relPath* construit normalement le bon
+valeur pour les sujets à la fois pour la publication et la liaison.
+
 
 post_topicPrefix (défaut: topicPrefix)
 --------------------------------------
@@ -1687,6 +1708,14 @@ niveaux de conformité par rapport à ce qui est couramment défini comme un cry
 Par exemple, si on se connecte à un site et que son certificat est expiré, et
 qu'il est quand même nécessaire de l’utiliser, alors définir tlsRigour a *lax* pourra
 permettre la connexion de réussir.
+
+topic <chaine> 
+--------------
+
+Définissez explicitement une chaîne de sujet d'abonnement ou de publication, en remplaçant la valeur
+dériver à partir de l'habituel groupe de paramètres. Pour les pompes de données Sarracenia, cela ne 
+devrait jamais être nécessaire, car l'utilisation de l'*exchange*, *topicPrefix* et *subtopic*  
+construit normalement le bon valeur.
 
 topicPrefix (défaut: v03)
 -------------------------

--- a/docs/source/fr/Reference/sr_post.7.rst
+++ b/docs/source/fr/Reference/sr_post.7.rst
@@ -127,6 +127,7 @@ Les en-têtes sont un tableau de paires nom:valeur::
                      "message" :  - message de rapport d’état documenté dans `Report Messages`_
                    }
 
+          "contentType" : "chaine mime-type"  - indique le format des données.
           "type": "Feature"   - utilisé pour la compatibilité geoJSON.
           "geometry" : ... selon la compatibilité GoJSON RFC7946.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 Sphinx
+magic
 paramiko
 nbsphinx
 jupyter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 Sphinx
-magic
+python-magic
 paramiko
 nbsphinx
 jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs
 humanfriendly
 humanize
 jsonpickle
+magic
 paramiko
 psutil>=5.3.0
 watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs
 humanfriendly
 humanize
 jsonpickle
-magic
+python-magic
 paramiko
 psutil>=5.3.0
 watchdog

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -24,7 +24,7 @@
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 #
 #
-__version__ = "3.00.40"
+__version__ = "3.00.41"
 
 from base64 import b64decode, b64encode
 import calendar

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -31,6 +31,7 @@ import calendar
 import datetime
 import importlib.util
 import logging
+import magic
 import os
 import os.path
 import paramiko
@@ -467,8 +468,18 @@ class Message(dict):
             returns a well-formed message, or none.
         """
         m = sarracenia.Message.fromFileInfo(path, o, lstat)
-        if lstat and os_stat.S_ISREG(lstat.st_mode):
-            m.__computeIntegrity(path, o)
+        if lstat :
+            if os_stat.S_ISREG(lstat.st_mode):
+                m.__computeIntegrity(path, o)
+                try:
+                    t = magic.from_file(path,mime=True)
+                    m['contentType'] = t
+                except Exception as ex:
+                    logging.info("trying to determine mime-type. Exception details:", exc_info=True)
+            elif os_stat.S_ISDIR(lstat.st_mode):
+                m['contentType'] = 'text/directory' # source: https://www.w3.org/2002/12/cal/rfc2425.html
+            elif os_stat.S_ISLNK(lstat.st_mode):
+                m['contentType'] = 'text/link' # I invented this one, could not find any reference
         return m
 
     @staticmethod

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -124,7 +124,7 @@ duration_options = [
     'sanity_log_dead', 'sleep', 'timeout', 'varTimeOffset'
 ]
 
-list_options = ['path']
+list_options = ['path' ]
 
 # set, valid values of the set.
 set_options = [ 'logEvents', 'fileEvents' ]

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -146,7 +146,7 @@ str_options = [
     'pollUrl', 'post_baseUrl', 'post_baseDir', 'post_broker', 'post_exchange',
     'post_exchangeSuffix', 'post_format', 'queueName', 'sendTo', 'rename',
     'report_exchange', 'source', 'strip', 'timezone', 'nodupe_ttl',
-    'nodupe_basis', 'tlsRigour', 'vip'
+    'nodupe_basis', 'tlsRigour', 'topic', 'vip'
 ]
 """
    for backward compatibility, 

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -144,7 +144,7 @@ str_options = [
     'action', 'admin', 'baseDir', 'broker', 'cluster', 'directory', 'exchange',
     'exchange_suffix', 'feeder', 'filename', 'flatten', 'flowMain', 'header', 'integrity', 'logLevel', 
     'pollUrl', 'post_baseUrl', 'post_baseDir', 'post_broker', 'post_exchange',
-    'post_exchangeSuffix', 'post_format', 'queueName', 'sendTo', 'rename',
+    'post_exchangeSuffix', 'post_format', 'post_topic', 'queueName', 'sendTo', 'rename',
     'report_exchange', 'source', 'strip', 'timezone', 'nodupe_ttl',
     'nodupe_basis', 'tlsRigour', 'topic', 'vip'
 ]

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import importlib
 import logging
+import magic
 import os
 import re
 
@@ -25,6 +26,7 @@ from sys import platform as _platform
 
 from base64 import b64decode, b64encode
 from mimetypes import guess_type
+
 # end v2 subscriber
 
 from sarracenia import nowflt
@@ -1834,6 +1836,9 @@ class Flow:
                         if os.path.isfile(new_file):
                             os.remove(new_file)
                         os.rename(new_inflight_path, new_file)
+                    # older versions don't include the contentType, so patch it here.
+                    if 'contentType' not in msg:
+                        msg['contentType'] = magic.from_file(new_file,mime=True)
             elif len_written < 0:
                 logger.error("failed to download %s" % new_file)
                 return False
@@ -1944,6 +1949,10 @@ class Flow:
                                                 msg) + '/' + msg['relPath']
         else:
             local_path = '/' + msg['relPath']
+
+        # older versions don't include the contentType, so patch it here.
+        if 'contentType' not in msg:
+            m['contentType'] = magic.from_file(new_file,mime=True)
 
         local_dir = os.path.dirname(local_path).replace('\\', '/')
         local_file = os.path.basename(local_path).replace('\\', '/')

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -484,9 +484,13 @@ class Flow:
                     for m in self.worklist.ok:
                         if ('new_baseUrl' in m) and (m['baseUrl'] !=
                                                      m['new_baseUrl']):
+                            m['old_baseUrl'] = m['baseUrl']
+                            m['_deleteOnPost'] |= set(['old_baseUrl'])
                             m['baseUrl'] = m['new_baseUrl']
                         if ('new_retrievePath' in m) :
+                            m['old_retrievePath'] = m['retrievePath']
                             m['retrievePath'] = m['new_retrievePath']
+                            m['_deleteOnPost'] |= set(['old_retrievePath'])
 
                         # if new_file does not match relPath, then adjust relPath so it does.
                         if 'relPath' in m and m['new_file'] != m['relPath'].split('/')[-1]:
@@ -502,11 +506,18 @@ class Flow:
                                     m['new_relPath'] = m['new_file']
 
                         if ('new_relPath' in m) and (m['relPath'] != m['new_relPath']):
+                            m['old_relPath'] = m['relPath']
+                            m['_deleteOnPost'] |= set(['old_relPath'])
                             m['relPath'] = m['new_relPath']
+                            m['old_subtopic'] = m['subtopic']
+                            m['_deleteOnPost'] |= set(['old_subtopic'])
                             m['subtopic'] = m['new_subtopic']
-                        if ('_format' in m) and ( m['_format'] != 
-                                                  m['post_format']):
-                            m['_format'] = m['post_format']
+
+                        if '_format' in m:
+                            m['old_format'] = m['_format']
+                            m['_deleteOnPost'] |= set(['old_format'])
+                        m['_format'] = m['post_format']
+                        
 
                     self._runCallbacksWorklist('after_work')
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -178,8 +178,8 @@ class Flow:
 
         if (( hasattr(self.o, 'delete_source') and self.o.delete_source ) or \
             ( hasattr(self.o, 'delete_destination') and self.o.delete_destination )) and \
-            ('sarracenia.flowcb.work.delete.Delete' not in self.plugins_late['load']):
-            self.plugins_late['load'].append('sarracenia.flowcb.work.delete.Delete')
+            ('sarracenia.flowcb.work.delete.Delete' not in self.o.plugins_late):
+            self.o.plugins_late.append('sarracenia.flowcb.work.delete.Delete')
 
         # transport stuff.. for download, get, put, etc...
         self.scheme = None

--- a/sarracenia/flowcb/accept/trim_legacy_fields.py
+++ b/sarracenia/flowcb/accept/trim_legacy_fields.py
@@ -1,0 +1,24 @@
+"""
+Plugin :
+    This plugin is aesthetic... some users want less cluttered messages, remove fields
+    that are not needed in the non-file replication case, and where sundew_compatibility
+    is irrelevant.
+
+Usage:
+    callback accept.trim_legacy_fields
+"""
+
+import logging
+import os, stat, time
+from sarracenia.flowcb import FlowCB
+
+logger = logging.getLogger(__name__)
+
+
+class Trim_legacy_fields(FlowCB):
+
+    def after_accept(self, worklist):
+        for message in worklist.incoming:
+            for h in [ 'atime', 'filename', 'from_cluster', 'mtime', 'source', 'sundew_extension', 'to_clusters' ]:
+                if h in message:
+                    del message[h]

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -22,15 +22,17 @@ class Message(FlowCB):
         if hasattr(self.o, 'post_broker'):
             props = sarracenia.moth.default_options
             props.update(self.o.dictify())
-            props.update({
-                'broker': self.o.post_broker,
-                'exchange': self.o.post_exchange,
-                'topicPrefix': self.o.post_topicPrefix,
-            })
-            if hasattr(self.o, 'post_exchangeSplit'):
-                props.update({
-                    'exchangeSplit': self.o.post_exchangeSplit,
-                })
+
+            if hasattr(self.o, 'topic' ):
+                del self.o['topic']
+
+            # adjust settings post_xxx to be xxx, as Moth does not use post_ ones.
+            for k in [ 'broker', 'exchange', 'topicPrefix', 'exchangeSplit', 'topic' ]:
+                post_one='post_'+k
+                if hasattr( self.o, post_one ): 
+                    #props.update({ k: getattr(self.o,post_one) } )
+                    props[ k ] = getattr(self.o,post_one)
+
             self.poster = sarracenia.moth.Moth.pubFactory(props)
 
     def post(self, worklist):

--- a/sarracenia/flowcb/work/delete.py
+++ b/sarracenia/flowcb/work/delete.py
@@ -90,10 +90,14 @@ class Delete(FlowCB):
                     s = os.stat(d)
                     age = time.time() - s.st_mtime
                     if age > self.o.housekeeping:
-                        os.rmdir(d)
-                        self.dirsOfDeletion.remove(d)
-                        self.dirsofDeltion.add(dirname(d))
-                        logger.info( f"deleting {d}")
+                        try:
+                            os.rmdir(d)
+                            self.dirsOfDeletion.remove(d)
+                            self.dirsofDeltion.add(dirname(d))
+                            logger.info( f"deleted {d}")
+                        except Exception as err:
+                            logger.error("could not unlink {}: {}".format(f, err))
+                            logger.debug("Exception details:", exc_info=True)
                     else:
                         logger.info( f"but not for long enough yet.")
 

--- a/sarracenia/flowcb/work/delete.py
+++ b/sarracenia/flowcb/work/delete.py
@@ -1,6 +1,9 @@
 import logging
 import os
 from sarracenia.flowcb import FlowCB
+import time
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -24,6 +27,15 @@ class Delete(FlowCB):
         logger.debug("initialized")
         self.o.add_option('delete_source', 'flag', True)
         self.o.add_option('delete_destination', 'flag', False)
+        self.dirsOfDeletion=set([])
+
+         # dirs not to be deleted.
+        self.sacredDirs=set([])
+        if hasattr(self.o, 'baseDir'):
+            self.sacredDirs.add(self.o.baseDir)
+        if hasattr(self.o, 'post_baseDir'):
+            self.sacredDirs.add(self.o.post_baseDir)
+
 
     def after_accept(self, worklist):
         new_incoming = []
@@ -50,6 +62,7 @@ class Delete(FlowCB):
                 files_to_delete.append(message['delete_source'])
 
             if self.o.delete_destination:
+                self.dirsOfDeletion |= set(message['new_dir'])
                 files_to_delete.append(
                     "%s/%s" % (message['new_dir'], message['new_file']))
 
@@ -60,3 +73,27 @@ class Delete(FlowCB):
                 except OSError as err:
                     logger.error("could not unlink {}: {}".format(f, err))
                     logger.debug("Exception details:", exc_info=True)
+
+    def on_housekeeping(self):
+
+        dirlist=self.dirsOfDeletion
+
+        logger.info('scan for directories to cleanup')
+        for d in dirlist:
+            if d in self.sacredDirs:
+                self.dirsOfDeletion.remove(d)
+                continue
+            if os.path.isdir(d):
+                l = os.listdir(d)
+                if len(l) == 0: # empty directory
+                    logger.info( f"found {d} is empty.")
+                    s = os.stat(d)
+                    age = time.time() - s.st_mtime
+                    if age > self.o.housekeeping:
+                        os.rmdir(d)
+                        self.dirsOfDeletion.remove(d)
+                        self.dirsofDeltion.add(dirname(d))
+                        logger.info( f"deleting {d}")
+                    else:
+                        logger.info( f"but not for long enough yet.")
+

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -123,7 +123,7 @@ class AMQP(Moth):
             else:
                 content_type = None
 
-            msg = PostFormat.importAny( body, raw_msg.headers, content_type )
+            msg = PostFormat.importAny( body, raw_msg.headers, content_type, self.o )
             if not msg:
                 logger.error('Decode failed, discarding message')
                 return None
@@ -605,7 +605,7 @@ class AMQP(Moth):
         else:
             ttl = "0"
 
-        raw_body, headers, content_type = PostFormat.exportAny( body, version, self.o['topicPrefix'] )
+        raw_body, headers, content_type = PostFormat.exportAny( body, version, self.o['topicPrefix'], self.o )
 
         topic = '.'.join(headers['topic'])
         topic = topic.replace('#', '%23')

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -127,7 +127,6 @@ class MQTT(Moth):
         self.o.update(default_options)
         self.o.update(options)
 
-
         if 'qos' in self.o:
             if type(self.o['qos']) is not int:
                 self.o['qos'] = int(self.o['qos'])
@@ -629,7 +628,7 @@ class MQTT(Moth):
             return False
 
         if not self.connected:
-            self.__putSetup(self.o)
+            self.__putSetup()
 
         postFormat = body['_format']
 
@@ -685,6 +684,7 @@ class MQTT(Moth):
             if headers:
                 props.UserProperty=list(map( lambda x :  (x,headers[x]) , headers ))
 
+            print( f"hoho {self.o['messageDebugDump']} post_format: {self.o['post_format']}" )
             if self.o['messageDebugDump']:
                 logger.info( f"Message to publish: topic: {topic} body type:{type(raw_body)} body:{raw_body}" )
                 if hasattr(props, 'UserProperty'): 

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -530,7 +530,7 @@ class MQTT(Moth):
                 [ headers.update({k:v}) for k,v in mqttMessage.properties.UserProperty ]
             else:
                 headers=None
-            message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType)
+            message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
 
         except Exception as ex:
             logger.error("ignored malformed message: %s" % mqttMessage.payload)
@@ -670,7 +670,7 @@ class MQTT(Moth):
         props.ContentType = PostFormat.content_type( postFormat )
 
         try:
-            raw_body, headers, content_type = PostFormat.exportAny( body, postFormat, [exchange]+self.o['topicPrefix'] )
+            raw_body, headers, content_type = PostFormat.exportAny( body, postFormat, [exchange]+self.o['topicPrefix'], self.o )
             # FIXME: might
             topic = '/'.join(headers['topic']) 
 

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -529,7 +529,7 @@ class MQTT(Moth):
                              (type(mqttMessage.payload), len(mqttMessage.payload), mqttMessage.payload))
 
             if hasattr(mqttMessage.properties, 'UserProperty'): 
-                logger.info( f'UserProperty: {mqttMessage.properties.UserProperty} ')
+                logger.info( f"User Property: {mqttMessage.properties.UserProperty} ")
 
         self.metrics['rxByteCount'] += len(mqttMessage.payload)
         try:
@@ -688,12 +688,11 @@ class MQTT(Moth):
 
             if headers:
                 props.UserProperty=list(map( lambda x :  (x,headers[x]) , headers ))
-                logger.critical( f"FIXME HOHO ... props.UserProperty: {props.UserProperty} ... headers: {headers}  " )
 
             if self.o['messageDebugDump']:
                 logger.info( f"Message to publish: topic: {topic} body type:{type(raw_body)} body:{raw_body}" )
                 if hasattr(props, 'UserProperty'): 
-                    logger.info( f"user_property:{props.UserProperty}" )
+                    logger.info( f"UserProperty:{props.UserProperty}" )
                     
 
             info = self.client.publish(topic=topic, payload=raw_body, qos=self.o['qos'], properties=props)

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -48,7 +48,7 @@ class PostFormat:
         return self.mimetype
 
     @staticmethod
-    def importAny(payload, headers, content_type ) -> sarracenia.Message:
+    def importAny(payload, headers, content_type, options ) -> sarracenia.Message:
         """
           given a message in a wire format, with the given properties (or headers) in a dictionary,
           return the message as a normalized v03 message.
@@ -57,21 +57,21 @@ class PostFormat:
        """
         for sc in PostFormat.__subclasses__():
             #logger.info( f" sc={sc}, scct={sc.content_type()}, content_type={content_type} " )
-            if sc.mine(payload, headers, content_type):
-                return sc.importMine(payload, headers )
+            if sc.mine(payload, headers, content_type, options ):
+                return sc.importMine(payload, headers, options )
         return None
 
         pass
 
     @staticmethod
-    def exportAny(msg, post_format='v03', topicPrefix=[ 'v03' ]) -> (str, dict, str):
+    def exportAny(msg, post_format='v03', topicPrefix=[ 'v03' ], options={ 'post_format': 'v03', 'topicPrefix':'v03' } ) -> (str, dict, str):
         """
           return a tuple of the encoded message body, a headers dict, and content_type
           and a completed topic as a list as one header.
        """
         for sc in PostFormat.__subclasses__():
             if post_format == sc.__name__.lower():
-                return sc.exportMine( msg, topicPrefix ) 
+                return sc.exportMine( msg, topicPrefix, options ) 
 
         return None, None, None
 

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -71,7 +71,7 @@ class PostFormat:
        """
         for sc in PostFormat.__subclasses__():
             if post_format == sc.__name__.lower():
-                return sc.exportMine( msg, topicPrefix, options ) 
+                return sc.exportMine( msg, options ) 
 
         return None, None, None
 

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -134,7 +134,7 @@ class V02(PostFormat):
         return msg
 
     @staticmethod
-    def exportMine(body,topic_prefix, options) -> (str, dict, str):
+    def exportMine(body, options) -> (str, dict, str):
         """
            given a v03 (internal) message, produce an encoded version.
        """
@@ -147,4 +147,9 @@ class V02(PostFormat):
         ]:
             if h in v2m.headers:
                     del v2m.headers[h]
+
+        if ( 'broker' in options ) and ( 'exchange' in options ) and \
+            options['broker'].url.scheme.startswith('mqtt'):
+            v2m.headers['topic'] = options['exchange'] +  v2m.headers['topic']
+
         return v2m.notice, v2m.headers, V02.content_type()

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -23,7 +23,7 @@ class V02(PostFormat):
         return 'text/plain'
 
     @staticmethod
-    def mine(payload, headers, content_type) -> bool:
+    def mine(payload, headers, content_type, options) -> bool:
         """
           return true if the message is in this post format.
        """
@@ -32,7 +32,7 @@ class V02(PostFormat):
         return False
 
     @staticmethod
-    def importMine(body, headers) -> sarracenia.Message:
+    def importMine(body, headers, options) -> sarracenia.Message:
         """
           given a message in a wire format, with the given properties (or headers) in a dictionary,
           return the message as a normalized v03 message.
@@ -134,7 +134,7 @@ class V02(PostFormat):
         return msg
 
     @staticmethod
-    def exportMine(body,topic_prefix) -> (str, dict, str):
+    def exportMine(body,topic_prefix, options) -> (str, dict, str):
         """
            given a v03 (internal) message, produce an encoded version.
        """

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -19,7 +19,7 @@ class V03(PostFormat):
         return 'application/json'
 
     @staticmethod
-    def mine(payload, headers, content_type) -> bool:
+    def mine(payload, headers, content_type, options) -> bool:
         """
           return true if the message is in this post format.
        """
@@ -28,7 +28,7 @@ class V03(PostFormat):
         return False
 
     @staticmethod
-    def importMine(body, headers) -> sarracenia.Message:
+    def importMine(body, headers, options) -> sarracenia.Message:
         """
           given a message in a wire format, with the given properties (or headers) in a dictionary,
           return the message as a normalized v03 message.
@@ -76,7 +76,7 @@ class V03(PostFormat):
         return msg
 
     @staticmethod
-    def exportMine(body,topic_prefix) -> (str, dict, str):
+    def exportMine(body,topic_prefix,options) -> (str, dict, str):
         """
            given a v03 (internal) message, produce an encoded version.
        """

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -76,15 +76,29 @@ class V03(PostFormat):
         return msg
 
     @staticmethod
-    def exportMine(body,topic_prefix,options) -> (str, dict, str):
+    def exportMine(body,options) -> (str, dict, str):
         """
            given a v03 (internal) message, produce an encoded version.
        """
         raw_body = json.dumps(body)
 
-        if 'relPath' in body:
-            headers = { 'topic': topic_prefix + body['relPath'].split('/')[0:-1]  }
+        topic_separator='.'
+
+        if options['broker'].url.scheme.startswith('mqtt'):
+            if ( 'exchange' in options ) and ( 'topicPrefix' in options ):
+                topic_prefix = options['exchange'] + options['topicPrefix'] 
+            topic_separator='/'
         else:
-            headers = { 'topic': topic_prefix }
+            topic_prefix = options['topicPrefix']
+
+        if 'topic' in options:
+            topic = options['topic'].split(topic_separator)
+        else:
+            if 'relPath' in body:
+                topic = topic_prefix + body['relPath'].split('/')[0:-1]  
+            else:
+                topic = topic_prefix
+
+        headers = { 'topic': topic }
 
         return raw_body, headers, V03.content_type()

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -72,7 +72,7 @@ class Wis(PostFormat):
                     msg[literal] = GeoJSONBody[literal]
 
             for h in GeoJSONBody['properties']:
-                if h not in [ 'geometry', 'properties' ]:
+                if h not in [ 'geometry', 'properties', 'pubTime' ]:
                     msg[h] = GeoJSONBody['properties'][h]
             if 'type' in msg:
                 del msg['type']
@@ -96,8 +96,11 @@ class Wis(PostFormat):
 
             """
             for h in body:
-                if h not in [ 'geometry', 'properties', 'size', 'baseUrl', 'relPath', 'retrievePath', 'subtopic' ]:
+                if h not in [ 'geometry', 'properties', 'size', 'baseUrl', 'relPath', 'retrievePath', 'subtopic', 'pubTime' ]:
                     GeoJSONBody['properties'][h] = body[h]
+
+            t=body['pubTime']
+            GeoJSONBody['properties']['pubtime'] = t[0:4]+'-'+t[4:6]+'-'+t[6:11]+':'+t[11:13]+':'+t[12:14]+'.'+t[14:]
 
             if 'geometry' in body:
                 GeoJSONBody['geometry'] = body['geometry']
@@ -105,9 +108,9 @@ class Wis(PostFormat):
             GeoJSONBody['data_id'] =  str(uuid.uuid4())
 
             if 'retrievePath' in body :
-                url = '/'.join( [ body['baseUrl'], body['retrievePath'] ] )
+                url = body['baseUrl'] + body['retrievePath']
             else:
-                url = '/'.join( [ body['baseUrl'], body['relPath'] ] )
+                url = body['baseUrl'] + body['relPath']
 
             GeoJSONBody['links'] = [{
                 'rel': 'canonical',

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -62,7 +62,6 @@ class Wis(PostFormat):
           the path a retrieval one.
 
        """
-            logger.warning( f"FIXME Hi!")
             msg = sarracenia.Message()
             msg["_format"] = __name__.split('.')[-1].lower()
             try:

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -2,6 +2,10 @@ import json
 import logging
 import sarracenia
 from sarracenia.postformat import PostFormat
+import uuid
+
+#from pywis_pubsub.publish import create_message
+
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +23,18 @@ class Wis(PostFormat):
        internally All messages are represented as v03. 
        post format implement translations to other protocols for interop.
 
+       STATUS: creates bogus, but "correctly" formatted messages
+           not working... can't even figure out what the WMO wants... 
+
+       * there is no algorithm for the topic yet. just post a bogus one.
+       * data-id field... no algorithm to derive it yet... uuid was once suggested.
+       * geometry field should be set before calling.
+       
+       from internal format:
+       * sarracenia does not include the content-type of the data in the message, so that is omitted for now.
+         (reading up on relevant mime-type standards, when you do not know, you are supposed to omit.)
+
+
    """
 
     @staticmethod
@@ -35,10 +51,12 @@ class Wis(PostFormat):
         return False
 
     @staticmethod
-    def importMine(body, headers) -> sarracenia.Message:
+    def xxximportMine(body, headers) -> sarracenia.Message:
             """
           given a message in a wire format, with the given properties (or headers) in a dictionary,
           return the message as a normalized v03 message.
+
+          Since I can't figure out a baseUrl, I can't import any messages. so import is broken for now.
        """
             msg = sarracenia.Message()
             msg["_format"] = __name__.split('.')[-1].lower()
@@ -52,6 +70,7 @@ class Wis(PostFormat):
             for literal in [ 'geometry', 'properties' ]:
                 if literal in GeoJSONBody:
                     msg[literal] = GeoJSONBody[literal]
+
             for h in GeoJSONBody['properties']:
                 if h not in [ 'geometry', 'properties' ]:
                     msg[h] = GeoJSONBody['properties'][h]
@@ -61,17 +80,41 @@ class Wis(PostFormat):
             return msg
 
     @staticmethod
-    def exportMine(body) -> (str, dict, str):
+    def exportMine(body,topicPrefix) -> (str, dict, str):
             """
            given a v03 (internal) message, produce an encoded version.
        """
-            GeoJSONBody={ 'type': 'Feature', 'geometry': None, 'properties':{} }
+            GeoJSONBody={ 'type': 'Feature', 'geometry': None, 'properties':{}, 'version':'v04' }
+
             for literal in [ 'geometry', 'properties' ]:
                 if literal in body:
                     GeoJSONBody[literal] = body[literal]
+
+            headers = { 'topic' : 'origin/a/wis2/can/eccc-msc/data/core/weather/surface-based-observations/synop'.split('/') }
+            """
+                  topicPrefix and body['subtopic'] could be used to build a topic...
+
+            """
             for h in body:
-                if h not in [ 'geometry', 'properties' ]:
+                if h not in [ 'geometry', 'properties', 'size', 'baseUrl', 'relPath', 'retrievePath', 'subtopic' ]:
                     GeoJSONBody['properties'][h] = body[h]
-            GeoJSONBody['properties']['version'] = 'v04'
+
+            if 'geometry' in body:
+                GeoJSONBody['geometry'] = body['geometry']
+
+            GeoJSONBody['data_id'] =  str(uuid.uuid4())
+
+            if 'retrievePath' in body :
+                url = '/'.join( [ body['baseUrl'], body['retrievePath'] ] )
+            else:
+                url = '/'.join( [ body['baseUrl'], body['relPath'] ] )
+
+            GeoJSONBody['links'] = [{
+                'rel': 'canonical',
+                #'type': 'unknown',, mime content-type of data, not available in message.
+                'href': url,
+                'length': body['size']
+            }]
+
             raw_body = json.dumps(GeoJSONBody)
-            return raw_body, None, V03.content_type()
+            return raw_body, headers, Wis.content_type()

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -104,11 +104,13 @@ class Wis(PostFormat):
                 urlstr = GeoJSONBody['links'][0]['href']
                 url = urllib.parse.urlparse( urlstr )
                 msg['size']  = GeoJSONBody['links'][0]['length']
+                if 'type' in GeoJSONBody['links'][0]:
+                    msg['contentType']  = GeoJSONBody['links'][0]['type']
                 msg['links'] = GeoJSONBody['links']
                 msg['baseUrl'] = url.scheme + '://' + url.netloc
                 msg['retrievePath' ] = urlstr[len(msg['baseUrl']):] 
             else:
-                logger.warning( 'message missing version (WMO mandatory field)' )
+                logger.warning( 'message missing links (WMO mandatory field)' )
 
             return msg
 
@@ -152,12 +154,15 @@ class Wis(PostFormat):
                 url = body['baseUrl'] + body['relPath']
 
             if not 'links' in GeoJSONBody:
+
                 GeoJSONBody['links'] = [{
                     'rel': 'canonical',
                     #'type': 'unknown',, mime content-type of data, not available in message.
                     'href': url,
                     'length': body['size']
                 }]
+                if 'contentType' in body:
+                    GeoJSONBody['links'][0]['type'] = body['contentType']
 
             raw_body = json.dumps(GeoJSONBody)
             return raw_body, headers, Wis.content_type()

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -57,6 +57,9 @@ class Wis(PostFormat):
           return the message as a normalized v03 message.
 
           Since I can't figure out a baseUrl, I can't import any messages. so import is broken for now.
+          for now:  just parse the first url in 'links', assign the host part to baseUrl, and make
+          the path a retrieval one.
+
        """
             msg = sarracenia.Message()
             msg["_format"] = __name__.split('.')[-1].lower()
@@ -83,11 +86,12 @@ class Wis(PostFormat):
             if 'version' in msg and msg['geometry'] == 'v04':
                 del msg['version']
 
-            url = urllib.urlparse( msg['links'][0]['href'] )
+            urlstr = msg['links'][0]['href']
+            url = urllib.urlparse( urlstr )
 
             msg['baseUrl'] = url.scheme + '://' + url.netloc
-            msg['retrievePath' ] = url.path
-            msg['size'] = msg['links'][0]['length']
+            
+            msg['retrievePath' ] = urlstr[len(msg['baseUrl']):] 
 
             return msg
 

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -42,7 +42,7 @@ class Wis(PostFormat):
         return 'application/geo+json'
 
     @staticmethod
-    def mine(payload, headers, content_type) -> bool:
+    def mine(payload, headers, content_type, options) -> bool:
         """
           return true if the message is in this encoding.
        """
@@ -51,7 +51,7 @@ class Wis(PostFormat):
         return False
 
     @staticmethod
-    def importMine(body, headers) -> sarracenia.Message:
+    def importMine(body, headers, options) -> sarracenia.Message:
             """
           given a message in a wire format, with the given properties (or headers) in a dictionary,
           return the message as a normalized v03 message.
@@ -96,7 +96,7 @@ class Wis(PostFormat):
             return msg
 
     @staticmethod
-    def exportMine(body,topicPrefix) -> (str, dict, str):
+    def exportMine(body, topicPrefix, options) -> (str, dict, str):
             """
            given a v03 (internal) message, produce an encoded version.
        """

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'Topic :: System :: Logging',
     ],
     install_requires=[
-        "appdirs", "humanfriendly", "humanize", "jsonpickle", "paramiko",
+        "appdirs", "humanfriendly", "humanize", "jsonpickle", "magic", "paramiko",
         "psutil>=5.3.0", "watchdog"
     ],
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'Topic :: System :: Logging',
     ],
     install_requires=[
-        "appdirs", "humanfriendly", "humanize", "jsonpickle", "magic", "paramiko",
+        "appdirs", "humanfriendly", "humanize", "jsonpickle", "python-magic", "paramiko",
         "psutil>=5.3.0", "watchdog"
     ],
     extras_require = {

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -22,7 +22,7 @@ pip3 install pyftpdlib paramiko net-tools
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
 # See issue #407, #445.
-for PKG in amqp appdirs dateparser magic watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr ; do
+for PKG in amqp appdirs dateparser python-magic watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr ; do
     PKG_INSTALLED="`pip3 list | grep ${PKG}`"
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -8,7 +8,7 @@
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt-get update
-sudo apt -y install python3-setuptools
+sudo apt -y install python3-setuptools python3-magic
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -7,7 +7,8 @@
 # Install and configure dependencies
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
-sudo apt-get update
+sudo apt update
+sudo apt upgrade
 sudo apt -y install python3-setuptools 
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -13,11 +13,8 @@ sudo apt -y install python3-setuptools
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
-# in case it was installed as a dependency.
-sudo apt -y remove metpx-sr3
 
 pip3 install -U pip
-pip3 install -e .
 pip3 install pyftpdlib paramiko net-tools
 
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
@@ -31,6 +28,11 @@ for PKG in amqp appdirs dateparser python-magic watchdog netifaces humanize json
         pip3 install ${PKG}
     fi
 done
+
+# in case it was installed as a dependency.
+sudo apt -y remove metpx-sr3
+
+pip3 install -e .
 
 # Setup basic configs
 mkdir -p ~/.config/sarra ~/.config/sr3

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -8,7 +8,7 @@
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt-get update
-sudo apt -y install python3-setuptools python3-magic
+sudo apt -y install python3-setuptools 
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
@@ -22,7 +22,7 @@ pip3 install pyftpdlib paramiko net-tools
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
 # See issue #407, #445.
-for PKG in amqp appdirs dateparser watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr ; do
+for PKG in amqp appdirs dateparser magic watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr ; do
     PKG_INSTALLED="`pip3 list | grep ${PKG}`"
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"

--- a/travis/flow_autoconfig_add_mosquitto.sh
+++ b/travis/flow_autoconfig_add_mosquitto.sh
@@ -1,4 +1,4 @@
-# Flow Test Autoconfig
+
 #
 # Script not meant to be run on personal machines (may break some configs)
 # Intended use case is a fresh sys (tested on ubuntu18.04desktop)
@@ -15,8 +15,8 @@ mkdir -p ~/.config/sr3
 
 sed -i 's/MQP=amqp/MQP=mqtt/' ~/.config/sr3/default.conf
 
-ADMIN_PASSWORD="`grep 'amqp://bunnymaster' ~/.config/sr3/credentials.conf | sed 's+amqp:\/\/bunnymaster:++;s+@localhost/++'`"
-OTHER_PASSWORD="`grep 'amqp://tsource' ~/.config/sr3/credentials.conf | sed 's+amqp:\/\/tsource:++;s+@localhost/++'`"
+ADMIN_PASSWORD="`grep -e 'amqp://bunnymaster:.*@localhost' ~/.config/sr3/credentials.conf | head -1 | sed 's+amqp:\/\/bunnymaster:++;s+@localhost.*$++'`"
+OTHER_PASSWORD="`grep -e 'amqp://tsource:.*@localhost' ~/.config/sr3/credentials.conf | head -1 | sed 's+amqp:\/\/tsource:++;s+@localhost.*$++'`"
 
 cat >> ~/.config/sr3/credentials.conf << EOF
 mqtt://bunnymaster:${ADMIN_PASSWORD}@localhost/
@@ -70,6 +70,3 @@ if [[ $(($check_wsl == "init" )) ]]; then
 else
 	sudo systemctl restart mosquitto
 fi
-
-echo "dir: +${PWD}+"
-git clone https://github.com/MetPX/sr_insects


### PR DESCRIPTION
OK, so finally all the pieces are in place to allow support of non-sarracenia messages (talk to external systems).  This is about #615, and #617 mostly.

The work is mostly around this file:

postformat/wis.py   *postformat* has two other classes in it, v02.py, and v03.py for the two native sarracenia formats.  

In order to demonstrate encapsulation of foreign notification formats, using the wis one as an example.
It is defined here:

* https://github.com/wmo-im/wis2-notification-message/
* and there is some code to generate them here: https://github.com/wmo-im/pywis-pubsub

So what had to change?   The generation of a topic in Sarracenia is structured to be nearly automatic.  In other systems,  the way the *topic* field is generated will depend on the network itself, as well as some settings that the user may provide.  So that meant that we now need to supply the options (settings) to the postformat encoding class (where it was formerly self-containted.)

Also had to delegate the topic generation to the postformat itself... because it v03.py messages will have a different topic header than wis.py ones, even though both can be sent over MQTT (the same messaging protocol.)

With this branch... someone can subscribe to a sarracenia datapump and post to a WMO pump and vice versa, exchanging messages in the format appropriate for the pump (v03 for Sarracenia, wis for the WMO pump.)



