### PR TITLE
Resolves issue #712

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -261,6 +261,9 @@ def durationToSeconds(str_value, default=None) -> float:
 
     if type(str_value) in [int, float]:
         return str_value
+    
+    if type(str_value) is not str:
+        return 0
 
     if str_value.lower() in [ 'none', 'off', 'false' ]:
         return 0


### PR DESCRIPTION
Added an if statement to check if `str_value` is not a string 

Previously, the code only checked for `None` as a string. Now it checks for None as a `NoneType` by making sure `str_value` is a `str` type. This could've been implemented by 
`if str_value == None:`
         `return 0`
However, checking that `str_value` is not a string covers more cases. 