### PR TITLE
V03 issue720 -- fixing crash when a flag option is entered twice creating a list.

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -50,11 +50,13 @@ jobs:
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       # https://github.com/marketplace/actions/debugging-with-tmate
+      # 2023/07/22 PAS, removed because when manually invoking test it always enables in spite
+      # of the github box not being checked, so cannot invoke the tests manually.
       # 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event.inputs.debug_enabled }}
-        #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      #- name: Setup tmate session
+      #  uses: mxschmitt/action-tmate@v3
+      #  if: ${{ github.event.inputs.debug_enabled }}
+      #  #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Limit ${{ matrix.which_test }} test.
         run: |

--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -30,11 +30,6 @@ jobs:
           travis/flow_autoconfig.sh
           travis/ssh_localhost.sh
          
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event.inputs.debug_enabled }}
-        #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
-
       - name: Add and Remove configs, 
         run: |
           pwd

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -991,6 +991,11 @@ class Config:
         # Retreive the 'new' option & enforce the correct type.
         v = getattr(self, option)
 
+        if kind not in [ 'list', 'set' ] and type(v) == list:
+            v=v[-1]
+            logger.warning( f"multiple declarations of {option}={getattr(self,option)} choosing last one: {v}" )
+
+
         if kind == 'count':
             count_options.append(option)
             if type(v) is not int:

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1705,7 +1705,9 @@ class Config:
             if hasattr(self, 'post_exchangeSuffix'):
                 self.post_exchange += '_%s' % self.post_exchangeSuffix
 
-            if hasattr(self, 'post_exchangeSplit') and self.post_exchangeSplit > 1:
+            if hasattr(self,'post_exchange') and (type(self.post_exchange) is list ):
+                pass
+            elif hasattr(self, 'post_exchangeSplit') and self.post_exchangeSplit > 1:
                 l = []
                 for i in range(0, int(self.post_exchangeSplit)):
                     y = self.post_exchange + '%02d' % i

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -112,7 +112,7 @@ class Credential:
             if self.url.hostname:
                 s += '@' + self.url.hostname
             if self.url.port:
-                s += ':' + self.url.port
+                s += ':' + str(self.url.port)
             if self.url.path:
                 s += self.url.path
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -198,6 +198,8 @@ class Flow:
 
         self.plugins['load'].extend(self.o.plugins_late)
 
+        self.plugins['load'].extend(self.o.destfn_scripts)
+
         # metrics - dictionary with names of plugins as the keys
         self.metricsFlowReset()
 
@@ -206,7 +208,10 @@ class Flow:
               'transferConnected': False, 'transferConnectStart': 0, 'transferConnectTime':0, 
               'transferRxBytes': 0, 'transferTxBytes': 0, 'transferRxFiles': 0, 'transferTxFiles': 0 } }
 
-    def loadCallbacks(self, plugins_to_load):
+    def loadCallbacks(self, plugins_to_load=None):
+
+        if not plugins_to_load:
+            plugins_to_load=self.plugins['load']
 
         for m in self.o.imports:
             try:
