### PR TITLE
Fix object has no attribute 'onfly_checksum'

### DIFF
--- a/sarra/plugins/part_check.py
+++ b/sarra/plugins/part_check.py
@@ -51,7 +51,7 @@ class PartCheck(object):
           lag= now-then
 
           if msg.onfly_checksum != msg.checksum :
-             msg = "checksum differ - %s - %s  msg %s" % (msg.new_file, parent.onfly_checksum,msg.checksum)
+             msg = "checksum differ - %s - %s  msg %s" % (msg.new_file, msg.onfly_checksum, msg.checksum)
              if lag > parent.part_check_lag_threshold :
                  logger.warning("part_check might just be referring to an older version of file, but " + msg)
                  return True


### PR DESCRIPTION
This tries to use `parent.onfly_checksum` when it should use `msg.onfly_checksum`.