### PR TITLE
Update unit testing patterns

### DIFF
--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -2,8 +2,13 @@ import pytest, jsonpickle
 import os
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.diskqueue import DiskQueue
 

--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -96,11 +96,6 @@ def test___len__(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'work_retry')
 
-    # fp = open(download_retry.queue_file, 'a')
-    # fp_new = open(download_retry.new_path, 'a')
-    # fp_hk = open(download_retry.housekeeping_path, 'a')
-    
-    # fp_new.write(download_retry.msgToJSON(message))
     download_retry.msg_count += 1
     assert len(download_retry) == 1
 
@@ -296,7 +291,7 @@ def test_on_housekeeping(tmp_path, caplog):
             log_found_NumMessages = True
         if "on_housekeeping elapse" in record.message:
             log_found_Elapsed = True
-            
+
     assert log_found_HasQueue == True
     assert log_found_NumMessages == True
     assert log_found_Elapsed == True

--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -13,20 +13,22 @@ def pretty(*things, **named_things):
 from sarracenia.diskqueue import DiskQueue
 
 class Options:
+    def __init__(self):
+        self.no = 1
+        self.retry_ttl = 0
+        self.logLevel = "DEBUG"
+        self.logFormat = ""
+        self.queueName = "TEST_QUEUE_NAME"
+        self.component = "sarra"
+        self.retry_driver = 'disk'
+        self.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
+        self.config = "foobar.conf"
+        self.pid_filename = "/tmp/sarracenia/diskqueue_test/pid_filename"
+        self.housekeeping = float(39)
+        self.batch = 0
     def add_option(self, option, type, default = None):
         if not hasattr(self, option):
             setattr(self, option, default)