@@ -369,7 +374,7 @@ class Flow:
           check if stop_requested once in a while, but never return otherwise.
         """
 
-        if not self.loadCallbacks(self.plugins['load']+self.o.destfn_scripts):
+        if not self.loadCallbacks(self.plugins['load']):
            return
 
         logger.debug( f"working directory: {os.getpid()}" )

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -33,9 +33,9 @@ default_options = {
 }
 
 def ProtocolPresent(p) -> bool:
-    if ( p in ['amqp', 'amqps' ] ) and sarracenia.extras['amqp']['present']:
+    if ( p[0:4] in ['amqp'] ) and sarracenia.extras['amqp']['present']:
        return True
-    if ( p in ['mqtt', 'mqtts' ] ) and sarracenia.extras['mqtt']['present']:
+    if ( p[0:4] in ['mqtt'] ) and sarracenia.extras['mqtt']['present']:
        return True
     if p in sarracenia.extras:
         logger.critical( f"support for {p} missing, please install python packages: {' '.join(sarracenia.extras[p]['modules_needed'])}" )
@@ -218,9 +218,11 @@ class Moth():
            return None
 
         for sc in Moth.__subclasses__():
-            if (props['broker'].url.scheme == sc.__name__.lower()) or (
-                (props['broker'].url.scheme[0:-1] == sc.__name__.lower()) and
-                (props['broker'].url.scheme[-1] == 's')):
+            driver=sc.__name__.lower()
+            scheme=props['broker'].url.scheme
+            if (scheme == driver) or \
+               ( (scheme[0:-1] == driver) and (scheme[-1] in [ 's', 'w' ])) or \
+               ( (scheme[0:-2] == driver) and (scheme[-2] == 'ws')):
                 return sc(props, True)
         logger.error('broker intialization failure')
         return None
@@ -240,9 +242,11 @@ class Moth():
            return None
 
         for sc in Moth.__subclasses__():
-            if (props['broker'].url.scheme == sc.__name__.lower()) or (
-                (props['broker'].url.scheme[0:-1] == sc.__name__.lower()) and
-                (props['broker'].url.scheme[-1] == 's')):
+            driver=sc.__name__.lower()
+            scheme=props['broker'].url.scheme
+            if (scheme == driver) or \
+               ( (scheme[0:-1] == driver) and (scheme[-1] in [ 's', 'w' ])) or \
+               ( (scheme[0:-2] == driver) and (scheme[-2] == 'ws')):
                 return sc(props, False)
 
         # ProtocolPresent test should ensure that we never get here...

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -714,7 +714,6 @@ class MQTT(Moth):
         try:
             raw_body, headers, content_type = PostFormat.exportAny( body, postFormat, self.o['topicPrefix'], self.o )
             # FIXME: might
-            logger.critical( f" headers:{headers} format: {postFormat}, pfx: {self.o['topicPrefix']} " )
             topic = '/'.join(headers['topic']) 
 
             # url-quote wildcard characters in topics.

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -298,8 +298,15 @@ class MQTT(Moth):
 
         self.connect_in_progress = True
 
-        client = paho.mqtt.client.Client( userdata=self, \
-            client_id=cid, protocol=paho.mqtt.client.MQTTv5 )
+        if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
+           (self.o['broker'].url.scheme[-1] == 'w' ) : 
+            logger.critical("yo! FIXME. I have websockets")
+            client = paho.mqtt.client.Client( userdata=self, transport="websockets", \
+                client_id=cid, protocol=paho.mqtt.client.MQTTv5 )
+        else:
+            logger.critical("yo! FIXME. darnwebnot")
+            client = paho.mqtt.client.Client( userdata=self, \
+                client_id=cid, protocol=paho.mqtt.client.MQTTv5 )
 
         client.connected = False
         client.on_connect = MQTT.__sub_on_connect
@@ -432,8 +439,18 @@ class MQTT(Moth):
                 if self.o['message_ttl'] > 0:
                     props.MessageExpiryInterval = int(self.o['message_ttl'])
 
-                self.client = paho.mqtt.client.Client(
-                    protocol=self.proto_version, userdata=self)
+                if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
+                   (self.o['broker'].url.scheme[-1] == 'w' ) : 
+                    logger.critical("yo! FIXME. I have websockets")
+                    self.client = paho.mqtt.client.Client( userdata=self, transport="websockets", \
+                        protocol=self.proto_version )
+                else:
+                    logger.critical("yo! FIXME. darnwebnot")
+                    self.client = paho.mqtt.client.Client( userdata=self, \
+                        protocol=self.proto_version )
+
+                #self.client = paho.mqtt.client.Client(
+                #    protocol=self.proto_version, userdata=self)
 
                 self.client.enable_logger(logger)
                 self.client.on_connect = MQTT.__pub_on_connect

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -323,7 +323,7 @@ class MQTT(Moth):
         logger.info("ok, asked to stop")
         self.please_stop=True
 
-    def __getSetup(self):
+    def getSetup(self):
         """
            Establish a connection to consume messages with.  
         """
@@ -419,7 +419,7 @@ class MQTT(Moth):
 
 
 
-    def __putSetup(self):
+    def putSetup(self):
         """
            establish a connection to allow publishing. 
         """
@@ -613,6 +613,8 @@ class MQTT(Moth):
 
         #logger.debug( f"rx_msg queue before: indices: {self.rx_msg_iToApp} {self.rx_msg_iFromBroker} " )
         #logger.debug( f"rx_msg queue before: {len(self.rx_msg[self.rx_msg_iToApp])} indices: {self.rx_msg_iToApp} {self.rx_msg_iFromBroker} " )
+        if not self.connected:
+            self.getSetup()
 
         if len(self.rx_msg[self.rx_msg_iToApp]) > self.o['batch']:
             mqttml = self.rx_msg[self.rx_msg_iToApp][0:self.o['batch']]
@@ -630,6 +632,9 @@ class MQTT(Moth):
         return mqttml
 
     def getNewMessage(self) -> sarracenia.Message:
+
+        if not self.connected:
+            self.getSetup()
 
         if len(self.rx_msg) > 0:
             m = self.rx_msg[self.rx_msg_iToApp][0]
@@ -662,7 +667,7 @@ class MQTT(Moth):
             return False
 
         if not self.connected:
-            self.__putSetup()
+            self.putSetup()
 
         # The caller probably doesn't expect the message to get modified by this method, so use a copy of the message
         body = copy.deepcopy(body)

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -175,10 +175,8 @@ class MQTT(Moth):
             self.rx_msg[3]=[]
             self.rx_msg[4]=[]
             self.rx_msg_mutex.release()
-            self.__getSetup()
-        else:
-            self.__putSetup()
 
+      
         logger.warning("note: mqtt support is newish, not very well tested")
 
     def __sub_on_disconnect(client, userdata, rc, properties=None):

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -75,6 +75,38 @@ class PostFormat:
 
         return None, None, None
 
+    def topicDerive(msg, options ) -> list:
+        """
+           Sarracenia standard topic derivation.
+
+           https://metpx.github.io/sarracenia/Explanation/Concepts.html#amqp-v09-rabbitmq-settings
+        """
+
+        if options['broker'].url.scheme.startswith('mqtt'):
+            if ( 'exchange' in options ) and ( 'topicPrefix' in options ):
+                if 'exchangeSplit' in options and options['exchangeSplit'] > 1:
+                    idx = sum( bytearray(msg['identity']['value'], 'ascii')) % len(options['exchange'])
+                    exchange = options['exchange'][idx]
+                else:
+                    exchange = options['exchange'][0]
+            topic_prefix = [exchange] + options['topicPrefix']
+            topic_separator='/'
+        else:
+            topic_prefix = options['topicPrefix']
+            topic_separator='.'
+
+        if 'topic' in options:
+            topic = options['topic'].split(topic_separator)
+        else:
+            if 'relPath' in msg: 
+                topic = topic_prefix + msg['relPath'].split('/')[0:-1]
+            else:
+                topic = topic_prefix
+
+        return topic
+
+   
+
 # test for v04 first, because v03 may claim all other JSON.
 import sarracenia.postformat.wis
 import sarracenia.postformat.v03

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -139,7 +139,7 @@ class V02(PostFormat):
            given a v03 (internal) message, produce an encoded version.
        """
         v2m = v2wrapper.Message(body)
