### PR TITLE
V03 issue415

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -50,11 +50,13 @@ jobs:
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       # https://github.com/marketplace/actions/debugging-with-tmate
+      # 2023/07/22 PAS, removed because when manually invoking test it always enables in spite
+      # of the github box not being checked, so cannot invoke the tests manually.
       # 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event.inputs.debug_enabled }}
-        #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      #- name: Setup tmate session
+      #  uses: mxschmitt/action-tmate@v3
+      #  if: ${{ github.event.inputs.debug_enabled }}
+      #  #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Limit ${{ matrix.which_test }} test.
         run: |

--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -30,11 +30,6 @@ jobs:
           travis/flow_autoconfig.sh
           travis/ssh_localhost.sh
          
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event.inputs.debug_enabled }}
-        #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
       - name: Add and Remove configs, 
         run: |
           pwd

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -112,7 +112,7 @@ class Credential:
             if self.url.hostname:
                 s += '@' + self.url.hostname
             if self.url.port:
-                s += ':' + self.url.port
+                s += ':' + str(self.url.port)
             if self.url.path:
                 s += self.url.path
 

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -33,9 +33,9 @@ default_options = {
 }
 
 def ProtocolPresent(p) -> bool:
-    if ( p in ['amqp', 'amqps' ] ) and sarracenia.extras['amqp']['present']:
+    if ( p[0:4] in ['amqp'] ) and sarracenia.extras['amqp']['present']:
        return True
-    if ( p in ['mqtt', 'mqtts' ] ) and sarracenia.extras['mqtt']['present']:
+    if ( p[0:4] in ['mqtt'] ) and sarracenia.extras['mqtt']['present']:
        return True
     if p in sarracenia.extras:
         logger.critical( f"support for {p} missing, please install python packages: {' '.join(sarracenia.extras[p]['modules_needed'])}" )
@@ -218,9 +218,11 @@ class Moth():
            return None
 
         for sc in Moth.__subclasses__():
-            if (props['broker'].url.scheme == sc.__name__.lower()) or (
-                (props['broker'].url.scheme[0:-1] == sc.__name__.lower()) and
-                (props['broker'].url.scheme[-1] == 's')):
+            driver=sc.__name__.lower()
+            scheme=props['broker'].url.scheme
+            if (scheme == driver) or \
+               ( (scheme[0:-1] == driver) and (scheme[-1] in [ 's', 'w' ])) or \
+               ( (scheme[0:-2] == driver) and (scheme[-2] == 'ws')):
                 return sc(props, True)
         logger.error('broker intialization failure')
         return None
@@ -240,9 +242,11 @@ class Moth():
            return None
 
         for sc in Moth.__subclasses__():
-            if (props['broker'].url.scheme == sc.__name__.lower()) or (
-                (props['broker'].url.scheme[0:-1] == sc.__name__.lower()) and
-                (props['broker'].url.scheme[-1] == 's')):
+            driver=sc.__name__.lower()
+            scheme=props['broker'].url.scheme
+            if (scheme == driver) or \
+               ( (scheme[0:-1] == driver) and (scheme[-1] in [ 's', 'w' ])) or \
+               ( (scheme[0:-2] == driver) and (scheme[-2] == 'ws')):
                 return sc(props, False)
 
         # ProtocolPresent test should ensure that we never get here...

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -298,8 +298,15 @@ class MQTT(Moth):
 
         self.connect_in_progress = True
 
-        client = paho.mqtt.client.Client( userdata=self, \
-            client_id=cid, protocol=paho.mqtt.client.MQTTv5 )
+        if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
+           (self.o['broker'].url.scheme[-1] == 'w' ) : 
+            logger.critical("yo! FIXME. I have websockets")
+            client = paho.mqtt.client.Client( userdata=self, transport="websockets", \
+                client_id=cid, protocol=paho.mqtt.client.MQTTv5 )
+        else:
+            logger.critical("yo! FIXME. darnwebnot")
+            client = paho.mqtt.client.Client( userdata=self, \
+                client_id=cid, protocol=paho.mqtt.client.MQTTv5 )
 
         client.connected = False
         client.on_connect = MQTT.__sub_on_connect
@@ -432,8 +439,18 @@ class MQTT(Moth):
                 if self.o['message_ttl'] > 0:
                     props.MessageExpiryInterval = int(self.o['message_ttl'])
 