-        
-    pass
-
-BaseOptions = Options()
-BaseOptions.retry_ttl = 0
-BaseOptions.logLevel = "DEBUG"
-BaseOptions.queueName = "TEST_QUEUE_NAME"
-BaseOptions.component = "sarra"
-BaseOptions.config = "foobar.conf"
-BaseOptions.pid_filename = "/tmp/sarracenia/diskqueue_test/pid_filename"
-BaseOptions.housekeeping = float(39)
 
 message = {
     "pubTime": "20180118151049.356378078",
@@ -47,18 +49,21 @@ message = {
 }
 
 def test_msgFromJSON(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'work_retry')
 
     assert message == download_retry.msgFromJSON(jsonpickle.encode(message))
 
 def test_msgToJSON(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'work_retry')
 
     assert jsonpickle.encode(message) + '\n' == download_retry.msgToJSON(message)
 
 def test__is_exired__TooSoon(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.retry_ttl = 100000
     download_retry = DiskQueue(BaseOptions, 'work_retry')
@@ -66,6 +71,7 @@ def test__is_exired__TooSoon(tmp_path):
     assert download_retry.is_expired(message) == True
 
 def test__is_exired__TooLate(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.retry_ttl = 1
     download_retry = DiskQueue(BaseOptions, 'work_retry')
@@ -76,6 +82,7 @@ def test__is_exired__TooLate(tmp_path):
     assert download_retry.is_expired(message) == False
 
 def test___len__(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'work_retry')
 
@@ -91,6 +98,7 @@ def test___len__(tmp_path):
     assert len(download_retry) == 2
 
 def test_in_cache(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'work_retry')
 
@@ -102,6 +110,7 @@ def test_in_cache(tmp_path):
     assert download_retry.in_cache(message) == True
 
 def test_needs_requeuing(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'work_retry')
 
@@ -115,6 +124,7 @@ def test_needs_requeuing(tmp_path):
     assert download_retry.needs_requeuing(message) == False
     
 def test_put__Single(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_put__Single')
 
@@ -126,6 +136,7 @@ def test_put__Single(tmp_path):
     assert open(download_retry.new_path, 'r').read() == line
 
 def test_put__Multi(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_put__Multi')
 
@@ -139,6 +150,7 @@ def test_put__Multi(tmp_path):
     assert contents == line + line + line
 
 def test_cleanup(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_cleanup')
 
@@ -155,6 +167,7 @@ def test_cleanup(tmp_path):
     assert download_retry.msg_count == 0
 
 def test_msg_get_from_file__NoLine(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_msg_get_from_file__NoLine')
 
@@ -164,6 +177,7 @@ def test_msg_get_from_file__NoLine(tmp_path):
     assert msg == None
 
 def test_msg_get_from_file(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_msg_get_from_file')
 
@@ -179,6 +193,7 @@ def test_msg_get_from_file(tmp_path):
     assert msg == message
 
 def test_get__Single(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_get__Single')
 
@@ -194,6 +209,7 @@ def test_get__Single(tmp_path):
     assert gotten == [message]
 
 def test_get__Multi(tmp_path):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_get__Multi')
 
@@ -209,6 +225,7 @@ def test_get__Multi(tmp_path):
     assert gotten == [message, message]
 
 def test_on_housekeeping__FinishRetry(tmp_path, caplog):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_on_housekeeping__FinishRetry')
 
@@ -226,6 +243,7 @@ def test_on_housekeeping__FinishRetry(tmp_path, caplog):
             assert "have not finished retry list" in record.message
 
 def test_on_housekeeping(tmp_path, caplog):
+    BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     download_retry = DiskQueue(BaseOptions, 'test_on_housekeeping')
 

--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -261,9 +261,13 @@ def test_on_housekeeping__FinishRetry(tmp_path, caplog):
 
     assert hk_out == None
 
+    log_found_notFinished = False
+
     for record in caplog.records:
         if "have not finished retry list" in record.message:
-            assert "have not finished retry list" in record.message
+            log_found_notFinished = True
+    
+    assert log_found_notFinished == True
 
 def test_on_housekeeping(tmp_path, caplog):
     BaseOptions = Options()
@@ -283,10 +287,16 @@ def test_on_housekeeping(tmp_path, caplog):
     assert os.path.exists(download_retry.queue_file) == True
     assert os.path.exists(download_retry.new_path) == False
 
+    log_found_HasQueue = log_found_NumMessages = log_found_Elapsed = False
+
     for record in caplog.records:
         if "has queue" in record.message:
-            assert "has queue" in record.message
+            log_found_HasQueue = True
         if "Number of messages in retry list" in record.message:
-            assert "Number of messages in retry list" in record.message
+            log_found_NumMessages = True
         if "on_housekeeping elapse" in record.message:
-            assert "on_housekeeping elapse" in record.message
+            log_found_Elapsed = True
+            
+    assert log_found_HasQueue == True
+    assert log_found_NumMessages == True
+    assert log_found_Elapsed == True

--- a/tests/sarracenia/flowcb/nodupe/data_test.py
+++ b/tests/sarracenia/flowcb/nodupe/data_test.py
@@ -2,8 +2,13 @@ import pytest
 import os, types, copy
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.flowcb.nodupe.data import Data
 from sarracenia import Message as SR3Message

--- a/tests/sarracenia/flowcb/nodupe/disk_test.py
+++ b/tests/sarracenia/flowcb/nodupe/disk_test.py
@@ -2,8 +2,13 @@ import pytest
 import os, types, copy
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.flowcb.nodupe.disk import NoDupe
 from sarracenia import Message as SR3Message

--- a/tests/sarracenia/flowcb/nodupe/name_test.py
+++ b/tests/sarracenia/flowcb/nodupe/name_test.py
@@ -2,8 +2,13 @@ import pytest
 import os, types, copy
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.flowcb.nodupe.name import Name
 from sarracenia import Message as SR3Message

--- a/tests/sarracenia/flowcb/nodupe/nodupe_test.py
+++ b/tests/sarracenia/flowcb/nodupe/nodupe_test.py
@@ -5,8 +5,13 @@ import os, types, copy
 import fakeredis
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.flowcb.nodupe.redis import NoDupe as NoDupe_Redis
 from sarracenia.flowcb.nodupe.disk import NoDupe as NoDupe_Disk

--- a/tests/sarracenia/flowcb/nodupe/redis_test.py
+++ b/tests/sarracenia/flowcb/nodupe/redis_test.py
@@ -5,8 +5,13 @@ import os, types, copy
 import fakeredis, urllib.parse
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.flowcb.nodupe.redis import NoDupe
 from sarracenia import Message as SR3Message

--- a/tests/sarracenia/flowcb/retry_test.py
+++ b/tests/sarracenia/flowcb/retry_test.py
@@ -4,8 +4,13 @@ from unittest.mock import patch
 import os, types
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 #from sarracenia.flowcb import FlowCB
 from sarracenia.flowcb.retry import Retry

--- a/tests/sarracenia/flowcb/retry_test.py
+++ b/tests/sarracenia/flowcb/retry_test.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-import os, types
+import os, types, copy
 
 #useful for debugging tests
 import pprint
@@ -143,10 +143,11 @@ def test_after_post(tmp_path):
 
         message = make_message()
 
+        after_post_worklist_disk = copy.deepcopy(WorkList)
         after_post_worklist_disk.failed = [message, message, message]
         retry_disk.after_post(after_post_worklist_disk)
 
-        after_post_worklist_redis = WorkList
+        after_post_worklist_redis = copy.deepcopy(WorkList)
         after_post_worklist_redis.failed = [message, message, message]
         retry_redis.after_post(after_post_worklist_redis)
 
@@ -168,10 +169,11 @@ def test_after_work__WLFailed(tmp_path):
 
         message = make_message()
 
+        after_work_worklist_disk = copy.deepcopy(WorkList)
         after_work_worklist_disk.failed = [message, message, message]
         retry_disk.after_work(after_work_worklist_disk)
 
-        after_work_worklist_redis = WorkList
+        after_work_worklist_redis = copy.deepcopy(WorkList)
         after_work_worklist_redis.failed = [message, message, message]
         retry_redis.after_work(after_work_worklist_redis)
 
@@ -196,10 +198,11 @@ def test_after_work__SmallQty(tmp_path):
 
         message = make_message()
 
+        after_work_worklist_disk = copy.deepcopy(WorkList)
         after_work_worklist_disk.ok = [message, message, message]
         retry_disk.after_work(after_work_worklist_disk)
 
-        after_work_worklist_redis = WorkList
+        after_work_worklist_redis = copy.deepcopy(WorkList)
         after_work_worklist_redis.ok = [message, message, message]
         retry_redis.after_work(after_work_worklist_redis)
 
@@ -223,12 +226,13 @@ def test_after_work(tmp_path):
 
         message = make_message()
 
+        after_work_worklist_disk = copy.deepcopy(WorkList)
         after_work_worklist_disk.ok = [message, message, message]
         retry_disk.post_retry.put([message, message, message])
         retry_disk.on_housekeeping()
         retry_disk.after_work(after_work_worklist_disk)
 
-        after_work_worklist_redis = WorkList
+        after_work_worklist_redis = copy.deepcopy(WorkList)
         after_work_worklist_redis.ok = [message, message, message]
         retry_redis.post_retry.put([message, message, message])
         retry_redis.on_housekeeping()
@@ -255,10 +259,11 @@ def test_after_accept__SmallQty(tmp_path):
 
         message = make_message()
 
+        after_work_worklist_disk = copy.deepcopy(WorkList)
         after_work_worklist_disk.incoming = [message, message, message]
         retry_disk.after_accept(after_work_worklist_disk)
 
-        after_work_worklist_redis = WorkList
+        after_work_worklist_redis = copy.deepcopy(WorkList)
         after_work_worklist_redis.incoming = [message, message, message]
         retry_redis.after_accept(after_work_worklist_redis)
 
@@ -281,12 +286,13 @@ def test_after_accept(tmp_path):
 
         message = make_message()
 
+        after_work_worklist_disk = copy.deepcopy(WorkList)
         after_work_worklist_disk.incoming = [message, message, message]
         retry_disk.download_retry.put([message, message, message])
         retry_disk.on_housekeeping()
         retry_disk.after_accept(after_work_worklist_disk)
 
-        after_work_worklist_redis = WorkList
+        after_work_worklist_redis = copy.deepcopy(WorkList)
         after_work_worklist_redis.incoming = [message, message, message]
         retry_redis.download_retry.put([message, message, message])
         retry_redis.on_housekeeping()

--- a/tests/sarracenia/flowcb/retry_test.py
+++ b/tests/sarracenia/flowcb/retry_test.py
@@ -239,7 +239,7 @@ def test_after_work(tmp_path):
         retry_redis.after_work(after_work_worklist_redis)
 
         assert len(retry_disk.download_retry) == len(retry_redis.download_retry) == 0
-        assert len(after_work_worklist_disk.ok) == len(after_work_worklist_redis.ok) == 4
+        assert len(after_work_worklist_disk.ok) == len(after_work_worklist_redis.ok) == 3
 
 @pytest.mark.depends(on=['sarracenia/diskqueue_test.py', 'sarracenia/redisqueue_test.py'])
 def test_after_accept__SmallQty(tmp_path):
@@ -298,8 +298,8 @@ def test_after_accept(tmp_path):
         retry_redis.on_housekeeping()
         retry_redis.after_accept(after_work_worklist_redis)
 
-        assert len(retry_disk.download_retry) == len(retry_redis.download_retry) == 0
-        assert len(after_work_worklist_disk.incoming) == len(after_work_worklist_redis.incoming) == 4
+        assert len(retry_disk.download_retry) == len(retry_redis.download_retry) == 1
+        assert len(after_work_worklist_disk.incoming) == len(after_work_worklist_redis.incoming) == 3
 
 @pytest.mark.depends(on=['sarracenia/diskqueue_test.py', 'sarracenia/redisqueue_test.py'])
 def test_on_housekeeping(tmp_path, caplog):

--- a/tests/sarracenia/flowcb/retry_test.py
+++ b/tests/sarracenia/flowcb/retry_test.py
@@ -18,17 +18,19 @@ from sarracenia.flowcb.retry import Retry
 import fakeredis
 
 class Options:
-    retry_driver = 'disk'
-    redisqueue_serverurl = ''
-    no = 1
-    retry_ttl = 0
-    batch = 8
-    logLevel = "DEBUG"
-    queueName = "TEST_QUEUE_NAME"
-    component = "sarra"
-    config = "foobar.conf"
-    pid_filename = "NotARealPath"
-    housekeeping = float(0)
+    def __init__(self):
+        self.no = 1
+        self.retry_ttl = 0
+        self.logLevel = "DEBUG"
+        self.logFormat = ""
+        self.queueName = "TEST_QUEUE_NAME"
+        self.component = "sarra"
+        self.retry_driver = 'disk'
+        self.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
+        self.config = "foobar.conf"
+        self.pid_filename = "/tmp/sarracenia/retyqueue_test/pid_filename"
+        self.housekeeping = float(0)
+        self.batch = 0
     def add_option(self, option, type, default = None):
         if not hasattr(self, option):
             setattr(self, option, default)
@@ -64,6 +66,7 @@ def test_cleanup(tmp_path):
     
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
         BaseOptions_disk = Options()
+        BaseOptions_disk.retry_driver = 'disk'
         BaseOptions_disk.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
         retry_disk = Retry(BaseOptions_disk)
 

--- a/tests/sarracenia/flowcb/retry_teststeps.py
+++ b/tests/sarracenia/flowcb/retry_teststeps.py
@@ -15,6 +15,7 @@ def pretty(*things, **named_things):
 
 #from sarracenia.flowcb import FlowCB
 from sarracenia.flowcb.retry import Retry
+from sarracenia import Message as SR3Message
 
 import fakeredis
 
@@ -43,23 +44,25 @@ WorkList.rejected = []
 WorkList.failed = []
 WorkList.directories_ok = []
 
-message = {
-    "pubTime": "20180118151049.356378078",
-    "topic": "v02.post.sent_by_tsource2send",
-    "headers": {
-        "atime": "20180118151049.356378078", 
-        "from_cluster": "localhost",
-        "mode": "644",
-        "mtime": "20180118151048",
-        "parts": "1,69,1,0,0",
-        "source": "tsource",
-        "sum": "d,c35f14e247931c3185d5dc69c5cd543e",
-        "to_clusters": "localhost"
-    },
-    "baseUrl": "https://NotARealURL",
-    "relPath": "ThisIsAPath/To/A/File.txt",
-    "notice": "20180118151050.45 ftp://anonymous@localhost:2121 /sent_by_tsource2send/SXAK50_KWAL_181510___58785"
-}
+def make_message():
+    m = SR3Message()
+    m["pubTime"] = "20180118151049.356378078"
+    m["topic"] = "v02.post.sent_by_tsource2send"
+    m["mtime"] = "20180118151048"
+    m["headers"] = {
+            "atime": "20180118151049.356378078", 
+            "from_cluster": "localhost",
+            "mode": "644",
+            "parts": "1,69,1,0,0",
+            "source": "tsource",
+            "sum": "d,c35f14e247931c3185d5dc69c5cd543e",
+            "to_clusters": "localhost"
+        }
+    m["baseUrl"] =  "https://NotARealURL"
+    m["relPath"] = "ThisIsAPath/To/A/File.txt"
+    m["notice"] = "20180118151050.45 ftp://anonymous@localhost:2121 /sent_by_tsource2send/SXAK50_KWAL_181510___58785"
+    m["_deleteOnPost"] = set()
+    return m
 
 @pytest.mark.bug("DiskQueue.py doesn't cleanup properly")
 @test_steps('disk', 'redis')
@@ -75,6 +78,8 @@ def cleanup__disk(tmp_path):
     # -- DiskQueue
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
+
+    message = make_message()
 
     retry.download_retry.put([message, message, message])
     retry.post_retry.put([message, message, message])
@@ -96,6 +101,8 @@ def cleanup__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_cleanup"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         retry.download_retry.put([message, message, message])
         retry.post_retry.put([message, message, message])
@@ -125,6 +132,8 @@ def metricsReport__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     retry.download_retry.put([message, message, message])
     retry.post_retry.put([message, message, message])
 
@@ -141,6 +150,8 @@ def metricsReport__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_metricsReport"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         retry.download_retry.put([message, message, message])
         retry.post_retry.put([message, message, message])
@@ -166,6 +177,8 @@ def after_post__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     after_post_worklist = WorkList
     after_post_worklist.failed = [message, message, message]
 
@@ -181,6 +194,8 @@ def after_post__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_after_post"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         after_post_worklist = WorkList
         after_post_worklist.failed = [message, message, message]
@@ -205,6 +220,8 @@ def after_work__WLFailed__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     after_work_worklist = WorkList
     after_work_worklist.failed = [message, message, message]
 
@@ -221,6 +238,8 @@ def after_work__WLFailed__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_after_work__WLFailed"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         after_work_worklist = WorkList
         after_work_worklist.failed = [message, message, message]
@@ -248,6 +267,8 @@ def after_work__SmallQty__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     after_work_worklist = WorkList
     after_work_worklist.ok = [message, message, message]
 
@@ -265,6 +286,8 @@ def after_work__SmallQty__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_after_work__SmallQty"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         after_work_worklist = WorkList
         after_work_worklist.ok = [message, message, message]
@@ -290,6 +313,8 @@ def after_work__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     after_work_worklist = WorkList
     after_work_worklist.ok = [message, message, message]
     retry.post_retry.put([message, message, message])
@@ -308,6 +333,8 @@ def after_work__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_after_work"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         after_work_worklist = WorkList
         after_work_worklist.ok = [message, message, message]
@@ -336,6 +363,8 @@ def after_accept__SmallQty__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     after_accept_worklist = WorkList
     after_accept_worklist.incoming = [message, message, message]
 
@@ -353,6 +382,8 @@ def after_accept__SmallQty__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_after_accept__SmallQty"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         after_accept_worklist = WorkList
         after_accept_worklist.incoming = [message, message, message]
@@ -379,6 +410,8 @@ def after_accept__disk(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     retry.download_retry.put([message, message, message])
     retry.on_housekeeping()
 
@@ -398,6 +431,8 @@ def after_accept__redis():
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_after_accept"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         after_accept_worklist = WorkList
         after_accept_worklist.incoming = [message, message, message]
@@ -425,6 +460,8 @@ def on_housekeeping__disk(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     retry = Retry(BaseOptions)
 
+    message = make_message()
+
     retry.download_retry.put([message, message, message])
     retry.post_retry.put([message, message, message])
 
@@ -447,6 +484,8 @@ def on_housekeeping__redis(caplog):
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
         BaseOptions.queueName = "test_on_housekeeping"
         retry = Retry(BaseOptions)
+
+        message = make_message()
 
         #server_test_on_housekeeping = fakeredis.FakeServer()
         #retry.download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_on_housekeeping)

--- a/tests/sarracenia/flowcb/retry_teststeps.py
+++ b/tests/sarracenia/flowcb/retry_teststeps.py
@@ -2,7 +2,7 @@ import pytest
 from pytest_steps import test_steps
 from unittest.mock import patch
 
-import os, types
+import os, types, copy
 
 #useful for debugging tests
 import pprint
@@ -179,7 +179,7 @@ def after_post__disk(tmp_path):
 
     message = make_message()
 
-    after_post_worklist = WorkList
+    after_post_worklist = copy.deepcopy(WorkList)
     after_post_worklist.failed = [message, message, message]
 
     retry.after_post(after_post_worklist)
@@ -197,7 +197,7 @@ def after_post__redis():
 
         message = make_message()
 
-        after_post_worklist = WorkList
+        after_post_worklist = copy.deepcopy(WorkList)
         after_post_worklist.failed = [message, message, message]
 
         retry.after_post(after_post_worklist)
@@ -222,7 +222,7 @@ def after_work__WLFailed__disk(tmp_path):
 
     message = make_message()
 
-    after_work_worklist = WorkList
+    after_work_worklist = copy.deepcopy(WorkList)
     after_work_worklist.failed = [message, message, message]
 
     retry.after_work(after_work_worklist)
@@ -241,7 +241,7 @@ def after_work__WLFailed__redis():
 
         message = make_message()
 
-        after_work_worklist = WorkList
+        after_work_worklist = copy.deepcopy(WorkList)
         after_work_worklist.failed = [message, message, message]
 
         retry.after_work(after_work_worklist)
@@ -269,7 +269,7 @@ def after_work__SmallQty__disk(tmp_path):
 
     message = make_message()
 
-    after_work_worklist = WorkList
+    after_work_worklist = copy.deepcopy(WorkList)
     after_work_worklist.ok = [message, message, message]
 
     retry.after_work(after_work_worklist)
@@ -289,7 +289,7 @@ def after_work__SmallQty__redis():
 
         message = make_message()
 
-        after_work_worklist = WorkList
+        after_work_worklist = copy.deepcopy(WorkList)
         after_work_worklist.ok = [message, message, message]
 
         retry.after_work(after_work_worklist)
@@ -315,7 +315,7 @@ def after_work__disk(tmp_path):
 
     message = make_message()
 
-    after_work_worklist = WorkList
+    after_work_worklist = copy.deepcopy(WorkList)
     after_work_worklist.ok = [message, message, message]
     retry.post_retry.put([message, message, message])
     retry.on_housekeeping()
@@ -336,7 +336,7 @@ def after_work__redis():
 
         message = make_message()
 
-        after_work_worklist = WorkList
+        after_work_worklist = copy.deepcopy(WorkList)
         after_work_worklist.ok = [message, message, message]
         retry.post_retry.put([message, message, message])
         retry.on_housekeeping()
@@ -365,7 +365,7 @@ def after_accept__SmallQty__disk(tmp_path):
 
     message = make_message()
 
-    after_accept_worklist = WorkList
+    after_accept_worklist = copy.deepcopy(WorkList)
     after_accept_worklist.incoming = [message, message, message]
 
     retry.after_accept(after_accept_worklist)
@@ -385,7 +385,7 @@ def after_accept__SmallQty__redis():
 
         message = make_message()
 
-        after_accept_worklist = WorkList
+        after_accept_worklist = copy.deepcopy(WorkList)
         after_accept_worklist.incoming = [message, message, message]
 
         retry.after_accept(after_accept_worklist)
@@ -415,7 +415,7 @@ def after_accept__disk(tmp_path):
     retry.download_retry.put([message, message, message])
     retry.on_housekeeping()
 
-    after_accept_worklist = WorkList
+    after_accept_worklist = copy.deepcopy(WorkList)
     after_accept_worklist.incoming = [message, message, message]
 
     retry.after_accept(after_accept_worklist)
@@ -434,7 +434,7 @@ def after_accept__redis():
 
         message = make_message()
 
-        after_accept_worklist = WorkList
+        after_accept_worklist = copy.deepcopy(WorkList)
         after_accept_worklist.incoming = [message, message, message]
         retry.download_retry.put([message, message, message])
         retry.on_housekeeping()

--- a/tests/sarracenia/flowcb/retry_teststeps.py
+++ b/tests/sarracenia/flowcb/retry_teststeps.py
@@ -5,8 +5,13 @@ from unittest.mock import patch
 import os, types
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 #from sarracenia.flowcb import FlowCB
 from sarracenia.flowcb.retry import Retry

--- a/tests/sarracenia/flowcb/retry_teststeps.py
+++ b/tests/sarracenia/flowcb/retry_teststeps.py
@@ -1,3 +1,20 @@
+
+###############################################################################
+#                                  NOTES
+#
+# This file isn't used, but serves as an example of how one might use 
+#  the pytest-steps package to break down comparative tests into 
+#  driver-specific steps
+#
+# This works well, except it doesn't help us validate that drivers 
+#  do/return the same things, so it was abandoned. It is kept purely as a
+#  reference to how this *could* be done in other cases
+#
+# To use it, one would just have to install the `pytest-steps` package, 
+#  and ideally add it to the tests/requirements.txt file so that the
+#  Unit Test pipeline works properly
+###############################################################################
+
 import pytest
 from pytest_steps import test_steps
 from unittest.mock import patch

--- a/tests/sarracenia/flowcb/retry_teststeps.py
+++ b/tests/sarracenia/flowcb/retry_teststeps.py
@@ -19,22 +19,22 @@ from sarracenia.flowcb.retry import Retry
 import fakeredis
 
 class Options:
-    retry_driver = 'disk'
-    redisqueue_serverurl = ''
-    no = 1
-    retry_ttl = 0
-    batch = 8
-    logLevel = "DEBUG"
-    queueName = "TEST_QUEUE_NAME"
-    component = "sarra"
-    config = "foobar.conf"
-    pid_filename = "NotARealPath"
-    housekeeping = float(0)
+    def __init__(self):
+        self.no = 1
+        self.retry_ttl = 0
+        self.logLevel = "DEBUG"
+        self.logFormat = ""
+        self.queueName = "TEST_QUEUE_NAME"
+        self.component = "sarra"
+        self.retry_driver = 'disk'
+        self.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
+        self.config = "foobar.conf"
+        self.pid_filename = "/tmp/sarracenia/retyqueue_test/pid_filename"
+        self.housekeeping = float(0)
+        self.batch = 8
     def add_option(self, option, type, default = None):
         if not hasattr(self, option):
             setattr(self, option, default)
-
-
 
 WorkList = types.SimpleNamespace()
 WorkList.ok = []

--- a/tests/sarracenia/redisqueue_test.py
+++ b/tests/sarracenia/redisqueue_test.py
@@ -17,19 +17,22 @@ import fakeredis
 import jsonpickle
 
 class Options:
+    def __init__(self):
+        self.no = 1
+        self.retry_ttl = 0
+        self.logLevel = "DEBUG"
+        self.logFormat = ""
+        self.queueName = "TEST_QUEUE_NAME"
+        self.component = "sarra"
+        self.retry_driver = 'disk'
+        self.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
+        self.config = "foobar.conf"
+        self.pid_filename = "/tmp/sarracenia/diskqueue_test/pid_filename"
+        self.housekeeping = float(39)
+        self.batch = 0
     def add_option(self, option, type, default = None):
         if not hasattr(self, option):
             setattr(self, option, default)
-    pass
-
-BaseOptions = Options()
-BaseOptions.retry_ttl = 0
-BaseOptions.logLevel = "INFO"
-BaseOptions.queueName = "TEST_QUEUE_NAME"
-BaseOptions.component = "sarra"
-BaseOptions.config = "foobar.conf"
-BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
-BaseOptions.housekeeping = float(39)
 
 message = {
     "pubTime": "20180118151049.356378078",
@@ -51,6 +54,7 @@ message = {
 
 def test___len__():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test___len__')
         download_retry.redis.lpush(download_retry.key_name, "first")
         assert len(download_retry) == 1
@@ -61,6 +65,7 @@ def test___len__():
 
 def test__in_cache():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test__in_cache')
 
         download_retry.retry_cache = {}
@@ -71,6 +76,7 @@ def test__in_cache():
 
 def test__is_exired__TooSoon():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         BaseOptions.retry_ttl = 100000
         download_retry = RedisQueue(BaseOptions, 'test__is_exired__TooSoon')
 
@@ -78,6 +84,7 @@ def test__is_exired__TooSoon():
 
 def test__is_exired__TooLate():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         BaseOptions.retry_ttl = 1
         download_retry = RedisQueue(BaseOptions, 'test__is_exired__TooLate')
 
@@ -88,6 +95,7 @@ def test__is_exired__TooLate():
 
 def test__needs_requeuing():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test__needs_requeuing')
 
         download_retry.retry_cache = {}
@@ -99,18 +107,21 @@ def test__needs_requeuing():
 
 def test__msgFromJSON():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test__msgFromJSON')
 
         assert message == download_retry._msgFromJSON(jsonpickle.encode(message))
 
 def test__msgToJSON():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test__msgToJSON')
 
         assert jsonpickle.encode(message) == download_retry._msgToJSON(message)
 
 def test__lpop():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test__lpop')
         #server_test__lpop = fakeredis.FakeServer()
         #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test__lpop)
@@ -121,6 +132,7 @@ def test__lpop():
     
 def test_put__Single():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_put__Single')
 
         #server_test_put_single = fakeredis.FakeServer()
@@ -131,6 +143,7 @@ def test_put__Single():
 
 def test_put__Multi():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_put__Multi')
 
         #server_test_put_multi = fakeredis.FakeServer()
@@ -141,7 +154,7 @@ def test_put__Multi():
 
 def test_cleanup():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-        
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_cleanup')
 
         #This test fails unless you explicity tell it to use a different server than the rest of the tests
@@ -165,7 +178,7 @@ def test_cleanup():
 
 def test_get__NotLocked_Single():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_get__NotLocked_Single')
 
         #server_test_get__NotLocked = fakeredis.FakeServer()
@@ -180,7 +193,7 @@ def test_get__NotLocked_Single():
 
 def test_get__NotLocked_Multi():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_get__NotLocked_Multi')
 
         #server_test_get__NotLocked = fakeredis.FakeServer()
@@ -200,7 +213,7 @@ def test_get__NotLocked_Multi():
 
 def test_get__Locked():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_get__Locked')
 
         #server_test_get__NotLocked = fakeredis.FakeServer()
@@ -217,6 +230,7 @@ def test_get__Locked():
 
 def test_on_housekeeping__TooSoon(caplog):
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping__TooSoon')
 
         #server_test_on_housekeeping__TooSoon = fakeredis.FakeServer()
@@ -259,6 +273,7 @@ def test_on_housekeeping__TooSoon(caplog):
 
 def test_on_housekeeping__FinishRetry(caplog):
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         BaseOptions.queueName = "test_on_housekeeping__FinishRetry"
         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping__FinishRetry')
 
@@ -280,6 +295,7 @@ def test_on_housekeeping__FinishRetry(caplog):
 
 def test_on_housekeeping(caplog):
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        BaseOptions = Options()
         BaseOptions.queueName = "test_on_housekeeping"
         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping')
 

--- a/tests/sarracenia/redisqueue_test.py
+++ b/tests/sarracenia/redisqueue_test.py
@@ -315,9 +315,13 @@ def test_on_housekeeping__FinishRetry(caplog):
 
         assert hk_out == None
 
+        log_found_notFinished = False
+
         for record in caplog.records:
             if "have not finished retry list" in record.message:
-                assert "have not finished retry list" in record.message
+                log_found_notFinished = True
+    
+        assert log_found_notFinished == True
 
 def test_on_housekeeping(caplog):
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
@@ -343,9 +347,13 @@ def test_on_housekeeping(caplog):
         assert hk_out == None
         assert download_retry.redis.exists(download_retry.key_name_hk) == False
 
-        import re
+        log_found_LockReleased = log_found_Elapsed = False
+
         for record in caplog.records:
             if "released redis_lock" in record.message:
-                assert "released redis_lock" in record.message
+                log_found_LockReleased = True
             if "on_housekeeping elapse" in record.message:
-                assert "on_housekeeping elapse" in record.message
+                log_found_Elapsed = True
+
+        assert log_found_LockReleased == True
+        assert log_found_Elapsed == True

--- a/tests/sarracenia/redisqueue_test.py
+++ b/tests/sarracenia/redisqueue_test.py
@@ -135,8 +135,6 @@ def test__lpop():
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
         BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test__lpop')
-        #server_test__lpop = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test__lpop)
 
         message = make_message()
 
@@ -149,9 +147,6 @@ def test_put__Single():
         BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_put__Single')
 
-        #server_test_put_single = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_put_single)
-
         message = make_message()
 
         download_retry.put([message])
@@ -163,9 +158,6 @@ def test_put__Multi():
         download_retry = RedisQueue(BaseOptions, 'test_put__Multi')
 
         message = make_message()
-
-        #server_test_put_multi = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_put_multi)
 
         download_retry.put([message, message, message, message])
         assert download_retry.redis.llen(download_retry.key_name_new) == 4
@@ -195,9 +187,6 @@ def test_get__NotLocked_Single():
 
         message = make_message()
 
-        #server_test_get__NotLocked = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_get__NotLocked)
-
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
 
         gotten = download_retry.get()
@@ -212,15 +201,10 @@ def test_get__NotLocked_Multi():
 
         message = make_message()
 
-        #server_test_get__NotLocked = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_get__NotLocked)
-
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
-
-        #with patch(target="redis_lock.Lock.locked", new=lambda foo: False):
 
         gotten = download_retry.get(2)
 
@@ -233,9 +217,6 @@ def test_get__Locked():
         download_retry = RedisQueue(BaseOptions, 'test_get__Locked')
 
         message = make_message()
-
-        #server_test_get__NotLocked = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_get__NotLocked)
 
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
 
@@ -251,9 +232,6 @@ def test_on_housekeeping__TooSoon(caplog):
         BaseOptions = Options()
         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping__TooSoon')
 
-        #server_test_on_housekeeping__TooSoon = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_on_housekeeping__TooSoon)
-
         download_retry.redis.set(download_retry.key_name_lasthk, download_retry.now)
         hk_out = download_retry.on_housekeeping()
 
@@ -263,32 +241,6 @@ def test_on_housekeeping__TooSoon(caplog):
             if "Housekeeping ran less than " in record.message:
                 assert "Housekeeping ran less than " in record.message
 
-# @pytest.mark.skip("No need to check if we're locked, per Peter")
-# def test_on_housekeeping__Locked(caplog):
-#     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-#         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping__Locked')
-
-#         #server_test_on_housekeeping__Locked = fakeredis.FakeServer()
-#         #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_on_housekeeping__Locked)
-
-#         #import jsonpickle
-
-#         #download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
-
-#         #with patch(target="redis_lock.Lock.locked", new=lambda foo: True):
-
-#         download_retry.redis.set(download_retry.key_name_lasthk, download_retry.now - download_retry.o.housekeeping - 100)
-#         download_retry.redis_lock.acquire()
-
-#         hk_out = download_retry.on_housekeeping()
-
-#         assert hk_out == None
-
-#         import re
-#         for record in caplog.records:
-#             if "Another instance has lock on" in record.message:
-#                 assert "Another instance has lock on" in record.message
-
 def test_on_housekeeping__FinishRetry(caplog):
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
         BaseOptions = Options()
@@ -296,9 +248,6 @@ def test_on_housekeeping__FinishRetry(caplog):
         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping__FinishRetry')
 
         message = make_message()
-
-        #server_test_on_housekeeping__FinishRetry = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_on_housekeeping__FinishRetry)
 
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
         download_retry.redis.lpush(download_retry.key_name, jsonpickle.encode(message))
@@ -324,11 +273,6 @@ def test_on_housekeeping(caplog):
         download_retry = RedisQueue(BaseOptions, 'test_on_housekeeping')
 
         message = make_message()
-
-        #server_test_on_housekeeping = fakeredis.FakeServer()
-        #download_retry.redis = fakeredis.FakeStrictRedis(server=server_test_on_housekeeping)
-
-        #with patch(target="redis_lock.Lock.locked", new=lambda foo: True):
 
         download_retry.redis.lpush(download_retry.key_name_new, jsonpickle.encode(message))
         download_retry.redis.lpush(download_retry.key_name_new, jsonpickle.encode(message))

--- a/tests/sarracenia/redisqueue_test.py
+++ b/tests/sarracenia/redisqueue_test.py
@@ -2,8 +2,13 @@ import pytest
 from unittest.mock import patch
 
 #useful for debugging tests
-#import pprint
-#pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+import pprint
+def pretty(*things, **named_things):
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
 from sarracenia.redisqueue import RedisQueue
 


### PR DESCRIPTION
In writing more and more tests, some things have been streamlined, or improved, and this is just back-porting those changes to previous tests.

- Define a `pretty` method that you can use while debugging your rests
  - Use like: `pretty(ThingYouWantToDump)`, then run your tests with `-vv` and `--capture=tee-sys` parameters
- Move `Options` and `Message` creation into methods (versus creating objects manually)
  - Should probably further use `sarracenia.config.default_config()` to generate base config
  - Could also turn them both into a fixture, but then you might have to break each test set into it's own test method so the fixture resets properly
- Use `deepcopy` instead of just straight copy, so tests don't affect eachother
- With the changes above there was some broken tests in `rety_test.py`, so fix those
- Add a note to `retry_teststeps.py` about how it works, and why we're not using it for our tests
  - tl;dr, it doesn't compare outputs from different drivers against a desired output, so we can't ensure drivers are doing/returning the same thing
- In some tests, I was seeing if logs were being generated, but the assertions were only happening inside an `if` block, so they could never fail; Fixed that