### PR TITLE
V03 issue745 Improve poll cod deriveKey & refactor to remove code duplication

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -178,9 +178,9 @@ class Flow:
         # open cache, get masks.
         if self.o.nodupe_ttl > 0:
             if self.o.nodupe_driver.lower() == "redis":
-                self.plugins['load'].append('sarracenia.flowcb.nodupe.redis.NoDupe')
+                self.plugins['load'].append('sarracenia.flowcb.nodupe.redis.Redis')
             else:
-                self.plugins['load'].append('sarracenia.flowcb.nodupe.disk.NoDupe')
+                self.plugins['load'].append('sarracenia.flowcb.nodupe.disk.Disk')
             
 
         if (( hasattr(self.o, 'delete_source') and self.o.delete_source ) or \

--- a/sarracenia/flowcb/nodupe/__init__.py
+++ b/sarracenia/flowcb/nodupe/__init__.py
@@ -1,0 +1,56 @@
+
+
+import logging
+
+from sarracenia.flowcb import FlowCB
+
+logger = logging.getLogger(__name__)
+
+
+class NoDupe(FlowCB):
+    """
+        duplicate suppression family of modules.
+
+        invoked with:
+
+        callback sarracenia.flowcb.nodupe.disk
+
+        or:
+        callback sarracenia.flowcb.nodupe.redis
+
+        with default being loaded depdending on the presence of a
+
+        nodupe_driver "redis"
+
+        setting (defaults to disk.)
+
+    """
+
+
+    def deriveKey(self, msg) -> str:
+
+        key=None
+        if ('nodupe_override' in msg) and ('key' in msg['nodupe_override']):
+            key = msg['nodupe_override']['key']
+        elif 'fileOp' in msg :
+            if 'link' in msg['fileOp']:
+                key = msg['fileOp']['link']
+            elif 'directory' in msg['fileOp']:
+                if 'remove' not in msg['fileOp']:
+                    key = msg['relPath']
+        elif ('identity' in msg) and not (msg['identity']['method'] in ['cod']):
+            key = msg['identity']['method'] + ',' + msg['identity']['value'].replace('\n', '')
+
+        if not key:
+            if 'mtime' in msg:
+                t = msg['mtime']
+            else:
+                t = msg['pubTime']
+            if 'size' in msg:
+                key = f"{msg['relPath']},{t},{msg['size']}"
+            else:
+                key = f"{msg['relPath']},{t}"
+
+        return key
+
+

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -11,12 +11,12 @@ import logging
 
 from sarracenia import nowflt, timestr2flt, timeflt2str
 
-from sarracenia.flowcb import FlowCB
+from sarracenia.flowcb.nodupe import NoDupe
 
 logger = logging.getLogger(__name__)
 
 
-class NoDupe(FlowCB):
+class Disk(NoDupe):
     """
        generalised duplicate suppression for sr3 programs. It is used as a 
        time based buffer that prevents, when activated, identical files (of some kinds) 
@@ -123,39 +123,6 @@ class NoDupe(FlowCB):
             logger.debug( f"added relpath={relpath}")
 
         return True
-
-    def deriveKey(self, msg) -> str:
-
-        key=None
-        if ('nodupe_override' in msg) and ('key' in msg['nodupe_override']):
-            key = msg['nodupe_override']['key']
-        elif 'fileOp' in msg :
-            if 'link' in msg['fileOp']:
-                key = msg['fileOp']['link']
-            elif 'directory' in msg['fileOp']: 
-                if 'remove' not in msg['fileOp']:
-                    key = msg['relPath']
-        elif 'identity' in msg:
-            if msg['identity']['method'] in ['cod']:
-                # if cod, revert to using the path.
-                key = msg['relPath']
-            else:
-                key = msg['identity']['method'] + ',' + msg['identity']['value'].replace('\n', '')
-
-
-        if not key:
-            if 'mtime' in msg:
-                t = msg['mtime']
-            else:
-                t = msg['pubTime']
-            if 'size' in msg:
-                key = f"{msg['relPath']},{t},{msg['size']}"
-            else:
-                key = f"{msg['relPath']},{t}"
-
-        return key
-
-
 
     def check_message(self, msg) -> bool :
         """

--- a/tests/sarracenia/flowcb/nodupe/disk_test.py
+++ b/tests/sarracenia/flowcb/nodupe/disk_test.py
@@ -10,7 +10,7 @@ def pretty(*things, **named_things):
         print(str(k) + ":")
         pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
-from sarracenia.flowcb.nodupe.disk import NoDupe
+from sarracenia.flowcb.nodupe.disk import Disk
 from sarracenia import Message as SR3Message
 
 class Options:
@@ -58,7 +58,7 @@ WorkList.directories_ok = []
 def test_deriveKey(tmp_path):
     BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     thismsg = make_message()
     thismsg['nodupe_override'] = {'key': "SomeKeyValue"}
@@ -74,7 +74,7 @@ def test_deriveKey(tmp_path):
 
     thismsg = make_message()
     thismsg['identity'] = {'method': "cod"}
-    assert nodupe.deriveKey(thismsg) == thismsg["relPath"]
+    assert nodupe.deriveKey(thismsg) == thismsg["relPath"] + "," + thismsg["mtime"]
 
     thismsg['identity'] = {'method': "method", 'value': "value\n"}
     assert nodupe.deriveKey(thismsg) == "method,value"
@@ -91,7 +91,7 @@ def test_open__WithoutFile(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.open()
     assert nodupe.cache_file == str(tmp_path) + os.sep + 'recent_files_005.cache'
@@ -103,7 +103,7 @@ def test_open__WithFile(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     filepath = str(tmp_path) + os.sep + 'recent_files_005.cache'
     fp = open(filepath, 'a')
@@ -120,7 +120,7 @@ def test_open__WithData(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     fp = open(str(tmp_path) + os.sep + 'recent_files_005.cache', 'a')
@@ -154,7 +154,7 @@ def test_on_start(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.on_start()
 
@@ -169,7 +169,7 @@ def test_on_stop(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.on_stop()
 
@@ -182,7 +182,7 @@ def test_close(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.on_start()
 
@@ -197,7 +197,7 @@ def test_close__ErrorThrown(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.on_start()
 
@@ -223,7 +223,7 @@ def test_close__Unlink(tmp_path):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.on_start()
 
@@ -240,7 +240,7 @@ def test_close__Unlink_ErrorThrown(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
 
     nodupe.on_start()
 
@@ -268,7 +268,7 @@ def test_clean(tmp_path, capsys):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.cache_dict = {
@@ -292,7 +292,7 @@ def test_clean__Persist_DelPath(tmp_path, capsys):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -322,7 +322,7 @@ def test_save(tmp_path, capsys):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -351,7 +351,7 @@ def test_save__Unlink_Error(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -388,7 +388,7 @@ def test_save__Open_Error(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -422,7 +422,7 @@ def test_on_housekeeping(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -457,7 +457,7 @@ def test__not_in_cache(tmp_path, caplog):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -495,7 +495,7 @@ def test_check_message(tmp_path, capsys):
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -528,7 +528,7 @@ def test_after_accept(tmp_path, capsys):
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
     BaseOptions.inflight = 0
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()
@@ -555,7 +555,7 @@ def test_after_accept__WithFileAges(tmp_path, capsys):
     BaseOptions.no = 5
     BaseOptions.inflight = 0
 
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
     nodupe.o.nodupe_fileAgeMin = 1000
     nodupe.o.nodupe_fileAgeMax = 1000
@@ -587,7 +587,7 @@ def test_after_accept__InFlight(tmp_path, capsys):
     BaseOptions.no = 5
     BaseOptions.inflight = 1000
 
-    nodupe = NoDupe(BaseOptions)
+    nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
 
     nodupe.open()

--- a/tests/sarracenia/flowcb/nodupe/nodupe_test.py
+++ b/tests/sarracenia/flowcb/nodupe/nodupe_test.py
@@ -13,8 +13,8 @@ def pretty(*things, **named_things):
         print(str(k) + ":")
         pprint.PrettyPrinter(indent=2, width=200).pprint(v)
 
-from sarracenia.flowcb.nodupe.redis import NoDupe as NoDupe_Redis
-from sarracenia.flowcb.nodupe.disk import NoDupe as NoDupe_Disk
+from sarracenia.flowcb.nodupe.redis import Redis as NoDupe_Redis
+from sarracenia.flowcb.nodupe.disk import Disk as NoDupe_Disk
 from sarracenia import Message as SR3Message
 
 class Options:


### PR DESCRIPTION
This is a fix for #745, just changing the default key derivation.  The main idea was to change one if statement in deriveKey() method to change how key is derived for "cod" case,  But noticed that deriveKey in nodupe.disk.NoDupe and nodupe.redis.NoDupe are the same... there are two identical methods in two weirdly named classes.

Which revealed the need to refactor:

* re-create create sarracenia.flowcb.nodupe.NoDupe as parent class.
* the only method in the above class is deriveKey()
* sarracenia.nodupe.disk.NoDupe, is renamed to sarracenia.nodupe.disk.Disk (as per normal python practice) and it subclasses the parent  NoDupe class
* sarracenia.nodupe.redis.NoDupe, is renamed to sarracenia.nodupe.redis.Redis (as per normal python convention) and it subclasses the parent NoDupe class.

Result: 

* deriveKey is now only exists once, in the parent class, where formerly it was present in both.
* both disk.py and redis.py follow python conventions for module naming.

Then had to update the unit tests to reflect the change. (2nd commit.)