-                self.client = paho.mqtt.client.Client(
-                    protocol=self.proto_version, userdata=self)
+                if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
+                   (self.o['broker'].url.scheme[-1] == 'w' ) : 
+                    logger.critical("yo! FIXME. I have websockets")
+                    self.client = paho.mqtt.client.Client( userdata=self, transport="websockets", \
+                        protocol=self.proto_version )
+                else:
+                    logger.critical("yo! FIXME. darnwebnot")
+                    self.client = paho.mqtt.client.Client( userdata=self, \
+                        protocol=self.proto_version )
+
+                #self.client = paho.mqtt.client.Client(
+                #    protocol=self.proto_version, userdata=self)
 
                 self.client.enable_logger(logger)
                 self.client.on_connect = MQTT.__pub_on_connect

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -75,6 +75,38 @@ class PostFormat:
 
         return None, None, None
 
+    def topicDerive(msg, options ) -> list:
+        """
+           Sarracenia standard topic derivation.
+
+           https://metpx.github.io/sarracenia/Explanation/Concepts.html#amqp-v09-rabbitmq-settings
+        """
+
+        if options['broker'].url.scheme.startswith('mqtt'):
+            if ( 'exchange' in options ) and ( 'topicPrefix' in options ):
+                if 'exchangeSplit' in options and options['exchangeSplit'] > 1:
+                    idx = sum( bytearray(msg['identity']['value'], 'ascii')) % len(options['exchange'])
+                    exchange = options['exchange'][idx]
+                else:
+                    exchange = options['exchange'][0]
+            topic_prefix = [exchange] + options['topicPrefix']
+            topic_separator='/'
+        else:
+            topic_prefix = options['topicPrefix']
+            topic_separator='.'
+
+        if 'topic' in options:
+            topic = options['topic'].split(topic_separator)
+        else:
+            if 'relPath' in msg: 
+                topic = topic_prefix + msg['relPath'].split('/')[0:-1]
+            else:
+                topic = topic_prefix
+
+        return topic
+
+   
+
 # test for v04 first, because v03 may claim all other JSON.
 import sarracenia.postformat.wis
 import sarracenia.postformat.v03

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -139,7 +139,7 @@ class V02(PostFormat):
            given a v03 (internal) message, produce an encoded version.
        """
         v2m = v2wrapper.Message(body)
-
+                                
         # v2wrapp
         for h in [
                     'pubTime', 'baseUrl', 'fileOp', 'relPath', 'size', 
@@ -148,8 +148,6 @@ class V02(PostFormat):
             if h in v2m.headers:
                     del v2m.headers[h]
 
-        if ( 'broker' in options ) and ( 'exchange' in options ) and \
-            options['broker'].url.scheme.startswith('mqtt'):
-            v2m.headers['topic'] = options['exchange'] +  v2m.headers['topic']
+        v2m.headers['topic'] = PostFormat.topicDerive( body, options )
 
         return v2m.notice, v2m.headers, V02.content_type()

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -86,23 +86,6 @@ class V03(PostFormat):
        """
         raw_body = json.dumps(body)
 
-        topic_separator='.'
-
-        if options['broker'].url.scheme.startswith('mqtt'):
-            if ( 'exchange' in options ) and ( 'topicPrefix' in options ):
-                topic_prefix = options['exchange'] + options['topicPrefix'] 
-            topic_separator='/'
-        else:
-            topic_prefix = options['topicPrefix']
-
-        if 'topic' in options:
-            topic = options['topic'].split(topic_separator)
-        else:
-            if 'relPath' in body:
-                topic = topic_prefix + body['relPath'].split('/')[0:-1]  
-            else:
-                topic = topic_prefix
-
-        headers = { 'topic': topic }
+        headers = { 'topic': PostFormat.topicDerive(body,options) }
 
         return raw_body, headers, V03.content_type()


### PR DESCRIPTION
As per #415, adding support for mqtt over websockets (changes connect verb in use of paho-mqtt library)  This is done by adding w or ws to the broker URL  (mqtt:// is pure mqtt protocol, mqttws:// is mqtt over websockets (using SSL))

Also noticed why the flow tests were failing for MQTT, there was a mistake in handling of exchangeSplit, fixed in this branch.  MQTT might completely work after this is merged.

