### PR TITLE
"possibly undeclared" option message should only be printed once.

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1569,7 +1569,8 @@ class Config:
                 setattr(self, k, v)
             else:
                 #FIXME: with _options lists for all types and addition of declare, this is probably now dead code.
-                logger.debug('possibly undeclared option: %s' % line )
+                if k not in self.undeclared:
+                    logger.debug('possibly undeclared option: %s' % line )
                 v = ' '.join(line[1:])
                 if hasattr(self, k):
                     if type(getattr(self, k)) is float:


### PR DESCRIPTION
while working on OpenDCS integration, need to declare an entire database (hundreds of lines of configuration) and every occurrence of the plugin specific module, when in debug results in t "possibly undeclared option" which is odd, but really only need to produce that message once, not for every time the option shows up.

So only print the message the first time each option is encourntered, not every time. 
