### PR TITLE
Tentative addition of *features* action to help with dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ metpx-sr3 (3.00.42) UNRELEASED; urgency=medium
   * issue #415 MQTT/websocket support added. other fixes for MQTT.
   * issue #724 sr3 cli crashes when state files in a bad state.
   * issue #730, #731 many additions to unit testing.
+  * issue #727 bugfixes found during unit test development.
   * issue #719 complain about each undeclared options only once.
   * issue #712 crash when plugin declares a duration option without default
     value.

--- a/docs/source/Contribution/Development.rst
+++ b/docs/source/Contribution/Development.rst
@@ -1617,14 +1617,13 @@ Working with a non-packaged version:
 
 notes::
 
-    python3 setup.py build
-    python3 setup.py install
+    pip install -e .
 
 
 Windows
 ~~~~~~~
 
-Install winpython from github.io version 3.4 or higher.  Then use pip to install from PyPI.
+Install winpython from github.io version 3.5 or higher.  Then use pip to install from PyPI.
 
 
 
@@ -1642,4 +1641,41 @@ sr_report(7) notification messages should be emitted to indicate final dispositi
 any notifications or report messages (don't report report messages, it becomes an infinite loop!)
 For debugging and other information, the local log file is used.  For example, sr_shovel does
 not emit any sr_report(7) messages, because no data is transferred, only messages.
+
+
+Adding a New Dependency
+-----------------------
+
+Dependency Management is a complicated topic, because python has many different installation methods into disparate environments, and Sarracenia is multi-platform.  Standard python practice for dependencies is to make
+them *required* by listing them in requirements.txt or setup.py, and require all users to install them.
+In most python applications, if a dependency is missing, it just crashes with a import failure message
+of some kind.
+
+In Sr3, we have found that there are many different environments being deployed into where satisfying
+dependencies can be more trouble than they are worth, so each of the dependencies in setup.py are also
+dealt with in sarracenia/featuredetection, and the feature detection code allows the application to 
+keep working, just without the functionality provided by the missing module. This is called *degradation*
+or *degraded mode*. The idea being to help the user do as much as they can, in the environment they have,
+while telling them what is missing, and what would ideally be added.
+
+for a full discussion see:
+
+`Managing Dependencies (Discussion) <https://github.com/MetPX/sarracenia/issues/741>`
+
+Short version:
+
+In addition to requirements.dev/setup.py, if you need to add a new library that isn't part of 
+*batteries included*, typically provided by a separate os or pip package, then you want to 
+provide for the package to still work in the event that the package is not available (albeit 
+without the function you are adding) and to add support for explaining what's missing using 
+the sarracenia/featuredetection.py module.
+
+In that module is a *features* data structure, where you add an entry explaining the import 
+needed, and the functionality it brings to Sr3. You also add if feature['x']['present'] guards
+in the code where you are using the feature, in order to allow the code to degrade elegantly.
+
+If the dependency is added in a plugin, then there is also a method for that described here:
+
+`Plugin Developer Guide <../Explanation/SarraPluginDev.html#callbacks-that-need-python-modules>`
+
 

--- a/docs/source/Contribution/Development.rst
+++ b/docs/source/Contribution/Development.rst
@@ -1445,13 +1445,25 @@ Building a Windows Installer
 One can also build a Windows installer with that 
 `script <https://github.com/MetPX/sarracenia/blob/main/generate-win-installer.sh>`_.
 It needs to be run from a Linux OS (preferably Ubuntu 18) in the root directory of Sarracenia's git. 
+find the python version in use::
+
+    fractal% python -V
+    Python 3.10.12
+    fractal%
+
+So this is python 3.10.  Only a single minor version will have the embedded package needed
+by pynsist to build the executable, so look at::
+
+    https://www.python.org/downloads/windows/
+
+Then go look on python.org, for the "right" version (for 3.10, it is 3.10.11 )
 Then, from the shell, run::
 
  sudo apt install nsis
  pip3 install pynsist wheel
- ./generate-win-installer.sh 2>&1 > log.txt
+ ./generate-win-installer.sh 3.10.11 2>&1 > log.txt
 
-The final package should be placed in build/nsis directory.
+The final package will be generated into build/nsis directory.
 
 
 Daily Builds

--- a/docs/source/Contribution/index.rst
+++ b/docs/source/Contribution/index.rst
@@ -1,6 +1,6 @@
 
-Contributing to Sarracenia
-==========================
+Contributing 
+============
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/Contribution/v03.rst
+++ b/docs/source/Contribution/v03.rst
@@ -274,7 +274,7 @@ the two versions, is clear:
 |                          |                           |
 | sr_message.py            |                           |
 +--------------------------+---------------------------+
-| sr_checksum.py           | identity/                |
+| sr_checksum.py           | identity/                 |
 |                          |      __init__.py          |
 | sum/*                    |      *                    |
 +--------------------------+---------------------------+

--- a/docs/source/Explanation/SarraPluginDev.rst
+++ b/docs/source/Explanation/SarraPluginDev.rst
@@ -654,6 +654,62 @@ The destfn routine takes the notification message as an argument and should retu
 the new file name as a string.
 
 
+Callbacks that need Python Modules
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some callbacks need to use other python modules.  While normal imports
+are fine, one can integrate them better for sr3 users by supporting
+the *features* mechism::
+
+    from sarracenia.featuredetection import features
+    #
+    # Support for features inventory mechanism.
+    #
+    features['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
+            'lament' : 'cannot use clamd to av scan files transferred',
+            'rejoice' : 'can use clamd to av scan files transferred' }
+
+    try:
+        import pyclamd
+        features['clamd']['present'] = True
+    except:
+        features['clamd']['present'] = False
+
+This lets users know which *features* are available in their installetion
+so when they run *sr3 features* it provides an easily understood list of missing
+libraries::
+
+    fractal% sr3 features
+    2023-08-07 13:18:09,219 1993037 [INFO] sarracenia.flow loadCallbacks flowCallback plugins to load: ['sarracenia.flowcb.retry.Retry', 'sarracenia.flowcb.housekeeping.resources.Resources', 'dcpflow', 'log', 'post.message', 'clamav']
+    2023-08-07 13:18:09,224 1993037 [INFO] dcpflow __init__ really I mean hi
+    2023-08-07 13:18:09,224 1993037 [WARNING] sarracenia.config add_option multiple declarations of lrgs_download_redundancy=['Yes', 'on'] choosing last one: on
+    2023-08-07 13:18:09,225 1993037 [INFO] dcpflow __init__  lrgs_download_redundancy is True
+    2023-08-07 13:18:09,225 1993037 [INFO] sarracenia.flowcb.log __init__ flow initialized with: {'post', 'on_housekeeping', 'after_work', 'after_accept', 'after_post'}
+    2023-08-07 13:18:09,226 1993037 [CRITICAL] sarracenia.flow loadCallbacks flowCallback plugin clamav did not load: 'pyclamd'
+    
+    Status:    feature:   python imports:      Description:
+    Installed  amqp       amqp                 can connect to rabbitmq brokers
+    Installed  appdirs    appdirs              place configuration and state files appropriately for platform (windows/mac/linux)
+    Installed  filetypes  magic                able to set content headers
+    Installed  ftppoll    dateparser,pytz      able to poll with ftp
+    Installed  humanize   humanize             humans numbers that are easier to read.
+    Absent     mqtt       paho.mqtt.client     cannot connect to mqtt brokers
+    Installed  redis      redis,redis_lock     can use redis implementations of retry and nodupe
+    Installed  sftp       paramiko             can use sftp or ssh based services
+    Installed  vip        netifaces            able to use the vip option for high availability clustering
+    Installed  watch      watchdog             watch directories
+    Installed  xattr      xattr                on linux, will store file metadata in extended attributes
+    MISSING    clamd      pyclamd              cannot use clamd to av scan files transferred
+    
+     state dir: /home/peter/.cache/sr3
+     config dir: /home/peter/.config/sr3
+    
+    fractal%
+    
+You can see that that clamd feature is disabled because the pyclamd python library is not installed.
+
+
+
 
 Flow Callback Poll Customization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -164,13 +164,15 @@ git
 
   with pip installation, one can include all the extras via::
 
-      pip install metpx-sr3[amqp,mqtt,ftppoll,vip]
+      pip install metpx-sr3[all]
 
   with Linux packages, install the corresponding native packages to activate the corresponding features
 
   on Ubuntu, respectively::
 
       apt install python3-amqp 
+      apt install python3-magic 
+      apt install python3-paramiko 
       apt install python3-paho-mqtt 
       apt install python3-dateparser python3-tz
       apt install python3-netifaces

--- a/docs/source/How2Guides/v2ToSr3.rst
+++ b/docs/source/How2Guides/v2ToSr3.rst
@@ -320,7 +320,7 @@ In general, v3 plugins:
   msg.pubtime      msg['pubTime']                     when the message was originally published (standard field)
   msg.baseurl      msg['baseUrl']                     root of the url tree of posted file (standard field)
   msg.relpath      msg['relPath']                     relative path concatenated to baseUrl for canonical path
-  *no equivalent*  msg['retrievePath']                     opaque retrieval path to override canonical one.
+  *no equivalent*  msg['retrievePath']                opaque retrieval path to override canonical one.
   msg.notice       no equivalent                      calculated from other field on v2 write
   msg.new_subtopic msg['new_subtopic']                avoid in sr3... calculated from relPath
   msg.new_dir      msg['new_dir']                     name of the directory where files will be written
@@ -331,7 +331,7 @@ In general, v3 plugins:
   msg.exchange     msg['exchange']                    the channel on which the message was received.
   msg.logger       logger                             pythonic logging setup describe above.
   msg.parts        msg['size']                        just omit, use sarracenia.Message constructor.
-  msg.sumflg       msg['identity']                   just omit, use sarracenia.Message constructor.
+  msg.sumflg       msg['identity']                    just omit, use sarracenia.Message constructor.
   msg.sumstr       v2wrapper.sumstrFromMessage(msg)   the literal string for a v2 checksum field.     
   parent.msg       worklist.incoming                  v2 is 1 message at a time, sr3 has lists or messages.
   ================ ================================== ==========================================================

--- a/docs/source/Reference/sr3.1.rst
+++ b/docs/source/Reference/sr3.1.rst
@@ -66,6 +66,7 @@ The type of action to take. One of:
  - disable:       mark a configuration as ineligible to run.
  - edit:          modify an existing configuration.
  - enable:        mark a configuration as eligible to run.
+ - features:      what parts of sr3 are working?
  - foreground: run a single instance in the foreground logging to stderr
  - list:          list all the configurations available.
  - list plugins:  list all the plugins available.

--- a/docs/source/Tutorials/Install.rst
+++ b/docs/source/Tutorials/Install.rst
@@ -30,6 +30,38 @@ For operational use, administrative access may be needed for package installatio
 and integration with systemd. Regardless of how it is installed, some periodic
 processing (on linux usually known as *cron jobs*) may also need to be configured.
 
+Some environments provide sarracenia, but the installation can be incomplete, in
+that, some environments do not provide for libraries that sarracenia depends on.
+To know what features your installation has, use the *features* command::
+
+    fractal% sr3 features
+    
+    Status:    feature:   python imports:      Description:
+    Installed  amqp       amqp                 can connect to rabbitmq brokers
+    Installed  appdirs    appdirs              place configuration and state files appropriately for platform (windows/mac/linux)
+    Installed  filetypes  magic                able to set content headers
+    Installed  ftppoll    dateparser,pytz      able to poll with ftp
+    Installed  humanize   humanize             humans numbers that are easier to read.
+    Absent     mqtt       paho.mqtt.client     cannot connect to mqtt brokers
+    Installed  redis      redis,redis_lock     can use redis implementations of retry and nodupe
+    Installed  sftp       paramiko             can use sftp or ssh based services
+    Installed  vip        netifaces            able to use the vip option for high availability clustering
+    Installed  watch      watchdog             watch directories
+    Installed  xattr      xattr                on linux, will store file metadata in extended attributes
+    MISSING    clamd      pyclamd              cannot use clamd to av scan files transferred
+    
+     state dir: /home/peter/.cache/sr3
+     config dir: /home/peter/.config/sr3
+    
+    fractal%
+    
+Each feature is explained, and the status is indicated. Note that plugins
+can also declare the extra libraries they need. Each feature depends on the python imports
+listed in the third column. Making those libraries available to the python environment
+will activate the given feature.
+
+For example, if "paramiko" is installed, support for SFTP polls and transfers will start
+working.
 
 
 Client Installation
@@ -41,6 +73,11 @@ launchpad repository. If you cannot use debian packages, then consider pip packa
 avialable from PyPI. In both cases, the other python packages (or dependencies) needed
 will be installed by the package manager automatically.
 
+Note that in some cases, the operating system does not provide all the required
+functionality for all features, so one can complement with pip packages, which
+can be installed system-wide, within a user's environment or even within 
+venv.  as long as *sr3 features* reports the feature as available, it will
+be used.
 
 
 Ubuntu/Debian (apt/dpkg) **Recommended**
@@ -53,6 +90,7 @@ On Ubuntu 22.04 and derivatives::
   sudo apt install metpx-sr3  # main python package.
   sudo apt install python3-magic # optional support putting file type content-type message headers.
   sudo apt install metpx-sr3c # optional C client.
+  sudo apt install python3-paramiko  # support SFTP (polls and transfers.)
   sudo apt install python3-amqp  # optionally support rabbitmq brokers
   sudo apt install python3-paho-mqtt  # optionally support MQTT brokers
   sudo apt install python3-netifaces # optionally support the vip directive (HA failover.)

--- a/docs/source/Tutorials/Install.rst
+++ b/docs/source/Tutorials/Install.rst
@@ -188,8 +188,10 @@ and to upgrade after the initial installation::
 
 NOTE:: 
 
-  On many systems where both pythons 2 and 3 are installed, you may need to specify pip3 rather than pip.
+  * On many systems where both pythons 2 and 3 are installed, you may need to specify pip3 rather than pip.
 
+  * on Windows, in order to get the filetype feature working, one will need to manually *pip install python-magic-bin*
+    see here for details: https://pypi.org/project/python-magic/
 
 System Startup and Shutdown
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/fr/CommentFaire/v2ASr3.rst
+++ b/docs/source/fr/CommentFaire/v2ASr3.rst
@@ -42,7 +42,7 @@ et sont plus flexibles et puissants que le mécanisme de v2.
  * Les classes v3 peuvent être sous-classées pour ajouter des fonctionnalités de base, comme un nouveau message
    de notification ou un protocole de transport de fichier.
 
-.. astuce::
+.. note::
   Il existe également quelques vidéos pas à pas sur Youtube montrant des ports simples v2 -> v3:
    - `Sender (10 min) <https://www.youtube.com/watch?v=rUazjoGzPac>`_
    - `Poll (20 min) <https://www.youtube.com/watch?v=P20M9ojn_Zw>`_
@@ -69,7 +69,7 @@ En bref, le point d’entrée sr3 est utilisé pour démarrer / arrêter / éval
 Dans sr3, on peut également utiliser des spécifications de style de globbing de fichier pour demander qu'une commande
 soit invoqué sur un groupe de configurations, alors que dans la v2, on ne pouvait fonctionner que sur une à la fois.
 
-.. caution::
+.. note::
   **sr3_post** est une exception à ce changement parce qu'il fonctionne comme sr_post de la v2, étant
   un outil d’affichage interactif.
 
@@ -186,13 +186,13 @@ En général, les plugins v3:
   Quoi qu’il en soit, une partie python naïve du fichier échouerait invariablement sans qu’une sorte de
   harnais de test ne soit enroulée autour d’elle.
 
-  .. Astuce:: Dans la v3, supprimez ces lignes (généralement situées au bas du fichier)
+  .. Note:: Dans la v3, supprimez ces lignes (généralement situées au bas du fichier)
 
   Dans la v2, il y avait des problèmes étranges avec les importations, ce qui a entraîné la mise en place
   d'importer des instructions à l’intérieur des fonctions. Ce problème est résolu dans la v3, vous pouvez
   vérifier votre syntaxe d’importation en faisant *import X* dans n’importe quel interpréteur python.
 
-  .. Astuce:: Placez les importations nécessaires au début du fichier, comme tout autre module python
+  .. Note:: Placez les importations nécessaires au début du fichier, comme tout autre module python
            **et supprimez les importations situées dans les fonctions lors du portage**.
 
 * **Les plugins v3 peuvent être utilisés par les programmeurs d’applications.** Les plugins ne sont pas
@@ -222,7 +222,7 @@ En général, les plugins v3:
   Lors du portage des plugins v2 -> v3 : *logger.x* remplace *parent.logger.x*.
   Parfois, il y a aussi self.logger x... je ne sais pas pourquoi... ne demandez pas.
   
-  .. Astuce:: Dans vi, vous pouvez utiliser le remplacement global pour effectuer un travail rapide lors du portage::
+  .. Note:: Dans vi, vous pouvez utiliser le remplacement global pour effectuer un travail rapide lors du portage::
   
              :%s/parent.logger/logger/g
 
@@ -242,7 +242,7 @@ En général, les plugins v3:
        super().__init__(options,logger)
        self.o.add_option('OptionName', Type, DefaultValue)
        
-  .. Astuce:: Dans VI, vous pouvez utiliser le remplacement global::
+  .. Note:: Dans VI, vous pouvez utiliser le remplacement global::
   
              :%s/parent/self.o/g
 
@@ -298,7 +298,7 @@ En général, les plugins v3:
   msg.exchange     msg['exchange']     le canal sur lequel le message à été reçu.
   msg.logger       logger              les journeaux fonctionnent ¨normalement" pour python
   msg.parts        msg['size']         oublie ca, utilise une constructeur de sarracenia.Message
-  msg.sumflg       msg['identity']    oublie ca, utilise une constructeur de sarracenia.Message
+  msg.sumflg       msg['identity']     oublie ca, utilise une constructeur de sarracenia.Message
   parent.msg       worklist.incoming   sr3 traite des groupe des messages, pas individuelement
   ================ =================== ===========================================================
 
@@ -643,7 +643,7 @@ exemples:
  * flowcb/poll/airnow.py
 
 on_html_page -> sous-classement de flowcb/poll
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Voici un plugin v2 nsa_mls_nrt.py:
 
@@ -945,7 +945,7 @@ Exemple de débogage des fonctions destfn sr3 ::
 
 
 v3 seulement: post,gather
-------------------------
+-------------------------
 
 Le polling/posting est en fait effectuée dans des classes de rappel de flux (flowcb).
 Le statut de sortie n’a pas d’importance, toutes ces routines seront appelées dans l’ordre.

--- a/docs/source/fr/Contribution/Développement.rst
+++ b/docs/source/fr/Contribution/Développement.rst
@@ -1704,3 +1704,55 @@ données elles-mêmes, et non des notifications ou des messages de rapport (ne s
 de rapport, cela devient une boucle infinie!) Pour le débogage et d’autres informations, le fichier
 journal local est utilisé.  Par exemple, sr_shovel n’émet aucun message sr_report(7), car aucune
 donnée n’est transférée, seulement des messages.
+
+
+Adding a New Dependency
+-----------------------
+
+Dependency Management is a complicated topic, because python has many different installation methods into disparate environments, and Sarracenia is multi-platform.  Standard python practice for dependencies is to make
+them *required* by listing them in requirements.txt or setup.py, and require all users to install them.
+In most python applications, if a dependency is missing, it just crashes with a import failure message
+of some kind.
+
+In Sr3, we have found that there are many different environments being deployed into where satisfying
+dependencies can be more trouble than they are worth, so each of the dependencies in setup.py are also
+dealt with in sarracenia/featuredetection, and the feature detection code allows the application to
+keep working, just without the functionality provided by the missing module. This is called *degradation*
+or *degraded mode*. The idea being to help the user do as much as they can, in the environment they have,
+while telling them what is missing, and what would ideally be added.
+  
+La gestion des dépendances est un sujet compliqué, car python a de nombreuses méthodes d'installation 
+différentes dans des environnements disparates, et Sarracenia est multi-plateforme. La pratique standard 
+de python pour les dépendances consiste à faire les *nécessaires* en les listant dans requirements.txt 
+ou setup.py, et demandez à tous les utilisateurs de les installer.  Dans la plupart des applications 
+python, si une dépendance est manquante, elle se bloque simplement avec un message d'échec d'importation
+de quelques sortes.
+
+Dans Sr3, nous avons constaté qu'il existe de nombreux environnements différents déployés dans lesquels
+les dépendances peuvent être plus gênantes qu'elles n'en valent la peine, donc chacune des dépendances 
+dans setup.py est également traité dans sarracenia/featuredetection, et le code de détection de 
+fonctionnalité permet à l'application de continuer à travailler, juste sans la fonctionnalité fournie 
+par le module manquant. C'est ce qu'on appelle la *dégradation* ou *mode dégradé*. L'idée étant 
+d'aider l'utilisateur à faire le maximum, dans l'environnement dont il dispose, tout en leur disant
+ce qui manque, et ce qu'il faudrait idéalement ajouter.
+
+pleine discussion (en anglais seulement): 
+
+`Managing Dependencies (Discussion) <https://github.com/MetPX/sarracenia/issues/741>`_
+
+version courte:
+
+En plus de requirements.dev/setup.py, si vous devez ajouter une nouvelle bibliothèque qui ne fait pas partie de
+*piles incluses*, généralement fournies par un package os ou pip séparé, alors vous voulez
+prévoir que sr3 fonctionne toujours dans le cas où le package n'est pas disponible (bien que
+sans la fonction que vous ajoutez) et pour ajouter un support pour expliquer ce qui manque en utilisant
+le module sarracenia/featuredetection.py.
+
+Dans ce module se trouve une structure de données *features*, où vous ajoutez une entrée expliquant 
+l'importation nécessaire et les fonctionnalités qu'il apporte à Sr3. Vous ajoutez également les 
+protections if feature['x']['present'] dans le code où vous utilisez la fonctionnalité, afin de 
+permettre au code de se dégrader avec élégance.
+
+Si la dépendance est ajoutée dans un plugin, alors il y a aussi une méthode pour celle décrite ici :
+
+`Guide de Programmeur<../Explication/SarraPluginDev.html#ajout-de-dependance-python-dans-les-callbacks>`_

--- a/docs/source/fr/Contribution/Développement.rst
+++ b/docs/source/fr/Contribution/Développement.rst
@@ -1500,11 +1500,26 @@ Création d’un programme d’installation Windows
 On peut également construire un programme d’installation Windows avec cela
 `script <https://github.com/MetPX/sarracenia/blob/main/generate-win-installer.sh>`_.
 Il doit être exécuté à partir d’un système d’exploitation Linux (de préférence Ubuntu 18)
-dans le répertoire racine de git de Sarracenia. Ensuite, à partir du shell, exécutez ::
+dans le répertoire racine de git de Sarracenia. 
+
+déterminer la version de python::
+
+    fractal% python -V
+    Python 3.10.12
+    fractal%
+
+
+C'est donc python 3.10. Une seule version mineure aura le package intégré nécessaire
+par pynsist pour construire l'exécutable. On valide chez::
+
+   https://www.python.org/downloads/windows/
+
+afin to confirmer que la version avec un binaire *embedded* pour 3.10 et le 3.10.11
+Ensuite, à partir du shell, exécutez ::
 
  sudo apt install nsis
  pip3 install pynsist wheel
- ./generate-win-installer.sh 2>&1 > log.txt
+ ./generate-win-installer.sh 3.10.11 2>&1 > log.txt
 
 Le paquet final doit être placé dans le répertoire build/nsis.
 

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -7,9 +7,6 @@
 Travailler avec des plugins
 ---------------------------
 
-Enregistrement de révision
---------------------------
-
 :version: |release|
 :date: |today|
 
@@ -77,9 +74,6 @@ La structure de données de liste de travail est un ensemble de listes de messag
   * worklist.failed : messages pour lesquels le traitement a été tenté, mais qui a échoué.
 
 La liste de travail est transmise aux plugins *after_accept* et *after_work* comme détaillé dans la section suivante.
-
-
-~~~~~~~~~~~~~~~~~~~~
 
 Tous les composants (post, subscribe, sarra, sender, shovel, watch, winnow)
 partagent du code substantiel et ne diffèrent que par les paramètres de défaut.  L’algorithme de flux est :
@@ -849,12 +843,8 @@ les routines after_accept acceptent une liste de travail comme argument.
 
 
 
-Le Dépendance Python dans les Callbacks
-+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Some callbacks need to use other python modules.  While normal imports
-are fine, one can integrate them better for sr3 users by supporting
-the *features* mechism
+Ajout de Dépendance Python dans les Callbacks
+---------------------------------------------
 
 Certains *callback* doivent utiliser d'autres modules Python. Alors que les 
 importations normales sont bien, on peut mieux les intégrer pour les 
@@ -873,11 +863,6 @@ utilisateurs sr3 en prenant en se servant du mécanisme *features* ::
         features['clamd']['present'] = True
     except:
         features['clamd']['present'] = False
-
-This lets users know which *features* are available in their installetion
-so when they run *sr3 features* it provides an easily understood list of missing
-libraries
-
 
 Cela permet aux utilisateurs de savoir quelles *features* sont disponibles dans leur installation.
 Lorsqu'ils exécutent *sr3 features*, sr3 fournit une liste facile à comprendre des éléments manquants::

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -43,9 +43,6 @@ Il existe d’autres façons d’étendre Sarracenia v3 en sous-classant :
 
 Cela sera discuté après que les rappels auront été traités.
 
-Introduction
-------------
-
 Une pompe de données Sarracenia est un serveur Web avec des notifications pour les abonnés à
 savoir, rapidement, quand de nouvelles données sont arrivées. Pour savoir quelles données sont déjà
 disponible sur une pompe, visualisez l’arbre avec un navigateur web.  Pour de besoins simple et immédiats,
@@ -849,6 +846,70 @@ les routines after_accept acceptent une liste de travail comme argument.
    **FIXME**: peut-être montrer un moyen de vérifier l’en-tête des pièces
    avec une instruction afin d’agir uniquement sur le message de première partie
    pour les fichiers longs.
+
+
+
+Le Dépendance Python dans les Callbacks
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some callbacks need to use other python modules.  While normal imports
+are fine, one can integrate them better for sr3 users by supporting
+the *features* mechism
+
+Certains *callback* doivent utiliser d'autres modules Python. Alors que les 
+importations normales sont bien, on peut mieux les intégrer pour les 
+utilisateurs sr3 en prenant en se servant du mécanisme *features* ::
+
+    from sarracenia.featuredetection import features
+    #
+    # Support for features inventory mechanism.
+    #
+    features['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
+            'lament' : 'cannot use clamd to av scan files transferred',
+            'rejoice' : 'can use clamd to av scan files transferred' }
+
+    try:
+        import pyclamd
+        features['clamd']['present'] = True
+    except:
+        features['clamd']['present'] = False
+
+This lets users know which *features* are available in their installetion
+so when they run *sr3 features* it provides an easily understood list of missing
+libraries
+
+
+Cela permet aux utilisateurs de savoir quelles *features* sont disponibles dans leur installation.
+Lorsqu'ils exécutent *sr3 features*, sr3 fournit une liste facile à comprendre des éléments manquants::
+
+    fractal% sr3 features
+    2023-08-07 13:18:09,219 1993037 [INFO] sarracenia.flow loadCallbacks flowCallback plugins to load: ['sarracenia.flowcb.retry.Retry', 'sarracenia.flowcb.housekeeping.resources.Resources', 'dcpflow', 'log', 'post.message', 'clamav']
+    2023-08-07 13:18:09,224 1993037 [INFO] dcpflow __init__ really I mean hi
+    2023-08-07 13:18:09,224 1993037 [WARNING] sarracenia.config add_option multiple declarations of lrgs_download_redundancy=['Yes', 'on'] choosing last one: on
+    2023-08-07 13:18:09,225 1993037 [INFO] dcpflow __init__  lrgs_download_redundancy is True
+    2023-08-07 13:18:09,225 1993037 [INFO] sarracenia.flowcb.log __init__ flow initialized with: {'post', 'on_housekeeping', 'after_work', 'after_accept', 'after_post'}
+    2023-08-07 13:18:09,226 1993037 [CRITICAL] sarracenia.flow loadCallbacks flowCallback plugin clamav did not load: 'pyclamd'
+
+    Status:    feature:   python imports:      Description:
+    Installed  amqp       amqp                 can connect to rabbitmq brokers
+    Installed  appdirs    appdirs              place configuration and state files appropriately for platform (windows/mac/linux)
+    Installed  filetypes  magic                able to set content headers
+    Installed  ftppoll    dateparser,pytz      able to poll with ftp
+    Installed  humanize   humanize             humans numbers that are easier to read.
+    Absent     mqtt       paho.mqtt.client     cannot connect to mqtt brokers
+    Installed  redis      redis,redis_lock     can use redis implementations of retry and nodupe
+    Installed  sftp       paramiko             can use sftp or ssh based services
+    Installed  vip        netifaces            able to use the vip option for high availability clustering
+    Installed  watch      watchdog             watch directories
+    Installed  xattr      xattr                on linux, will store file metadata in extended attributes
+    MISSING    clamd      pyclamd              cannot use clamd to av scan files transferred
+
+     state dir: /home/peter/.cache/sr3
+     config dir: /home/peter/.config/sr3
+
+On peut voir que le module Python *pyclamed* nécessary pour que le *callback* fonctionne n´est pas
+installé.
+
 
 Idées d’extension
 -----------------

--- a/docs/source/fr/Tutoriel/Installer.rst
+++ b/docs/source/fr/Tutoriel/Installer.rst
@@ -31,6 +31,36 @@ Pour une utilisation opérationnelle, un accès administratif peut être nécess
 et l’intégration avec systemd. Quelle que soit la façon dont il est installé, du traitement
 périodique (sur Linux généralement connu sous le nom de *cron jobs*) peut également avoir besoin d’être configuré.
 
+Des fois, Sarracenia peut être partiellement installé. Pour voir un inventaire des modules de Sarracenia
+qui sont disponible, on peut se servir de *sr3 features*::
+
+    fractal% sr3 features
+
+    Status:    feature:   python imports:      Description:
+    Installed  amqp       amqp                 can connect to rabbitmq brokers
+    Installed  appdirs    appdirs              place configuration and state files appropriately for platform (windows/mac/linux)
+    Installed  filetypes  magic                able to set content headers
+    Installed  ftppoll    dateparser,pytz      able to poll with ftp
+    Installed  humanize   humanize             humans numbers that are easier to read.
+    Absent     mqtt       paho.mqtt.client     cannot connect to mqtt brokers
+    Installed  redis      redis,redis_lock     can use redis implementations of retry and nodupe
+    Installed  sftp       paramiko             can use sftp or ssh based services
+    Installed  vip        netifaces            able to use the vip option for high availability clustering
+    Installed  watch      watchdog             watch directories
+    Installed  xattr      xattr                on linux, will store file metadata in extended attributes
+    MISSING    clamd      pyclamd              cannot use clamd to av scan files transferred
+
+     state dir: /home/peter/.cache/sr3
+     config dir: /home/peter/.config/sr3
+
+    fractal%
+
+le sens de chaque *feature* est expliqué (en anglais) et le modules python nécessaire pour 
+permettre cette fonctionalité sont indiqué dans la troisième colonne.
+
+Dans l´exemple on peut voir que pyclamd manque à l´appel, tandis que *paramiko* nécessaire
+pour la fonctionallité SFTP est disponible.
+
 Installation Client
 -------------------
 
@@ -39,6 +69,13 @@ ils sont disponibles, les paquets debian sont recommandés. Ceux-ci peuvent êtr
 référentiel launchpad. Si vous ne pouvez pas utiliser les paquets Debian, envisagez les paquets pip
 avialable de PyPI. Dans les deux cas, les autres paquets python (ou dépendances) nécessaires
 seront installé automatiquement par le gestionnaire de paquets.
+
+Notez que dans certains cas, le système d'exploitation ne fournit pas tous les
+fonctionnalité pour toutes les fonctionnalités, de sorte que l'on peut compléter avec des packages pip, qui
+peut être installé à l'échelle du système, dans l'environnement d'un utilisateur ou même dans
+venv. Tant que *sr3 features* signale la fonctionnalité comme disponible, elle
+être utilisé.
+
 
 
 Ubuntu/Debian (apt/dpkg) **Recommandé**
@@ -51,6 +88,7 @@ Sur Ubuntu 22.04 et dérivés du même::
   sudo apt install metpx-sr3  # pacquet principale.
   sudo apt install metpx-sr3c # client binaire (en C) .
   sudo apt install python3-amqp  # support optionnel pour les courtiers AMWP (rabbitmq)
+  sudo apt install python3-paramiko  # support optionnel pour SFTP/SSH 
   sudo apt install python3-magic  # support optionnel pour les entêtes "content-type" dans les messages
   sudo apt install python3-paho-mqtt  # support optionnel pour les courtiers MQTT 
   sudo apt install python3-netifaces # support optionnel pour les vip (haut-disponibilité)
@@ -123,14 +161,14 @@ Par exemple, sur fedora 28 obligatoirement::
   $ sudo dnf install python3-humanize
   $ sudo dnf install python3-psutil
   $ sudo dnf install python3-watchdog
-  $ sudo dnf install python3-paramiko  
 
 Facultatifs::
 
-  $ sudo dnf install python3-amqp   # optionally support rabbitmq brokers
-  $ sudo dnf install python3-magic   # optionally support content-type headers in files.
-  $ sudo dnf install python3-netifaces # optionally support vip directive for HA.
-  $ sudo dnf install python3-paho-mqtt # optionally support mqtt brokers
+  $ sudo dnf install python3-paramiko  # support pour SFTP/SSH
+  $ sudo dnf install python3-amqp   # support pour les messages AMQP (couriers rabbitmq)
+  $ sudo dnf install python3-magic   # support optionnel pour le champs ¨content-type¨  
+  $ sudo dnf install python3-netifaces # support optionnel pour l´optio vip
+  $ sudo dnf install python3-paho-mqtt # support optionnel pour les courtiers MQTT 
 
   $ sudo dnf install python3-setuptools # needed to build rpm package.
 

--- a/docs/source/fr/Tutoriel/Installer.rst
+++ b/docs/source/fr/Tutoriel/Installer.rst
@@ -173,9 +173,12 @@ et à mettre à niveau après l’installation initiale::
 
 * Pour installer à l’échelle du serveur sur un serveur Linux, préfixez avec *sudo*
 
-REMARQUE::
+NOTE::
 
-  Sur de nombreux systèmes sur lesquels pythons 2 et 3 sont installés, vous devrez peut-être spécifier pip3 plutôt que pip.
+  * Sur de nombreux systèmes sur lesquels pythons 2 et 3 sont installés, vous devrez peut-être spécifier pip3 plutôt que pip.
+
+  * En Windows, pour que la fonction de type de fichier fonctionne, il faut manuellement *pip install python-magic-bin*
+    Pour plus de détails : https://pypi.org/project/python-magic/
 
 Démarrage et arrêt du système
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/generate-win-installer.sh
+++ b/generate-win-installer.sh
@@ -1,4 +1,36 @@
-#!/bin/bash
+#/bin/bash
+
+# so... if you invoke this without arguments it often fails with:
+#
+# Downloading embeddable Python build...
+#Getting https://www.python.org/ftp/python/3.10.12/python-3.10.12-embed-amd64.zip
+#Traceback (most recent call last):
+#  File "/home/peter/.local/bin/pynsist", line 8, in <module>
+#    sys.exit(main())
+#  File "/home/peter/.local/lib/python3.10/site-packages/nsist/__init__.py", line 533, in main
+#    ec = InstallerBuilder(**args).run(makensis=(not options.no_makensis))
+#  File "/home/peter/.local/lib/python3.10/site-packages/nsist/__init__.py", line 475, in run
+#    self.fetch_python_embeddable()
+#  File "/home/peter/.local/lib/python3.10/site-packages/nsist/__init__.py", line 205, in fetch_python_embeddable
+#    download(url, cache_file)
+#  File "/home/peter/.local/lib/python3.10/site-packages/nsist/util.py", line 22, in download
+#    r.raise_for_status()
+#  File "/home/peter/.local/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
+#    raise HTTPError(http_error_msg, response=self)
+#requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://www.python.org/ftp/python/3.10.12/python-3.10.12-embed-amd64.zip
+#
+#
+#  you need to visit https://www.python.org/downloads/windows/
+#
+#  And look for the minor version that they announce has the AMD64 embedded package...
+#
+#  hunting for python 3.10, we see it is 3.10.9 that is blessed, so call the thing with that version:
+#
+#  ./generate_win_installer 3.10.9
+#
+#  and it should find it.
+#
+
 set -e
 
 # Windows specific pkgs
@@ -9,9 +41,15 @@ cd pynsist_pkgs/
 # Ensure to download only windows binaries
 pip3 download amqp --only-binary=:all: --platform win_amd64
 pip3 download appdirs --only-binary=:all: --platform win_amd64
-pip3 download netifaces --only-binary=:all: --platform win_amd64
-#pip3 download netifaces-w38 --only-binary=:all: --platform win_amd64
-pip3 download pika --only-binary=:all: --platform win_amd64
+pip3 download humanfriendly --only-binary=:all: --platform win_amd64
+
+# these are often missing... means vip will be disabled.
+#pip3 download netifaces --only-binary=:all: --platform win_amd64
+#pip3 download netifaces-w39 --only-binary=:all: --platform win_amd64
+
+# not used anymore.
+#pip3 download pika --only-binary=:all: --platform win_amd64
+
 pip3 download psutil --only-binary=:all: --platform win_amd64
 pip3 download paramiko --only-binary=:all: --platform win_amd64
 pip3 download regex --only-binary=:all: --platform win_amd64
@@ -28,6 +66,7 @@ pip3 download humanize --only-binary=:all: --platform win_amd64
 #pip3 download pycparser --only-binary=:all: --platform win_amd64
 #pip3 download pathtools --only-binary=:all: --platform win_amd64
 pip3 download watchdog --only-binary=:all: --platform win_amd64
+pip3 download python-magic-bin --only-binary=:all: --platform win_amd64
 
 cd ..
 
@@ -41,7 +80,7 @@ if [ "$1" ]; then
 else
     PYVERSION="`python3 -V| awk '{ print $2; }'`"
 fi
-VERSION=`grep __version__ sarracenia/__init__.py | cut -c15- | sed -e 's/"//g'`
+VERSION=`grep __version__ sarracenia/_version.py | cut -c15- | sed -e 's/"//g'`
 
 sed 's/__version__/'$VERSION'/; s/__pyversion__/'$PYVERSION'/;' <win_installer.cfg.tem >win_installer.cfg
 # NSIS packaging

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -474,7 +474,7 @@ class Message(dict):
         if lstat :
             if os_stat.S_ISREG(lstat.st_mode):
                 m.__computeIdentity(path, o)
-                if extras['filetypes']['present']:
+                if features['filetypes']['present']:
                     try:
                         t = magic.from_file(path,mime=True)
                         m['contentType'] = t
@@ -796,11 +796,11 @@ class Message(dict):
   Extra Feature Scanning and Enablement.
 
   checking for extra dependencies, not "hard" dependencies ("requires")
-  listed as extras in setup.py and omitted entirely from debian packaging.
+  listed as features in setup.py and omitted entirely from debian packaging.
   this allows installation with fewer dependencies ahead of time, and then
   provide some messaging to users when they "need" an optional dependency.
  
-  optional extras can be enabled using pip install metpx-sr3[extra]
+  optional features can be enabled using pip install metpx-sr3[extra]
   where extra is one of the features listed below. Alternatively,
   one can just install the modules that are needed and the functionality
   will be enabled after a component restart.
@@ -814,7 +814,7 @@ class Message(dict):
   watch - monitor files or directories for changes.
 
 """
-extras = { 
+features = { 
         'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 
             'lament' : 'cannot connect to rabbitmq brokers', 
             'rejoice' : 'can connect to rabbitmq brokers' },
@@ -845,33 +845,33 @@ extras = {
            'rejoice': 'watch directories' }
 }
 
-for x in extras:
+for x in features:
    
-   extras[x]['present']=True
-   for y in  extras[x]['modules_needed']:
+   features[x]['present']=True
+   for y in  features[x]['modules_needed']:
        try:
            if importlib.util.find_spec( y ):
                #logger.debug( f'found feature {y}, enabled') 
                pass
            else:
                logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
-               extras[x]['present']=False
+               features[x]['present']=False
        except:
            logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
-           extras[x]['present']=False
+           features[x]['present']=False
 
 
-if extras['filetypes']['present']:
+if features['filetypes']['present']:
    import magic
 
-if extras['mqtt']['present']:
+if features['mqtt']['present']:
    import paho.mqtt.client
    if not hasattr( paho.mqtt.client, 'MQTTv5' ):
        # without v5 support, mqtt is not useful.
-       extras['mqtt']['present'] = False
+       features['mqtt']['present'] = False
 
 # if humanize is not present, compensate...
-if extras['humanize']['present']:
+if features['humanize']['present']:
     import humanize
 
     def naturalSize( num ):
@@ -889,7 +889,7 @@ else:
        return "%g" % dur
 
 
-if extras['appdirs']['present']:
+if features['appdirs']['present']:
     import appdirs
 
     def site_config_dir( app, author ):

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -26,6 +26,7 @@
 #
 from ._version import __version__
 
+
 from base64 import b64decode, b64encode
 import calendar
 import datetime
@@ -33,10 +34,9 @@ import importlib.util
 import logging
 import os
 import os.path
-import paramiko
 import random
 import re
-import sarracenia.filemetadata
+from sarracenia.featuredetection import features
 import stat as os_stat
 import sys
 import time
@@ -60,6 +60,65 @@ def baseUrlParse( url ):
             u.path = u.path[1:]
     return u
 
+
+if features['filetypes']['present']:
+   import magic
+
+if features['mqtt']['present']:
+   import paho.mqtt.client
+   if not hasattr( paho.mqtt.client, 'MQTTv5' ):
+       # without v5 support, mqtt is not useful.
+       features['mqtt']['present'] = False
+
+# if humanize is not present, compensate...
+if features['humanize']['present']:
+    import humanize
+
+    def naturalSize( num ):
+        return humanize.naturalsize(num,binary=True)
+
+    def naturalTime( dur ):
+        return humanize.naturaltime(dur)
+
+else:
+  
+    def naturalSize( num ):
+       return "%g" % num
+
+    def naturalTime( dur ):
+       return "%g" % dur
+
+
+if features['appdirs']['present']:
+    import appdirs
+
+    def site_config_dir( app, author ):
+        return appdirs.site_config_dir( app, author )
+
+    def user_config_dir( app, author ):
+        return appdirs.user_config_dir( app, author )
+
+    def user_cache_dir( app, author ):
+        return appdirs.user_cache_dir( app, author )
+else:
+    # if appdirs is missing, pretend we're on Linux.
+    import pathlib
+
+    def site_config_dir( app, author ):
+        return '/etc/xdg/xdg-ubuntu-xorg/%s' % app
+
+    def user_config_dir( app, author ):
+        return str(pathlib.Path.home()) + '/.config/%s' % app
+ 
+    def user_cache_dir( app, author ):
+        return str(pathlib.Path.home()) + '/.cache/%s' % app
+
+"""
+ end of extra feature scan. 
+
+"""
+
+import sarracenia.filemetadata
 
 class Sarracenia:
     """
@@ -96,12 +155,15 @@ class Sarracenia:
         m = sarracenia.Message.fromFileInfo( path, options, lstat )
     
         where you can make up the lstat values to fill in some fields in the message.
-        You can make a fake lstat structure to provide these values using paramiko.SFTPAttributes 
+        You can make a fake lstat structure to provide these values using sarracenia.filemetadata
+        class which is either an alias for paramiko.SFTPAttributes 
+        ( https://docs.paramiko.org/en/latest/api/sftp.html#paramiko.sftp_attr.SFTPAttributes )
+        if paramiko is installed, or a simple emulation if not.
     
     
-        import paramiko
+        from  sarracenia.filemetadata import FmdStat
     
-        lstat = paramiko.SFTPAttributes()
+        lstat = FmdStat()
         lstat.st_mtime= utcinteger second count in UTC (numeric version of a Sarracenia timestamp.)
         lstat.st_atime=
         lstat.st_mode=0o644
@@ -169,7 +231,7 @@ class TimeConversions:
     pass
 
 
-def stat( path ) -> paramiko.SFTPAttributes:
+def stat( path ) -> sarracenia.filemetadata.FmdStat:
     """
        os.stat call replacement which improves on it by returning
        and SFTPAttributes structure, in place of the OS stat one,
@@ -181,17 +243,19 @@ def stat( path ) -> paramiko.SFTPAttributes:
     """
     native_stat = os.stat( path )
     
-    sa = paramiko.SFTPAttributes()
+    sa = sarracenia.filemetadata.FmdStat()
     sa.st_mode = native_stat.st_mode
     sa.st_ino = native_stat.st_ino
-    sa.st_dev  = native_stat.st_dev 
-    sa.st_nlink  = native_stat.st_nlink 
-    sa.st_uid  = native_stat.st_uid 
-    sa.st_gid  = native_stat.st_gid 
-    sa.st_size  = native_stat.st_size 
+    sa.st_dev  = native_stat.st_dev
+    # st_nlink does not exist in paramiko.SFTPAttributes()
+    #  FmdStat comes from that type.
+    #sa.st_nlink  = native_stat.st_nlink
+    sa.st_uid  = native_stat.st_uid
+    sa.st_gid  = native_stat.st_gid
+    sa.st_size  = native_stat.st_size
 
-    sa.st_mtime = os.path.getmtime(path)    
-    sa.st_atime = os.path.getctime(path)    
+    sa.st_mtime = os.path.getmtime(path)
+    sa.st_atime = os.path.getctime(path)
     sa.st_ctime = native_stat.st_atime
     return sa
 
@@ -792,124 +856,3 @@ class Message(dict):
         with urllib.request.urlopen(retUrl) as response:
             return response.read()
 
-"""
-  Extra Feature Scanning and Enablement.
-
-  checking for extra dependencies, not "hard" dependencies ("requires")
-  listed as features in setup.py and omitted entirely from debian packaging.
-  this allows installation with fewer dependencies ahead of time, and then
-  provide some messaging to users when they "need" an optional dependency.
- 
-  optional features can be enabled using pip install metpx-sr3[extra]
-  where extra is one of the features listed below. Alternatively,
-  one can just install the modules that are needed and the functionality
-  will be enabled after a component restart.
-  
-  amqp - ability to communicate with AMQP (rabbitmq) brokers
-  mqtt - ability to communicate with MQTT brokers
-  filetypes - ability to
-  ftppoll - ability to poll FTP servers
-  vip  - enable vip (Virtual IP) settings to implement singleton processing
-         for high availability support.
-  watch - monitor files or directories for changes.
-
-"""
-features = { 
-        'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 
-            'lament' : 'cannot connect to rabbitmq brokers', 
-            'rejoice' : 'can connect to rabbitmq brokers' },
-   'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False, 
-           'lament' : 'assume linux file placement under home dir', 
-           'rejoice': 'place configuration and state files appropriately for platform (windows/mac/linux)', },
-   'ftppoll' : { 'modules_needed': ['dateparser', 'pytz'], 'present': False, 
-       'lament' : 'not able to poll with ftp' ,
-       'rejoice' : 'able to poll with ftp' },
-   'humanize' : { 'modules_needed': ['humanize' ], 'present': False, 
-           'lament': 'humans will have to read larger, uglier numbers',
-           'rejoice': 'humans numbers that are easier to read.' },
-   'mqtt' : { 'modules_needed': ['paho.mqtt.client'], 'present': False, 
-           'lament': 'cannot connect to mqtt brokers' ,
-           'rejoice': 'can connect to mqtt brokers' },
-   'filetypes' : { 'modules_needed': ['magic'], 'present': False, 
-           'lament': 'will not be able to set content headers' ,
-           'rejoice': 'able to set content headers' },
-   'redis' : { 'modules_needed': [ 'redis', 'redis_lock' ],
-        'lament': 'cannot use redis implementations of retry and nodupe',
-        'rejoice': 'can use redis implementations of retry and nodupe'
-        },
-   'vip'  : { 'modules_needed': ['netifaces'] , 'present': False, 
-           'lament': 'will not be able to use the vip option for high availability clustering' ,
-           'rejoice': 'able to use the vip option for high availability clustering' },
-   'watch'  : { 'modules_needed': ['watchdog'] , 'present': False, 
-           'lament': 'cannot watch directories' ,
-           'rejoice': 'watch directories' }
-}
-
-for x in features:
-   
-   features[x]['present']=True
-   for y in  features[x]['modules_needed']:
-       try:
-           if importlib.util.find_spec( y ):
-               #logger.debug( f'found feature {y}, enabled') 
-               pass
-           else:
-               logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
-               features[x]['present']=False
-       except:
-           logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
-           features[x]['present']=False
-
-
-if features['filetypes']['present']:
-   import magic
-
-if features['mqtt']['present']:
-   import paho.mqtt.client
-   if not hasattr( paho.mqtt.client, 'MQTTv5' ):
-       # without v5 support, mqtt is not useful.
-       features['mqtt']['present'] = False
-
-# if humanize is not present, compensate...
-if features['humanize']['present']:
-    import humanize
-
-    def naturalSize( num ):
-        return humanize.naturalsize(num,binary=True)
-
-    def naturalTime( dur ):
-        return humanize.naturaltime(dur)
-
-else:
-  
-    def naturalSize( num ):
-       return "%g" % num
-
-    def naturalTime( dur ):
-       return "%g" % dur
-
-
-if features['appdirs']['present']:
-    import appdirs
-
-    def site_config_dir( app, author ):
-        return appdirs.site_config_dir( app, author )
-
-    def user_config_dir( app, author ):
-        return appdirs.user_config_dir( app, author )
-
-    def user_cache_dir( app, author ):
-        return appdirs.user_cache_dir( app, author )
-else:
-    # if appdirs is missing, pretend we're on Linux.
-    import pathlib
-
-    def site_config_dir( app, author ):
-        return '/etc/xdg/xdg-ubuntu-xorg/%s' % app
-
-    def user_config_dir( app, author ):
-        return str(pathlib.Path.home()) + '/.config/%s' % app
- 
-    def user_cache_dir( app, author ):
-        return str(pathlib.Path.home()) + '/.cache/%s' % app
- 

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -815,14 +815,34 @@ class Message(dict):
 
 """
 extras = { 
-   'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 'lament' : 'will not be able to connect to rabbitmq brokers' },
-   'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False, 'lament' : 'will assume linux file placement under home dir' },
-   'ftppoll' : { 'modules_needed': ['dateparser', 'pytz'], 'present': False, 'lament' : 'will not be able to poll with ftp' },
-   'humanize' : { 'modules_needed': ['humanize' ], 'present': False, 'lament': 'humans will have to read larger, uglier numbers' },
-   'mqtt' : { 'modules_needed': ['paho.mqtt.client'], 'present': False, 'lament': 'will not be able to connect to mqtt brokers' },
-   'filetypes' : { 'modules_needed': ['magic'], 'present': False, 'lament': 'will not be able to set content headers' },
-   'vip'  : { 'modules_needed': ['netifaces'] , 'present': False, 'lament': 'will not be able to use the vip option for high availability clustering' },
-   'watch'  : { 'modules_needed': ['watchdog'] , 'present': False, 'lament': 'cannot watch directories' }
+        'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 
+            'lament' : 'cannot connect to rabbitmq brokers', 
+            'rejoice' : 'can connect to rabbitmq brokers' },
+   'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False, 
+           'lament' : 'assume linux file placement under home dir', 
+           'rejoice': 'place configuration and state files appropriately for platform (windows/mac/linux)', },
+   'ftppoll' : { 'modules_needed': ['dateparser', 'pytz'], 'present': False, 
+       'lament' : 'not able to poll with ftp' ,
+       'rejoice' : 'able to poll with ftp' },
+   'humanize' : { 'modules_needed': ['humanize' ], 'present': False, 
+           'lament': 'humans will have to read larger, uglier numbers',
+           'rejoice': 'humans numbers that are easier to read.' },
+   'mqtt' : { 'modules_needed': ['paho.mqtt.client'], 'present': False, 
+           'lament': 'cannot connect to mqtt brokers' ,
+           'rejoice': 'can connect to mqtt brokers' },
+   'filetypes' : { 'modules_needed': ['magic'], 'present': False, 
+           'lament': 'will not be able to set content headers' ,
+           'rejoice': 'able to set content headers' },
+   'redis' : { 'modules_needed': [ 'redis', 'redis_lock' ],
+        'lament': 'cannot use redis implementations of retry and nodupe',
+        'rejoice': 'can use redis implementations of retry and nodupe'
+        },
+   'vip'  : { 'modules_needed': ['netifaces'] , 'present': False, 
+           'lament': 'will not be able to use the vip option for high availability clustering' ,
+           'rejoice': 'able to use the vip option for high availability clustering' },
+   'watch'  : { 'modules_needed': ['watchdog'] , 'present': False, 
+           'lament': 'cannot watch directories' ,
+           'rejoice': 'watch directories' }
 }
 
 for x in extras:
@@ -840,7 +860,6 @@ for x in extras:
            logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
            extras[x]['present']=False
 
-# Some sort of graceful fallback, or good messaging for when dependencies are missing.
 
 if extras['filetypes']['present']:
    import magic

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -578,7 +578,7 @@ class Config:
 
     actions = [
         'add', 'cleanup', 'convert', 'devsnap', 'declare', 'disable', 'dump', 'edit',
-        'enable', 'foreground', 'log', 'list', 'remove', 'restart', 'run', 'sanity',
+        'enable', 'extras', 'foreground', 'log', 'list', 'remove', 'restart', 'run', 'sanity',
         'setup', 'show', 'start', 'stop', 'status', 'overview'
     ]
 

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -578,7 +578,7 @@ class Config:
 
     actions = [
         'add', 'cleanup', 'convert', 'devsnap', 'declare', 'disable', 'dump', 'edit',
-        'enable', 'extras', 'foreground', 'log', 'list', 'remove', 'restart', 'run', 'sanity',
+        'enable', 'features', 'foreground', 'log', 'list', 'remove', 'restart', 'run', 'sanity',
         'setup', 'show', 'start', 'stop', 'status', 'overview'
     ]
 
@@ -1882,8 +1882,8 @@ class Config:
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
 
-        if self.vip and not sarracenia.extras['vip']['present']:
-            logger.critical( f"vip feature requested, but library: {' '.join(sarracenia.extras['vip']['modules_needed'])} " )
+        if self.vip and not sarracenia.features['vip']['present']:
+            logger.critical( f"vip feature requested, but library: {' '.join(sarracenia.features['vip']['modules_needed'])} " )
             sys.exit(1)
 
     def check_undeclared_options(self):
@@ -2454,7 +2454,7 @@ def default_config():
     cfg.currentDir = None
     cfg.override(default_options)
     cfg.override(sarracenia.moth.default_options)
-    if sarracenia.extras['amqp']['present']:
+    if sarracenia.features['amqp']['present']:
         cfg.override(sarracenia.moth.amqp.default_options)
     cfg.override(sarracenia.flow.default_options)
 
@@ -2475,7 +2475,7 @@ def no_file_config():
     cfg.currentDir = None
     cfg.override(default_options)
     cfg.override(sarracenia.moth.default_options)
-    if sarracenia.extras['amqp']['present']:
+    if sarracenia.features['amqp']['present']:
         cfg.override(sarracenia.moth.amqp.default_options)
     cfg.override(sarracenia.flow.default_options)
     cfg.cfg_run_dir = '.'

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -51,6 +51,7 @@ if sys.version_info[0] >= 3 and sys.version_info[1] < 8:
 
 import sarracenia
 from sarracenia import durationToSeconds, site_config_dir, user_config_dir, user_cache_dir
+from sarracenia.featuredetection import features
 import sarracenia.credentials
 import sarracenia.flow
 import sarracenia.flowcb
@@ -1882,8 +1883,8 @@ class Config:
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
 
-        if self.vip and not sarracenia.features['vip']['present']:
-            logger.critical( f"vip feature requested, but library: {' '.join(sarracenia.features['vip']['modules_needed'])} " )
+        if self.vip and not features['vip']['present']:
+            logger.critical( f"vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )
             sys.exit(1)
 
     def check_undeclared_options(self):
@@ -2454,7 +2455,7 @@ def default_config():
     cfg.currentDir = None
     cfg.override(default_options)
     cfg.override(sarracenia.moth.default_options)
-    if sarracenia.features['amqp']['present']:
+    if features['amqp']['present']:
         cfg.override(sarracenia.moth.amqp.default_options)
     cfg.override(sarracenia.flow.default_options)
 
@@ -2475,7 +2476,7 @@ def no_file_config():
     cfg.currentDir = None
     cfg.override(default_options)
     cfg.override(sarracenia.moth.default_options)
-    if sarracenia.features['amqp']['present']:
+    if features['amqp']['present']:
         cfg.override(sarracenia.moth.amqp.default_options)
     cfg.override(sarracenia.flow.default_options)
     cfg.cfg_run_dir = '.'

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -1,0 +1,106 @@
+#
+# This file is part of sarracenia.
+# The sarracenia suite is Free and is proudly provided by the Government of Canada
+# Copyright (C) Her Majesty The Queen in Right of Canada, Environment Canada, 2008-2015
+#
+# Sarracenia repository: https://github.com/MetPX/sarracenia
+# Documentation: https://github.com/MetPX/sarracenia
+#
+########################################################################
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; version 2 of the License.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+#
+
+"""
+  Extra Feature Scanning and Enablement.
+
+  checking for extra dependencies, not "hard" dependencies ("requires")
+  listed as features in setup.py and omitted entirely from debian packaging.
+  this allows installation with fewer dependencies ahead of time, and then
+  provide some messaging to users when they "need" an optional dependency.
+ 
+  optional features can be enabled using pip install metpx-sr3[extra]
+  where extra is one of the features listed below. Alternatively,
+  one can just install the modules that are needed and the functionality
+  will be enabled after a component restart.
+  
+  amqp - ability to communicate with AMQP (rabbitmq) brokers
+  mqtt - ability to communicate with MQTT brokers
+  filetypes - ability to
+  ftppoll - ability to poll FTP servers
+  vip  - enable vip (Virtual IP) settings to implement singleton processing
+         for high availability support.
+  watch - monitor files or directories for changes.
+
+"""
+
+import importlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+features = { 
+    'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 
+            'lament' : 'cannot connect to rabbitmq brokers', 
+            'rejoice' : 'can connect to rabbitmq brokers' },
+   'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False, 
+           'lament' : 'assume linux file placement under home dir', 
+           'rejoice': 'place configuration and state files appropriately for platform (windows/mac/linux)', },
+   'filetypes' : { 'modules_needed': ['magic'], 'present': False, 
+           'lament': 'will not be able to set content headers' ,
+           'rejoice': 'able to set content headers' },
+   'ftppoll' : { 'modules_needed': ['dateparser', 'pytz'], 'present': False, 
+       'lament' : 'not able to poll with ftp' ,
+       'rejoice' : 'able to poll with ftp' },
+   'humanize' : { 'modules_needed': ['humanize' ], 'present': False, 
+           'lament': 'humans will have to read larger, uglier numbers',
+           'rejoice': 'humans numbers that are easier to read.' },
+   'mqtt' : { 'modules_needed': ['paho.mqtt.client'], 'present': False, 
+           'lament': 'cannot connect to mqtt brokers' ,
+           'rejoice': 'can connect to mqtt brokers' },
+   'redis' : { 'modules_needed': [ 'redis', 'redis_lock' ],
+        'lament': 'cannot use redis implementations of retry and nodupe',
+        'rejoice': 'can use redis implementations of retry and nodupe'
+        },
+   'sftp' : { 'modules_needed': [ 'paramiko' ],
+        'lament': 'cannot use or access sftp/ssh based services',
+        'rejoice': 'can use sftp or ssh based services'
+        },
+   'vip'  : { 'modules_needed': ['netifaces'] , 'present': False, 
+           'lament': 'will not be able to use the vip option for high availability clustering' ,
+           'rejoice': 'able to use the vip option for high availability clustering' },
+   'watch'  : { 'modules_needed': ['watchdog'] , 'present': False, 
+           'lament': 'cannot watch directories' ,
+           'rejoice': 'watch directories' },
+   'xattr'  : { 'modules_needed': ['xattr'] , 'present': False, 
+           'lament': '(only on Linux) to store additional file metadata in extended attributes' ,
+           'rejoice': 'on linux, will store file metadata in extended attributes' }
+}
+
+for x in features:
+   
+   features[x]['present']=True
+   for y in  features[x]['modules_needed']:
+       try:
+           if importlib.util.find_spec( y ):
+               logger.debug( f'found feature {y}, enabled') 
+               pass
+           else:
+               logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
+               features[x]['present']=False
+       except:
+           logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
+           features[x]['present']=False
+

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -97,7 +97,9 @@ features = {
 }
 
 if sys.platform == 'win32':
-   features['xattr']['modules_needed'] = ['ctypes']
+    features['ctypes'] = { 'modules_needed':['ctypes'], 'present':False, 
+           'lament': 'unable to store additional file metadata in extended attributes' ,
+           'rejoice': 'will store file metadata in extended attributes' }
    
 for x in features:
    

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -47,6 +47,7 @@
 
 import importlib
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -59,21 +60,27 @@ features = {
            'lament' : 'assume linux file placement under home dir', 
            'rejoice': 'place configuration and state files appropriately for platform (windows/mac/linux)', },
    'filetypes' : { 'modules_needed': ['magic'], 'present': False, 
-           'lament': 'will not be able to set content headers' ,
+           'lament': '(pip package python-magic, on windows python-magic-bin) will not be able to set content headers' ,
            'rejoice': 'able to set content headers' },
    'ftppoll' : { 'modules_needed': ['dateparser', 'pytz'], 'present': False, 
        'lament' : 'not able to poll with ftp' ,
        'rejoice' : 'able to poll with ftp' },
-   'humanize' : { 'modules_needed': ['humanize' ], 'present': False, 
+   'humanize' : { 'modules_needed': ['humanize', 'humanfriendly' ], 'present': False, 
            'lament': 'humans will have to read larger, uglier numbers',
            'rejoice': 'humans numbers that are easier to read.' },
    'mqtt' : { 'modules_needed': ['paho.mqtt.client'], 'present': False, 
            'lament': 'cannot connect to mqtt brokers' ,
            'rejoice': 'can connect to mqtt brokers' },
+   'process' : { 'modules_needed': ['psutil'], 'present': False,
+        'lament': 'cannot monitor running processes, sr3 CLI basically does not work.',
+        'rejoice': 'can monitor, start, stop processes:  Sr3 CLI should basically work' },
    'redis' : { 'modules_needed': [ 'redis', 'redis_lock' ],
         'lament': 'cannot use redis implementations of retry and nodupe',
         'rejoice': 'can use redis implementations of retry and nodupe'
         },
+   'retry': { 'modules_needed': ['jsonpickle'], 'present': False,
+           'lament': 'unable to use local queues on the side (disk or redis) to retry messages later',
+           'rejoice': 'can write messages to local queues to retry failed publishes/sends/downloads'},
    'sftp' : { 'modules_needed': [ 'paramiko' ],
         'lament': 'cannot use or access sftp/ssh based services',
         'rejoice': 'can use sftp or ssh based services'
@@ -85,10 +92,13 @@ features = {
            'lament': 'cannot watch directories' ,
            'rejoice': 'watch directories' },
    'xattr'  : { 'modules_needed': ['xattr'] , 'present': False, 
-           'lament': '(only on Linux) to store additional file metadata in extended attributes' ,
-           'rejoice': 'on linux, will store file metadata in extended attributes' }
+           'lament': 'unable to store additional file metadata in extended attributes' ,
+           'rejoice': 'will store file metadata in extended attributes' }
 }
 
+if sys.platform == 'win32':
+   features['xattr']['modules_needed'] = ['ctypes']
+   
 for x in features:
    
    features[x]['present']=True

--- a/sarracenia/filemetadata.py
+++ b/sarracenia/filemetadata.py
@@ -28,11 +28,35 @@
 #
 #
 
-try:
+from sarracenia.featuredetection import features
+
+if features['sftp']['present']:
+    import paramiko
+
+    FmdStat = paramiko.SFTPAttributes
+
+else:
+    class FmdStat(object):
+        def __init__(self):
+            """
+            (PAS: copied from paramiko)
+            Create a new (empty) SFTPAttributes object.  All fields will be empty.
+            """
+            self._flags = 0
+            self.st_size = None
+            self.st_uid = None
+            self.st_gid = None
+            self.st_mode = None
+            self.st_atime = None
+            self.st_mtime = None
+            self.attr = {}
+
+
+if features['xattr']['present']:
     import xattr
     supports_extended_attributes = True
 
-except:
+else:
     supports_extended_attributes = False
 
 import sys

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -28,6 +28,8 @@ from mimetypes import guess_type
 
 # end v2 subscriber
 
+from sarracenia.featuredetection import features
+
 from sarracenia import nowflt
 
 logger = logging.getLogger(__name__)
@@ -57,10 +59,10 @@ default_options = {
     'vip': None
 }
 
-if sarracenia.features['filetypes']['present']:
+if features['filetypes']['present']:
     import magic
 
-if sarracenia.features['vip']['present']:
+if features['vip']['present']:
     import netifaces
 
 
@@ -310,7 +312,7 @@ class Flow:
 
     def has_vip(self):
 
-        if not sarracenia.features['vip']['present']: return True
+        if not features['vip']['present']: return True
 
         # no vip given... standalone always has vip.
         if self.o.vip == None:
@@ -1875,7 +1877,7 @@ class Flow:
                 os.rename(new_inflight_path, new_file)
             
             # older versions don't include the contentType, so patch it here.
-            if sarracenia.features['filetypes']['present'] and 'contentType' not in msg:
+            if features['filetypes']['present'] and 'contentType' not in msg:
                 msg['contentType'] = magic.from_file(new_file,mime=True)
 
             self.metrics['flow']['transferRxBytes'] += len_written
@@ -1964,7 +1966,7 @@ class Flow:
             local_path = '/' + msg['relPath']
 
         # older versions don't include the contentType, so patch it here.
-        if sarracenia.features['filetypes']['present'] and \
+        if features['filetypes']['present'] and \
            ('contentType' not in msg) and (not 'fileOp' in msg):
             msg['contentType'] = magic.from_file(local_path,mime=True)
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -57,10 +57,10 @@ default_options = {
     'vip': None
 }
 
-if sarracenia.extras['filetypes']['present']:
+if sarracenia.features['filetypes']['present']:
     import magic
 
-if sarracenia.extras['vip']['present']:
+if sarracenia.features['vip']['present']:
     import netifaces
 
 
@@ -310,7 +310,7 @@ class Flow:
 
     def has_vip(self):
 
-        if not sarracenia.extras['vip']['present']: return True
+        if not sarracenia.features['vip']['present']: return True
 
         # no vip given... standalone always has vip.
         if self.o.vip == None:
@@ -1875,7 +1875,7 @@ class Flow:
                 os.rename(new_inflight_path, new_file)
             
             # older versions don't include the contentType, so patch it here.
-            if sarracenia.extras['filetypes']['present'] and 'contentType' not in msg:
+            if sarracenia.features['filetypes']['present'] and 'contentType' not in msg:
                 msg['contentType'] = magic.from_file(new_file,mime=True)
 
             self.metrics['flow']['transferRxBytes'] += len_written
@@ -1964,7 +1964,7 @@ class Flow:
             local_path = '/' + msg['relPath']
 
         # older versions don't include the contentType, so patch it here.
-        if sarracenia.extras['filetypes']['present'] and \
+        if sarracenia.features['filetypes']['present'] and \
            ('contentType' not in msg) and (not 'fileOp' in msg):
             msg['contentType'] = magic.from_file(local_path,mime=True)
 

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -7,6 +7,7 @@
 import logging
 import sarracenia
 from sarracenia.flow import Flow
+from sarracenia.featuredetection import features
 import sys
 
 
@@ -66,9 +67,9 @@ class Poll(Flow):
         self.plugins['load'].insert(0,
                                     'sarracenia.flowcb.post.message.Message')
 
-        if not sarracenia.features['ftppoll']['present']:
+        if not features['ftppoll']['present']:
             if hasattr( self.o, 'pollUrl' ) and ( self.o.pollUrl.startswith('ftp') ):
-                logger.critical( f"attempting to configure an FTP poll pollUrl={self.o.pollUrl}, but missing python modules: {' '.join(sarracenia.features['ftppoll']['modules_needed'])}" )
+                logger.critical( f"attempting to configure an FTP poll pollUrl={self.o.pollUrl}, but missing python modules: {' '.join(features['ftppoll']['modules_needed'])}" )
                 sys.exit(1)
 
     def do(self):

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -66,9 +66,9 @@ class Poll(Flow):
         self.plugins['load'].insert(0,
                                     'sarracenia.flowcb.post.message.Message')
 
-        if not sarracenia.extras['ftppoll']['present']:
+        if not sarracenia.features['ftppoll']['present']:
             if hasattr( self.o, 'pollUrl' ) and ( self.o.pollUrl.startswith('ftp') ):
-                logger.critical( f"attempting to configure an FTP poll pollUrl={self.o.pollUrl}, but missing python modules: {' '.join(sarracenia.extras['ftppoll']['modules_needed'])}" )
+                logger.critical( f"attempting to configure an FTP poll pollUrl={self.o.pollUrl}, but missing python modules: {' '.join(sarracenia.features['ftppoll']['modules_needed'])}" )
                 sys.exit(1)
 
     def do(self):

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -13,7 +13,7 @@ import sys
 entry_points = [
 
     'ack', 'after_accept', 'after_post', 'after_work', 'destfn', 'do_poll', 
-    'download', 'gather', 'metricsReport', 'on_cleanup', 'on_declare', 'on_extras',
+    'download', 'gather', 'metricsReport', 'on_cleanup', 'on_declare', 'on_features',
     'on_housekeeping', 'on_report', 'on_sanity', 'on_start', 'on_stop', 
     'please_stop', 'poll', 'post', 'send', 
 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -13,8 +13,9 @@ import sys
 entry_points = [
 
     'ack', 'after_accept', 'after_post', 'after_work', 'destfn', 'do_poll', 
-    'download', 'gather', 'metricsReport', 'on_cleanup', 'on_declare', 'on_housekeeping', 'on_report', 
-    'on_sanity', 'on_start', 'on_stop', 'please_stop', 'poll', 'post', 'send', 
+    'download', 'gather', 'metricsReport', 'on_cleanup', 'on_declare', 'on_extras',
+    'on_housekeeping', 'on_report', 'on_sanity', 'on_start', 'on_stop', 
+    'please_stop', 'poll', 'post', 'send', 
 
 ]
 

--- a/sarracenia/flowcb/clamav.py
+++ b/sarracenia/flowcb/clamav.py
@@ -17,7 +17,8 @@ import os
 import stat
 import time
 
-from sarracenia import nowflt,features
+from sarracenia import nowflt
+from sarracenia.featuredetection import features
 import sarracenia
 from sarracenia.flowcb import FlowCB
 

--- a/sarracenia/flowcb/clamav.py
+++ b/sarracenia/flowcb/clamav.py
@@ -17,22 +17,22 @@ import os
 import stat
 import time
 
-from sarracenia import nowflt,extras
+from sarracenia import nowflt,features
 import sarracenia
 from sarracenia.flowcb import FlowCB
 
 #
-# Support for extras inventory mechanism.
+# Support for features inventory mechanism.
 #
-extras['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
+features['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
         'lament' : 'cannot use clamd to av scan files trasnferred',
         'rejoice' : 'can use clamd to av scan files trasnferred' }
 
 try:
     import pyclamd
-    extras['clamd']['present'] = True
+    features['clamd']['present'] = True
 except:
-    extras['clamd']['present'] = False
+    features['clamd']['present'] = False
 
 
 
@@ -58,7 +58,7 @@ class Clamav(FlowCB):
         self.metric_scanned = 0
         self.metric_hits = 0
        
-        if sarracenia.extras['pyclamd']['present']:
+        if sarracenia.features['pyclamd']['present']:
             import pyclamd
             self.av = pyclamd.ClamdAgnostic()
             print("clam_scan on_part plugin initialized")

--- a/sarracenia/flowcb/clamav.py
+++ b/sarracenia/flowcb/clamav.py
@@ -14,12 +14,27 @@
 
 import logging
 import os
-import pyclamd
 import stat
 import time
 
-from sarracenia import nowflt
+from sarracenia import nowflt,extras
+import sarracenia
 from sarracenia.flowcb import FlowCB
+
+#
+# Support for extras inventory mechanism.
+#
+extras['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
+        'lament' : 'cannot use clamd to av scan files trasnferred',
+        'rejoice' : 'can use clamd to av scan files trasnferred' }
+
+try:
+    import pyclamd
+    extras['clamd']['present'] = True
+except:
+    extras['clamd']['present'] = False
+
+
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +54,14 @@ class Clamav(FlowCB):
     def __init__(self, options) -> None:
 
         super().__init__(options,logger)
-        self.av = pyclamd.ClamdAgnostic()
+
         self.metric_scanned = 0
         self.metric_hits = 0
-        print("clam_scan on_part plugin initialized")
+       
+        if sarracenia.extras['pyclamd']['present']:
+            import pyclamd
+            self.av = pyclamd.ClamdAgnostic()
+            print("clam_scan on_part plugin initialized")
 
     def avscan_hit(self, scanfn) -> bool:
 

--- a/sarracenia/flowcb/clamav.py
+++ b/sarracenia/flowcb/clamav.py
@@ -25,8 +25,8 @@ from sarracenia.flowcb import FlowCB
 # Support for features inventory mechanism.
 #
 features['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
-        'lament' : 'cannot use clamd to av scan files trasnferred',
-        'rejoice' : 'can use clamd to av scan files trasnferred' }
+        'lament' : 'cannot use clamd to av scan files transferred',
+        'rejoice' : 'can use clamd to av scan files transferred' }
 
 try:
     import pyclamd

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -27,7 +27,7 @@ from sys import platform as _platform
 import sys
 import time
 
-if sarracenia.extras['watch']['present']:
+if sarracenia.features['watch']['present']:
     from watchdog.observers import Observer
     from watchdog.observers.polling import PollingObserver
     from watchdog.events import PatternMatchingEventHandler
@@ -35,7 +35,7 @@ if sarracenia.extras['watch']['present']:
 logger = logging.getLogger(__name__)
 
 
-if sarracenia.extras['watch']['present']:
+if sarracenia.features['watch']['present']:
     class SimpleEventHandler(PatternMatchingEventHandler):
         def __init__(self, parent):
             self.on_created = parent.on_created
@@ -118,7 +118,7 @@ class File(FlowCB):
 
         super().__init__(options,logger)
 
-        if not sarracenia.extras['watch']['present']:
+        if not sarracenia.features['watch']['present']:
             logger.critical("watchdog module must be installed to watch directories")
             
         logger.debug("%s used to be overwrite_defaults" % self.o.component)
@@ -687,7 +687,7 @@ class File(FlowCB):
     def watch_dir(self, sld):
         logger.debug("watch_dir %s" % sld)
 
-        if not sarracenia.extras['watch']['present']:
+        if not sarracenia.features['watch']['present']:
             logger.critical("sr_watch needs the python watchdog library to be installed.")
             return []
 
@@ -769,7 +769,7 @@ class File(FlowCB):
             logger.debug("postpath = %s" % d)
 
             if self.o.sleep > 0:
-                if sarracenia.extras['watch']['present']:
+                if sarracenia.features['watch']['present']:
                     messages.extend(self.watch_dir(d))
                 else:
                     logger.critical("python watchdog package missing! Cannot watch directory")

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -19,15 +19,17 @@ from random import choice
 
 import sarracenia
 from sarracenia import *
+from sarracenia.featuredetection import features
 from sarracenia.flowcb import FlowCB
 import sarracenia.identity
+
 
 import stat
 from sys import platform as _platform
 import sys
 import time
 
-if sarracenia.features['watch']['present']:
+if features['watch']['present']:
     from watchdog.observers import Observer
     from watchdog.observers.polling import PollingObserver
     from watchdog.events import PatternMatchingEventHandler
@@ -35,7 +37,7 @@ if sarracenia.features['watch']['present']:
 logger = logging.getLogger(__name__)
 
 
-if sarracenia.features['watch']['present']:
+if features['watch']['present']:
     class SimpleEventHandler(PatternMatchingEventHandler):
         def __init__(self, parent):
             self.on_created = parent.on_created
@@ -118,7 +120,7 @@ class File(FlowCB):
 
         super().__init__(options,logger)
 
-        if not sarracenia.features['watch']['present']:
+        if not features['watch']['present']:
             logger.critical("watchdog module must be installed to watch directories")
             
         logger.debug("%s used to be overwrite_defaults" % self.o.component)
@@ -687,7 +689,7 @@ class File(FlowCB):
     def watch_dir(self, sld):
         logger.debug("watch_dir %s" % sld)
 
-        if not sarracenia.features['watch']['present']:
+        if not features['watch']['present']:
             logger.critical("sr_watch needs the python watchdog library to be installed.")
             return []
 
@@ -769,7 +771,7 @@ class File(FlowCB):
             logger.debug("postpath = %s" % d)
 
             if self.o.sleep > 0:
-                if sarracenia.features['watch']['present']:
+                if features['watch']['present']:
                     messages.extend(self.watch_dir(d))
                 else:
                     logger.critical("python watchdog package missing! Cannot watch directory")

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -38,6 +38,14 @@ import os
 import psutil
 from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
+from sarracenia.featuredetection import features
+
+if features['process']['present']:
+    import psutil
+else:
+    logger.error("missing psutil class cannot monitor process memory usage")
+
+
 import sys
 
 logger = logging.getLogger(__name__)
@@ -57,7 +65,11 @@ class Resources(FlowCB):
         self.msgCount = 0
 
     def on_housekeeping(self):
-        mem = psutil.Process().memory_info().vms
+        if features['process']['present']:
+            mem = psutil.Process().memory_info().vms
+        else:
+            mem = 0
+
         ost = os.times()
         logger.info(
             f"Current Memory cpu_times: user={ost.user} system={ost.system}")

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -16,7 +16,7 @@ import paramiko
 
 import sarracenia
 
-if sarracenia.extras['ftppoll']['present']:
+if sarracenia.features['ftppoll']['present']:
     import dateparser
     import pytz
 
@@ -316,7 +316,7 @@ class Poll(FlowCB):
 
     def filedate(self, line):
 
-        if not sarracenia.extras['ftppoll']['present']:
+        if not sarracenia.features['ftppoll']['present']:
            logger.error('need dateparser library to deal with polling of ftp servers, no date parsed')
            return 0
 

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -15,8 +15,9 @@ import os
 import paramiko
 
 import sarracenia
+from sarracenia.featuredetection import features
 
-if sarracenia.features['ftppoll']['present']:
+if features['ftppoll']['present']:
     import dateparser
     import pytz
 
@@ -316,7 +317,7 @@ class Poll(FlowCB):
 
     def filedate(self, line):
 
-        if not sarracenia.features['ftppoll']['present']:
+        if not features['ftppoll']['present']:
            logger.error('need dateparser library to deal with polling of ftp servers, no date parsed')
            return 0
 

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -13,6 +13,7 @@ from sarracenia import nowflt, timestr2flt
 import logging
 
 from sarracenia.flowcb import FlowCB
+from sarracenia.featuredetection import features
 
 
 # class sarra/retry
@@ -48,6 +49,10 @@ class Retry(FlowCB):
 
         super().__init__(options,logger)
 
+        if not features['retry']['present'] :
+            logger.critical( f"missing retry pre-requsites, module disabled")
+            return
+
         self.o.add_option( 'retry_driver', 'str', 'disk')
         #queuedriver = os.getenv('SR3_QUEUEDRIVER', 'disk')
 
@@ -69,6 +74,8 @@ class Retry(FlowCB):
         If there are only a few new messages, get some from the download retry queue and put them into
         `worklist.incoming`.
         """
+        if not features['retry']['present'] :
+            return
 
         qty = (self.o.batch / 2) - len(worklist.incoming)
         #logger.info('qty: %d len(worklist.incoming) %d' % ( qty, len(worklist.incoming) ) )
@@ -86,6 +93,9 @@ class Retry(FlowCB):
         Messages in `worklist.failed` should be put in the download retry queue. If there are only a few new
         messages, get some from the post retry queue and put them into `worklist.ok`.
         """
+        if not features['retry']['present'] :
+            return
+
         if len(worklist.failed) != 0:
             #logger.debug("putting %d messages into %s" % (len(worklist.failed),self.download_retry_name) )
             self.download_retry.put(worklist.failed)
@@ -105,6 +115,9 @@ class Retry(FlowCB):
         """
         Messages in `worklist.failed` should be put in the post retry queue.
         """
+        if not features['retry']['present'] :
+            return
+
         self.post_retry.put(worklist.failed)
         worklist.failed=[]
 

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -3,6 +3,7 @@ import paramiko
 import re
 
 import sarracenia
+from sarracenia.filemetadata import FmdStat
 from sarracenia.flowcb import FlowCB
 
 import time
@@ -78,7 +79,7 @@ class Scheduled(FlowCB):
         gathered_messages = []
 
         for relPath in self.o.path:
-            st = paramiko.SFTPAttributes()
+            st = FmdStat()
             m = sarracenia.Message.fromFileInfo(relPath, self.o, st)
             gathered_messages.append(m)
 

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -3,6 +3,8 @@ import json
 import logging
 import sys
 import time
+from sarracenia.featuredetection import features
+
 import sarracenia
 
 logger = logging.getLogger(__name__)
@@ -390,8 +392,8 @@ class Moth():
         else:
             self.putCleanUp()
 
-if sarracenia.features['amqp']['present']:
+if features['amqp']['present']:
     import sarracenia.moth.amqp
 
-if sarracenia.features['mqtt']['present']:
+if features['mqtt']['present']:
     import sarracenia.moth.mqtt

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -33,12 +33,12 @@ default_options = {
 }
 
 def ProtocolPresent(p) -> bool:
-    if ( p[0:4] in ['amqp'] ) and sarracenia.extras['amqp']['present']:
+    if ( p[0:4] in ['amqp'] ) and sarracenia.features['amqp']['present']:
        return True
-    if ( p[0:4] in ['mqtt'] ) and sarracenia.extras['mqtt']['present']:
+    if ( p[0:4] in ['mqtt'] ) and sarracenia.features['mqtt']['present']:
        return True
-    if p in sarracenia.extras:
-        logger.critical( f"support for {p} missing, please install python packages: {' '.join(sarracenia.extras[p]['modules_needed'])}" )
+    if p in sarracenia.features:
+        logger.critical( f"support for {p} missing, please install python packages: {' '.join(sarracenia.features[p]['modules_needed'])}" )
     else:
         logger.critical( f"Protocol scheme {p} unsupported for communications with message brokers" )
 
@@ -390,8 +390,8 @@ class Moth():
         else:
             self.putCleanUp()
 
-if sarracenia.extras['amqp']['present']:
+if sarracenia.features['amqp']['present']:
     import sarracenia.moth.amqp
 
-if sarracenia.extras['mqtt']['present']:
+if sarracenia.features['mqtt']['present']:
     import sarracenia.moth.mqtt

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1435,21 +1435,25 @@ class sr_GlobalState:
                 flow=None
 
         features_present=[]
+        print( f"\n{'Status:':10} {'feature:':10} {'Modules:':20} {'Description:'} ")
         features_absent=[]
         for x in sarracenia.features.keys():
             if x == 'all':
                 continue
             if sarracenia.features[x]['present']:
-                print( f"INSTALLED: {x:10} {sarracenia.features[x]['rejoice']}" )
+                word1="Installed"
+                desc=sarracenia.features[x]['rejoice']
             else:
                 if 'Needed' in sarracenia.features[x]:
                      word1="MISSING"
                 else:
                      word1="Absent"
+                desc=sarracenia.features[x]['lament']
 
-                print( f"{word1}: {x:10}: {sarracenia.features[x]['lament']}")
+            print( f"{word1:10} {x:10} {','.join(sarracenia.features[x]['modules_needed']):20} {desc}" )
+            #    print( f"{word1:10} {x:10} {sarracenia.features[x]['lament']}")
                 
-                print( f"\tpython import missing: {sarracenia.features[x]['modules_needed']}" )
+            #    print( f"\tpython import missing: {sarracenia.features[x]['modules_needed']}" )
 
         if not (sarracenia.features['amqp']['present'] or sarracenia.features['mqtt']['present'] ):
             print( "ERROR: need at least one of: amqp or mqtt" )

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -30,7 +30,6 @@ import os
 import os.path
 import pathlib
 import platform
-import psutil
 import random
 import re
 import shutil
@@ -48,6 +47,9 @@ from sarracenia import user_config_dir, user_cache_dir, naturalSize, nowstr, tim
 from sarracenia.config import *
 import sarracenia.moth
 import sarracenia.rabbitmq_admin
+
+if sarracenia.features['process']['present']:
+   import psutil
 
 import urllib.parse
 
@@ -198,6 +200,10 @@ class sr_GlobalState:
             f.seek(0, 0)
             f.truncate()
             f.write(getpass.getuser() + '\n')
+
+            if not features['process']['present']:
+                return
+
             for proc in psutil.process_iter():
                 f.write(
                     json.dumps(proc.as_dict(
@@ -265,6 +271,8 @@ class sr_GlobalState:
         if sys.platform == 'win32':
             self.me = os.environ['userdomain'] + '\\' + self.me
         self.auditors = 0
+        if not features['process']['present']:
+            return
         for proc in psutil.process_iter():
             try:
                 self._filter_sr_proc(

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1435,7 +1435,7 @@ class sr_GlobalState:
                 flow=None
 
         features_present=[]
-        print( f"\n{'Status:':10} {'feature:':10} {'Modules:':20} {'Description:'} ")
+        print( f"\n{'Status:':10} {'feature:':10} {'python imports:':20} {'Description:'} ")
         features_absent=[]
         for x in sarracenia.features.keys():
             if x == 'all':
@@ -1451,9 +1451,6 @@ class sr_GlobalState:
                 desc=sarracenia.features[x]['lament']
 
             print( f"{word1:10} {x:10} {','.join(sarracenia.features[x]['modules_needed']):20} {desc}" )
-            #    print( f"{word1:10} {x:10} {sarracenia.features[x]['lament']}")
-                
-            #    print( f"\tpython import missing: {sarracenia.features[x]['modules_needed']}" )
 
         if not (sarracenia.features['amqp']['present'] or sarracenia.features['mqtt']['present'] ):
             print( "ERROR: need at least one of: amqp or mqtt" )

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1411,7 +1411,7 @@ class sr_GlobalState:
                     os.remove(state_file_cfg_disabled)
                     logging.info(c + '/' + cfg)
 
-    def extras(self):
+    def features(self):
 
         # run on_declare plugins.
         for f in self.filtered_configurations:
@@ -1430,28 +1430,28 @@ class sr_GlobalState:
             if c not in [ 'cpost', 'cpump' ]:
                 flow = sarracenia.flow.Flow.factory(o)
                 flow.loadCallbacks()
-                flow.runCallbacksTime('on_extras')
+                flow.runCallbacksTime('on_features')
                 del flow
                 flow=None
 
-        extras_present=[]
-        extras_absent=[]
-        for x in sarracenia.extras.keys():
+        features_present=[]
+        features_absent=[]
+        for x in sarracenia.features.keys():
             if x == 'all':
                 continue
-            if sarracenia.extras[x]['present']:
-                print( f"INSTALLED: {x:10} {sarracenia.extras[x]['rejoice']}" )
+            if sarracenia.features[x]['present']:
+                print( f"INSTALLED: {x:10} {sarracenia.features[x]['rejoice']}" )
             else:
-                if 'Needed' in sarracenia.extras[x]:
+                if 'Needed' in sarracenia.features[x]:
                      word1="MISSING"
                 else:
                      word1="Absent"
 
-                print( f"{word1}: {x:10}: {sarracenia.extras[x]['lament']}")
+                print( f"{word1}: {x:10}: {sarracenia.features[x]['lament']}")
                 
-                print( f"\tpython import missing: {sarracenia.extras[x]['modules_needed']}" )
+                print( f"\tpython import missing: {sarracenia.features[x]['modules_needed']}" )
 
-        if not (sarracenia.extras['amqp']['present'] or sarracenia.extras['mqtt']['present'] ):
+        if not (sarracenia.features['amqp']['present'] or sarracenia.features['mqtt']['present'] ):
             print( "ERROR: need at least one of: amqp or mqtt" )
 
 
@@ -1890,9 +1890,9 @@ class sr_GlobalState:
                         signal_pid(pid, signal.SIGTERM)
         else:
             print('no missing processes found')
-        for l in sarracenia.extras.keys():
-            if not sarracenia.extras[l]['present']:
-                print( f"notice: python module {l} is missing: {sarracenia.extras[l]['lament']}" )
+        for l in sarracenia.features.keys():
+            if not sarracenia.features[l]['present']:
+                print( f"notice: python module {l} is missing: {sarracenia.features[l]['lament']}" )
 
         # run on_sanity plugins.
         for f in self.filtered_configurations:
@@ -2701,7 +2701,7 @@ def main():
             logger.setLevel(logging.INFO)
 
     actions = [
-        'convert', 'declare', 'devsnap', 'dump', 'edit', 'extras', 'log', 'overview', 'restart', 'run', 'sanity',
+        'convert', 'declare', 'devsnap', 'dump', 'edit', 'features', 'log', 'overview', 'restart', 'run', 'sanity',
         'setup', 'show', 'status', 'start', 'stop'
     ]
 
@@ -2771,8 +2771,8 @@ def main():
     if action == 'enable':
         gs.enable()
 
-    if action == 'extras':
-        gs.extras()
+    if action == 'features':
+        gs.features()
 
     if action == 'foreground':
         gs.foreground()

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1455,6 +1455,9 @@ class sr_GlobalState:
         if not (sarracenia.features['amqp']['present'] or sarracenia.features['mqtt']['present'] ):
             print( "ERROR: need at least one of: amqp or mqtt" )
 
+        print( f"\n state dir: {self.user_cache_dir} " )
+        print( f" config dir: {self.user_config_dir} " )
+
 
     def foreground(self):
 

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -36,6 +36,7 @@ import urllib.parse
 
 #from sarracenia.sr_xattr import *
 from sarracenia import nowflt, timestr2flt
+from sarracenia.featuredetection import features
 
 logger = logging.getLogger(__name__)
 
@@ -428,5 +429,7 @@ class Transfer():
 import sarracenia.transfer.file
 import sarracenia.transfer.ftp
 import sarracenia.transfer.https
-import sarracenia.transfer.sftp
+
+if features['sftp']['present']:
+    import sarracenia.transfer.sftp
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open(os.path.join(here, "sarracenia", "_version.py"), "r") as f:
 packages = find_packages()
 print("packages = %s" % packages)
 
-extras = {
+features = {
        'amqp' : [ "amqp" ],
        'filetypes': [ "python-magic" ], 
        'ftppoll' : ['dateparser' ],
@@ -44,7 +44,7 @@ extras = {
        'vip': [ 'netifaces' ],
        'redis': [ 'redis' ]
     } 
-extras['all'] = list(itertools.chain.from_iterable(extras.values()))
+features['all'] = list(itertools.chain.from_iterable(features.values()))
 
 setup(
     name='metpx-sr3',
@@ -100,7 +100,7 @@ setup(
         'python-magic-bin; sys_platform=="win32"'
 
     ],
-    extras_require = extras
+    extras_requires = features
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         'python-magic-bin; sys_platform=="win32"'
 
     ],
-    extras_requires = features
+    extras_require = features
     )
 
 

--- a/tests/sarracenia/__init___test.py
+++ b/tests/sarracenia/__init___test.py
@@ -105,15 +105,15 @@ def test_nowflt():
     assert time.time() - sarracenia.nowflt() < 0.001
 
 # def test_naturalSize():
-#     if sarracenia.extras['humanize']['present'] == True:
+#     if sarracenia.features['humanize']['present'] == True:
 #         assert sarracenia.naturalSize(1024) == '1.0 KiB'
-#     elif sarracenia.extras['humanize']['present'] == False:
+#     elif sarracenia.features['humanize']['present'] == False:
 #         assert sarracenia.naturalSize(1024) == '1024'
 
 # def test_naturalTime():
-#     if sarracenia.extras['humanize']['present'] == True:
+#     if sarracenia.features['humanize']['present'] == True:
 #         assert sarracenia.naturalTime(1024) == '17 minutes ago'
-#     elif sarracenia.extras['humanize']['present'] == False:
+#     elif sarracenia.features['humanize']['present'] == False:
 #         assert sarracenia.naturalTime(1024) == '1024'
 
 @pytest.fixture


### PR DESCRIPTION
dependencies.  flowcb/clamav.py provides an example of a plugin reporting the dependencies it needs. so after installing sr3, you can check if deps are available using *sr3 extras* command like so:

```
fractal% sr3 extras
2023-07-27 23:55:46,296 1795514 [INFO] sarracenia.flow loadCallbacks flowCallback plugins to load: ['sarracenia.flowcb.retry.Retry', 'sarracenia.flowcb.housekeeping.resources.Resources', 'dcpflow', 'log', 'post.message', 'clamav']
2023-07-27 23:55:46,301 1795514 [INFO] dcpflow __init__ really I mean hi
2023-07-27 23:55:46,301 1795514 [WARNING] sarracenia.config add_option multiple declarations of lrgs_download_redundancy=['Yes', 'on'] choosing last one: on
2023-07-27 23:55:46,301 1795514 [INFO] dcpflow __init__  lrgs_download_redundancy is True 
2023-07-27 23:55:46,302 1795514 [INFO] sarracenia.flowcb.log __init__ flow initialized with: {'after_work', 'after_post', 'on_housekeeping', 'post', 'after_accept'}
2023-07-27 23:55:46,304 1795514 [CRITICAL] sarracenia.flow loadCallbacks flowCallback plugin clamav did not load: 'pyclamd'
INSTALLED: amqp       can connect to rabbitmq brokers
INSTALLED: appdirs    place configuration and state files appropriately for platform (windows/mac/linux)
INSTALLED: ftppoll    able to poll with ftp
INSTALLED: humanize   humans numbers that are easier to read.
Absent: mqtt      : cannot connect to mqtt brokers
	python import missing: ['paho.mqtt.client']
INSTALLED: filetypes  able to set content headers
INSTALLED: redis      can use redis implementations of retry and nodupe
INSTALLED: vip        able to use the vip option for high availability clustering
INSTALLED: watch      watch directories
MISSING: clamd     : cannot use clamd to av scan files trasnferred
	python import missing: ['pyclamd']

```

When a dependency that is not installed has a graceful degradaion, and so is optional, it is listed as *Absent* instead of Missing.  The *sr3 extras* command goes through all the flow callbacks in the configs, and each callback can report what additional dependencies are needed.

We had a complaint/user story about sr3 being installed without AMQP ( email feedback ) and another one about a new dependency that proved troublesome #721 ...

python has this concept of *extras* being optional packages that can be installed.  One can install the base package with 

```

pip install metpx-sr3

```
or add add options:

```

pip install metpx-sr3[amqp,mqtt,watch]

#or "all-dressed" option added in the current v03_wip branch:

pip install metpx-sr3[all]

```

So this gives a mechanism to separate out minimum dependencies and be granular about them.

But... is it just crap? Should we just let users figure out what modules they are missing?
I don't know if this is helpful or not.

So this is kind of a proof of concept implementation:  "We could do it like this"... but I dunno... 

more for discussion than a real pull request.

Documentation of the new command is also missing... waiting for more feedback.
