### PR TITLE
Sarracenia __init__ unit test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -55,12 +55,15 @@ If you want to run this in VSCode, and have it do all the things nicely, you'll 
 - [GitLens — Git supercharged](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)  
   Not strictly required, but *very* strongly recommended as it makes VS Code's git features fully functional
 
-Beyond that, changing a few options in your settings file will make it all work; thusly:
+Beyond that, changing a few things in your VS Code configs will make it all work.
+
+In `settings.json`, to get all the reports and coverage when running tests, and allow you to run individual tests even if they have dependencies:
 ```json
 {
     "python.testing.pytestArgs": [
         "tests", "-v", 
         "--cov-config=tests/.coveragerc", "--cov=sarracenia", "--cov-report=xml", "--cov-report=html",
+        "--html=tests/report.html", "--self-contained-html",
         "--failed-dependency-action=run", "--missing-dependency-action=run"
     ],
     "python.testing.unittestEnabled": false,
@@ -68,6 +71,28 @@ Beyond that, changing a few options in your settings file will make it all work;
     "coverage-gutters.coverageBaseDir": "tests/coverage",
 }
 ```
+
+
+In `launch.json` (per [documentation](https://code.visualstudio.com/docs/python/testing#_debug-tests)), to enable full debugging support in your tests:
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug Tests",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": false, 
+            "env": {"PYTEST_ADDOPTS": "--no-cov"}
+          }
+    ]
+}
+```
+
+**NOTE:** Don't just squash whatever you have in `settings.json`, or `launch.json`, but use some common sense to merge what's above into your existing files.
 
 ## Docker
 You can also run the exact same tests from within a Docker container if you want to avoid having to (re)-provision clean installs.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,7 @@ pytest-cov>=4.0
 pytest-bug>=1.2
 pytest-depends>=1.0
 pytest-html>=3.2
+pytest-mock>=3.11
 
 python-redis-lock>=4
 fakeredis>=2.11

--- a/tests/sarracenia/__init___test.py
+++ b/tests/sarracenia/__init___test.py
@@ -1,0 +1,276 @@
+import pytest
+
+import os
+from base64 import b64decode
+import urllib.request
+
+import sarracenia
+import sarracenia.config
+
+#useful for debugging tests
+import pprint
+pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+
+def test_baseUrlParse():
+    parsed = sarracenia.baseUrlParse('http://hostname.com/a/deep/path/file.txt?query=val')
+    assert parsed.scheme == "http"
+    assert parsed.query == "query=val"
+
+    parsed = sarracenia.baseUrlParse('file:////opt/foobar/file.txt')
+    assert parsed.scheme == "file"
+    assert parsed.path == "/opt/foobar/file.txt"
+
+def test_timev2tov3str():
+    assert sarracenia.timev2tov3str('20230710T120000.123') == '20230710T120000.123'
+    assert sarracenia.timev2tov3str('20230710120000.123') == '20230710T120000.123'
+
+def test_durationToSeconds():
+    assert sarracenia.durationToSeconds('none') == sarracenia.durationToSeconds('off') == sarracenia.durationToSeconds('false') == 0.0
+    assert sarracenia.durationToSeconds('on', default=10) == sarracenia.durationToSeconds('true', default=10) == 10.0
+
+    assert sarracenia.durationToSeconds('1s') == sarracenia.durationToSeconds('1S') == 1.0
+    assert sarracenia.durationToSeconds('2m') == sarracenia.durationToSeconds('2M') == 120.0
+    assert sarracenia.durationToSeconds('3h') == sarracenia.durationToSeconds('3H') == 10800.0
+    assert sarracenia.durationToSeconds('4d') == sarracenia.durationToSeconds('4D') == 345600.0
+    assert sarracenia.durationToSeconds('1w') == sarracenia.durationToSeconds('1W') == 604800.0
+    assert sarracenia.durationToSeconds('0.5h') == sarracenia.durationToSeconds('0.5H') == 1800.0
+
+    assert sarracenia.durationToSeconds('invalid') == 0.0
+    assert sarracenia.durationToSeconds(b'5') == 0.0
+    assert sarracenia.durationToSeconds([5]) == 5.0
+
+    assert sarracenia.durationToSeconds(2.5) == 2.5
+    assert sarracenia.durationToSeconds('1s', default=None) == 1.0
+    assert sarracenia.durationToSeconds('1y') == 1.0
+    assert sarracenia.durationToSeconds('-1s') == -1.0
+    assert sarracenia.durationToSeconds('-1.5h') == -5400.0
+
+def test_timeValidate():
+    assert sarracenia.timeValidate('20230710120000') == True
+    assert sarracenia.timeValidate('2023-07-10T12:00:00') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.') == False
+    assert sarracenia.timeValidate('20230710120000.123') == True
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.123') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00Z') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.123Z') == False
+    assert sarracenia.timeValidate('20230710120000Z') == False
+
+    assert sarracenia.timeValidate('20230710T10:11:00000') == False
+    assert sarracenia.timeValidate('!0230710120000') == False
+
+    assert sarracenia.timeValidate('') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.1234') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.123Za') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.!@#$%') == False
+    assert sarracenia.timeValidate('2023-07-10T12:00:00.   ') == False
+
+
+def test_timeflt2str():
+    assert sarracenia.timeflt2str(1632180811.123456) == '20210920T233331.123456001'
+    assert sarracenia.timeflt2str(1632180811.00123) == '20210920T233331.00123000145'
+    assert sarracenia.timeflt2str(1632180811) == '20210920T233331'
+    assert sarracenia.timeflt2str(0) == '19700101T000000'
+    assert sarracenia.timeflt2str(1234567890.123) == '20090213T233130.122999907'
+    assert sarracenia.timeflt2str(1625452800.5) == '20210705T024000.5'
+
+def test_timestr2flt():
+    assert sarracenia.timestr2flt('20210920T233331.123456') == 1632180811.123456
+    assert sarracenia.timestr2flt('20210920T233331.00123') == 1632180811.00123
+    assert sarracenia.timestr2flt('20210920T233331') == 1632180811.0
+    assert sarracenia.timestr2flt('19700101T000000') == 0.0
+    assert sarracenia.timestr2flt('19700101000000') == 0.0
+    assert sarracenia.timestr2flt('20090213T233130.123') == 1234567890.123
+    assert sarracenia.timestr2flt('20210705T024000.5') == 1625452800.5
+
+@pytest.mark.depends(on=['test_timestr2flt'])
+def test_nowstr():
+    import time
+    assert time.time() - sarracenia.timestr2flt(sarracenia.nowstr()) < 0.001
+
+@pytest.mark.depends(on=['test_nowstr'])
+def test_nowflt():
+    import time
+    assert time.time() - sarracenia.nowflt() < 0.001
+
+
+#def test_naturalSize():
+#    sarracenia.naturalSize()
+
+
+@pytest.fixture
+def message():
+    msg = sarracenia.Message()
+    msg['_format'] = 'v03'
+    msg['baseUrl'] = 'https://example.com'
+    msg['relPath'] = 'path/to/file.txt'
+    return msg
+
+
+
+class Test_Message():
+
+    @pytest.mark.depends(on=['test_fromFileInfo'])
+    def test_fromFileData(self, tmp_path):
+        path = str(tmp_path) + os.sep + "file.txt"
+        pathlink = str(tmp_path) + os.sep + "link.txt"
+        open(path, 'a').close()
+        os.symlink(path, pathlink)
+        o = sarracenia.config.default_config()
+
+        # Test regular file
+        msg1 = sarracenia.Message.fromFileData(path, o, os.lstat(path))
+        assert msg1['_format'] == 'v03'
+        assert len(msg1['_deleteOnPost']) == 10
+        assert msg1['local_offset'] == 0
+
+        msg2 = sarracenia.Message.fromFileData(str(tmp_path), o, os.lstat(str(tmp_path)))
+        assert msg2['contentType'] == 'text/directory'
+
+        msg3 = sarracenia.Message.fromFileData(pathlink, o, os.lstat(pathlink))
+        assert msg3['contentType'] == 'text/link'
+
+        msg4 = sarracenia.Message.fromFileData('/dev/null', o, os.lstat('/dev/null'))
+        assert msg4['size'] == 0
+
+        msg5 = sarracenia.Message.fromFileData('/dev/null', o)
+        assert "size" not in msg5.keys()
+
+
+    def test_fromFileInfo(self, tmp_path):
+        path = str(tmp_path) + os.sep + "file.txt"
+        open(path, 'a').close()
+        o = sarracenia.config.default_config()
+
+        # Test regular file
+        lstat = os.lstat(path)
+        msg = sarracenia.Message.fromFileInfo(path, o, lstat)
+        assert msg['_format'] == 'v03'
+        assert len(msg['_deleteOnPost']) == 10
+        assert msg['local_offset'] == 0
+
+    @pytest.mark.depends(on=['test_fromFileData'])
+    def test_fromStream(self, tmp_path):
+        path = str(tmp_path) + os.sep + "file.txt"
+        open(path, 'a').close()
+        o = sarracenia.config.default_config()
+
+        data = b"Hello, World!"
+
+        # Test fromStream method
+        msg = sarracenia.Message.fromStream(path, o, data)
+        assert msg['_format'] == 'v03'
+        assert len(msg['_deleteOnPost']) == 10
+        assert msg['local_offset'] == 0
+
+    def test_updatePaths(self, tmp_path):
+        path = str(tmp_path) + os.sep + "file.txt"
+        open(path, 'a').close()
+        options = sarracenia.config.default_config()
+
+        msg = sarracenia.Message()
+        new_file = "newfile.txt"
+        new_dir = str(tmp_path) + os.sep + "new"
+
+        # Test updatePaths method
+        msg.updatePaths(options, new_dir, new_file)
+        assert msg['_deleteOnPost'] == set([
+            'new_dir', 'new_file', 'new_relPath', 'new_baseUrl', 'new_subtopic', 'post_format', '_format'
+        ])
+        assert msg['new_dir'] == new_dir
+        assert msg['new_file'] == new_file
+
+        # Add more assertions for other fields in the message
+
+    def test_setReport(self):
+        msg = sarracenia.Message()
+
+        # Test setReport method
+        msg.setReport(201, "Download successful")
+        assert 'report' in msg
+        assert msg['report']['code'] == 201
+        assert msg['report']['message'] == "Download successful"
+
+        msg.setReport(304)
+        assert msg['report']['message'] == sarracenia.known_report_codes[304]
+
+        msg.setReport(418)
+        assert msg['report']['message'] == "unknown disposition"
+
+        msg.setReport(418, "I'm a teapot")
+        assert msg['report']['message'] == "I'm a teapot"
+
+        # Add more assertions for other fields in the message
+
+
+    def test_getContent(self):
+        msg = sarracenia.Message()
+
+        msg['content'] = {
+            'encoding': '',
+            'value': "sarracenia/_version.py"
+        }
+        assert msg.getContent() == b"sarracenia/_version.py"
+
+        msg['content'] = {
+            'encoding': 'base64',
+            'value': 'c2FycmFjZW5pYS9fdmVyc2lvbi5weQ=='
+        }
+        # Test getContent method with inlined/embedded content
+        assert msg.getContent() == b"sarracenia/_version.py"
+
+        # Test getContent method with external file
+        url = "https://raw.githubusercontent.com/MetPX/sarracenia/main/VERSION.txt"  # Replace with a real URL
+        with urllib.request.urlopen(url) as response:
+            expected_content = response.read()
+
+        msg = sarracenia.Message()
+        msg['baseUrl'] = "https://raw.githubusercontent.com"
+        msg['retrievePath'] = "MetPX/sarracenia/main/VERSION.txt"
+        assert msg.getContent() == expected_content
+
+        msg = sarracenia.Message()
+        msg['baseUrl'] = "https://raw.githubusercontent.com"
+        msg['relPath'] = "MetPX/sarracenia/main/VERSION.txt"
+        assert msg.getContent() == expected_content
+        
+
+    def test_copyDict(self, message):
+        message.copyDict(None)
+        assert message['_format'] == 'v03'
+
+        message.copyDict({'foobar': 'baz'})
+        assert message['foobar'] == 'baz'
+
+    def test_dumps(self, message):
+        # Test dumps method
+        assert message.dumps() == "{  '_deleteOnPost':'{'_format'}', '_format':'v03', 'baseUrl':'https://example.com', 'relPath':'path/to/file.txt' }"
+
+        assert sarracenia.Message.dumps(None) == ''
+
+        message['_format'] = 'v04'
+        message['properties'] = {'prop1': 'propval1'}
+        assert message.dumps() == "{  '_deleteOnPost':'{'_format'}', '_format':'v04', 'baseUrl':'https://example.com', 'properties':'https://example.com 'prop1':'propval1'', 'relPath':'path/to/file.txt' }"
+
+        message['id'] = "id111"
+        del message['properties']
+        assert message.dumps() == "{  '_deleteOnPost':'{'_format'}', '_format':'v04', 'baseUrl':'https://example.com', 'relPath':'path/to/file.txt' }"
+
+        message['_format'] = 'Wis'
+        del message['id']
+        assert message.dumps() == "{ 'geometry': None, 'properties':{  '_deleteOnPost':'{'_format'}', '_format':'Wis', 'baseUrl':'https://example.com', 'relPath':'path/to/file.txt', } }"
+
+        message['id'] = "id111"
+        message['geometry'] = "geometry111"
+        message['testdict'] = {'key1': 'val1', 'key2': 'val2'}
+        assert message.dumps() == "{ { 'id': 'id111', 'type':'Feature', 'geometry':geometry111 'properties':{  '_deleteOnPost':'{'_format'}', '_format':'Wis', 'baseUrl':'https://example.com', 'geometry':'geometry111', 'id':'id111', 'relPath':'path/to/file.txt', 'testdict':'{  'key1':'val1', 'key2':'val2' }', } }"
+
+        message['longfield'] = "hacskmbeponlfkfcmxxasoxjgrodcmovxbkzgnfxqimkmxshaztwsptqbulazgszjyiqoqasyukgjejtbrbeufvfdrxlurglhlszdehigvctczjtleadkpeycunthwzwdbxybhbewgcclljkebtwueldbhximikfbtgapiklmqzceyqlilebchekrxmvhfflaclqjddfrhicdttaabkfkhbwylnzyneattcjsgpordersenmbzyjeaybtyyahsde"
+        assert message.dumps() == "{ { 'id': 'id111', 'type':'Feature', 'geometry':geometry111 'properties':{  '_deleteOnPost':'{'_format'}', '_format':'Wis', 'baseUrl':'https://example.com', 'geometry':'geometry111', 'id':'id111', 'longfield':'hacskmbeponlfkfcmxxasoxjgrodcmovxbkzgnfxqimkmxshaztwsptqbulazgszjyiqoqasyukgjejtbrbeufvfdrxlurglhlszdehigvctczjtleadkpeycunthwzwdbxybhbewgcclljkebtwueldbhximikfbtgapiklmqzceyqlilebchekrxmvhfflaclqjddfrhicdttaabkfkhbwylnzyneattcjsgpordersenmbzyjeaybtyy...', 'relPath':'path/to/file.txt', 'testdict':'{  'key1':'val1', 'key2':'val2' }', } }"
+
+        message['longfield'] = "{hacskmbeponlfkfcmxxasoxjgrodcmovxbkzgnfxqimkmxshaztwsptqbulazgszjyiqoqasyukgjejtbrbeufvfdrxlurglhlszdehigvctczjtleadkpeycunthwzwdbxybhbewgcclljkebtwueldbhximikfbtgapiklmqzceyqlilebchekrxmvhfflaclqjddfrhicdttaabkfkhbwylnzyneattcjsgpordersenmbzyjeaybtyyahsde}"
+        assert message.dumps() == "{ { 'id': 'id111', 'type':'Feature', 'geometry':geometry111 'properties':{  '_deleteOnPost':'{'_format'}', '_format':'Wis', 'baseUrl':'https://example.com', 'geometry':'geometry111', 'id':'id111', 'longfield':'{hacskmbeponlfkfcmxxasoxjgrodcmovxbkzgnfxqimkmxshaztwsptqbulazgszjyiqoqasyukgjejtbrbeufvfdrxlurglhlszdehigvctczjtleadkpeycunthwzwdbxybhbewgcclljkebtwueldbhximikfbtgapiklmqzceyqlilebchekrxmvhfflaclqjddfrhicdttaabkfkhbwylnzyneattcjsgpordersenmbzyjeaybty...}', 'relPath':'path/to/file.txt', 'testdict':'{  'key1':'val1', 'key2':'val2' }', } }"
+
+
+
+
+


### PR DESCRIPTION
This test is pretty exhaustive, and probably overkill for the needs, but it's got 90% code coverage so that's pretty good.

There's some odd things that weren't able to provide coverage for though:
- `Message.dumps()`:
  - Couldn't generate anything that wasn't printable, and thus fail the `try` on line 451
- `Message.fromFileInfo()`:
  - It generates a new `msg` at every run, so couldn't get it to do the rename bits on lines 532-536. How sure how those are supposed to work
  - Messages never have the `new_retrievePath` key, so the `if o.rename` block on lines 543-547 throws a key error if it runs (there's a test case for that though)
  - Couldn't get the `try` on line 555 to fail no matter how many directories were striped, so the `except` never runs
- `Message.updatePaths()`:
  - The `new_dir` and `new_file` parameters are optional, but their concatenation on line 686 throws an error if they're not set (there's a test case for this too)
  - With `new_dir` effectively being mandatory, the `if`s on lines 719 and 735 don't really work properly because they can never evaluate to `True`
- "Extras" checking
  - It doesn't work because no way was found to emulate the packages being in a different state than they actually are on the system

Interesting bits/lessons learned when writing these tests:
- Mocked some internal modules/methods/attributes in order to "trick" the code to trigger a certain behaviour
  - Lines 150 and 162 are replacing `random.choice`'s return with `None`
  - Line 409 is faking being Windows for the following lines
  - Line 471 is faking `urllib.request.urlopen`'s return as a static string, bypassing the need to *actually* do an HTTP request
- Some method calls throw errors, and Pytest catches them properly (lines 317, 351, 443)
  - Could be good for doing doing input validation and such