-
+                                
         # v2wrapp
         for h in [
                     'pubTime', 'baseUrl', 'fileOp', 'relPath', 'size', 
@@ -148,8 +148,6 @@ class V02(PostFormat):
             if h in v2m.headers:
                     del v2m.headers[h]
 
-        if ( 'broker' in options ) and ( 'exchange' in options ) and \
-            options['broker'].url.scheme.startswith('mqtt'):
-            v2m.headers['topic'] = options['exchange'] +  v2m.headers['topic']
+        v2m.headers['topic'] = PostFormat.topicDerive( body, options )
 
         return v2m.notice, v2m.headers, V02.content_type()

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -86,23 +86,6 @@ class V03(PostFormat):
        """
         raw_body = json.dumps(body)
 
-        topic_separator='.'
-
-        if options['broker'].url.scheme.startswith('mqtt'):
-            if ( 'exchange' in options ) and ( 'topicPrefix' in options ):
-                topic_prefix = options['exchange'] + options['topicPrefix'] 
-            topic_separator='/'
-        else:
-            topic_prefix = options['topicPrefix']
-
-        if 'topic' in options:
-            topic = options['topic'].split(topic_separator)
-        else:
-            if 'relPath' in body:
-                topic = topic_prefix + body['relPath'].split('/')[0:-1]  
-            else:
-                topic = topic_prefix
-
-        headers = { 'topic': topic }
+        headers = { 'topic': PostFormat.topicDerive(body,options) }
 
         return raw_body, headers, V03.content_type()

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1653,11 +1653,16 @@ class sr_GlobalState:
             o = self.configs[c][cfg]['options']
             o.no=0
             o.finalize()
-            flow = sarracenia.flow.Flow.factory(o)
-            flow.loadCallbacks()
-            print('\nConfig of %s/%s: ' % (c, cfg))
-            flow.o.dump()
-            del flow
+            if c not in [ 'cpost', 'cpump' ]:
+                flow = sarracenia.flow.Flow.factory(o)
+                flow.loadCallbacks()
+                print('\nConfig of %s/%s: (with callbacks)' % (c, cfg))
+                flow.o.dump()
+                del flow
+                flow=None
+            else:
+                print('\nConfig of %s/%s: ' % (c, cfg))
+                o.dump()
 
     def remove(self):
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1276,6 +1276,7 @@ class sr_GlobalState:
                         'exchange': o.resolved_exchanges,
                         'message_strategy': { 'stubborn':True }
                     })
+                xdc.putSetup()
                 xdc.close()
 
         # then declare and bind queues....
@@ -1296,6 +1297,7 @@ class sr_GlobalState:
                 od['queueName'] = o.resolved_qname
                 od['dry_run'] = self.options.dry_run
                 qdc = sarracenia.moth.Moth.subFactory(od)
+                qdc.getSetup()
                 qdc.close()
 
     def disable(self):
@@ -1649,8 +1651,13 @@ class sr_GlobalState:
                 continue
 
             o = self.configs[c][cfg]['options']
+            o.no=0
+            o.finalize()
+            flow = sarracenia.flow.Flow.factory(o)
+            flow.loadCallbacks()
             print('\nConfig of %s/%s: ' % (c, cfg))
-            o.dump()
+            flow.o.dump()
+            del flow
 
     def remove(self):
 


### PR DESCRIPTION
So... I noticed... * plugins are not loaded by the *sr3 show* ... so the plugin defined options are listed as "possibly undefined." ....  to fix that, I needed to instantiate the flow class for the *show* command, and when I did that, it started initiating broker connections as part of the moth/* __init__ routines.  

So I needed to remove the broker connection from there, so that it just instantiated the object.  Once I did that, It's fine for get or put message stuff, because those check if the connection is still there, but for declare, need a new entry point...

so __getSetup() and __putSetup() lost their leading underscores to become public, and now in the *declare* action, we call .getSetup() ... or putSetup() whatever makes more sense.

This work needed the fixups to mqtt present in v03_issue415 ... so it's is rebased from there.
likely need to merge that before this.

This instantiation of flow object, and running of the plugins will also be needed to fix #643 
which will be followup work.
