### PR TITLE
V03 issue693 improve mqtt performance on restart_server flow test.

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -678,7 +678,7 @@ class Message(dict):
                 msg[k] = options.fixed_headers[k]
 
         msg['_deleteOnPost'] |= set([
-            'new_dir', 'new_file', 'new_relPath', 'new_baseUrl', 'new_subtopic', 'post_format'
+            'new_dir', 'new_file', 'new_relPath', 'new_baseUrl', 'new_subtopic', 'subtopic', 'post_format'
         ])
         if new_dir:
             msg['new_dir'] = new_dir

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -522,7 +522,7 @@ class Flow:
                             m['_deleteOnPost'] |= set(['old_relPath'])
                             m['relPath'] = m['new_relPath']
                             m['old_subtopic'] = m['subtopic']
-                            m['_deleteOnPost'] |= set(['old_subtopic'])
+                            m['_deleteOnPost'] |= set(['old_subtopic','subtopic'])
                             m['subtopic'] = m['new_subtopic']
 
                         if '_format' in m:

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -375,13 +375,15 @@ class MQTT(Moth):
                     self.client.connect( self.o['broker'].url.hostname, port=self.__sslClientSetup(), \
                            clean_start=False, properties=props )
                     self.client.enable_logger(logger)
+                    self.client.loop_start()
+                    ebo=1
                     while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
-                         self.client.loop()
-                         time.sleep(0.1)
+                         time.sleep(0.1*ebo)
                          if self.please_stop:
                               break
-                         logger.info("waiting for subscription to be set up.")
-                    self.client.loop_start()
+                         if ebo < 512 :
+                            ebo *= 2
+                         logger.info( f"waiting for subscription to be set up. (ebo={ebo})")
                     self.connected=True
                     break
                 else: # either 'declare' or 'foreground'
@@ -471,12 +473,15 @@ class MQTT(Moth):
 
                 self.client.loop_start()
 
+                ebo=1
                 while self.connect_in_progress:
-                     time.sleep(0.1)
+                     time.sleep(0.1*ebo)
                      if self.please_stop:
                           break
-                     logger.info( f"waiting for connection to {self.o['broker']}")
-                     self.client.loop()
+                     if ebo < 512:
+                          ebo *= 2
+                     logger.info( f"waiting for connection to {self.o['broker']} ebo={ebo}")
+                    
 
                 if not self.connect_in_progress:
                     self.connected=True

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -378,12 +378,12 @@ class MQTT(Moth):
                     self.client.loop_start()
                     ebo=1
                     while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
+                         logger.info( f"waiting for subscription to be set up. (ebo={ebo})")
                          time.sleep(0.1*ebo)
                          if self.please_stop:
                               break
                          if ebo < 512 :
                             ebo *= 2
-                         logger.info( f"waiting for subscription to be set up. (ebo={ebo})")
                     self.connected=True
                     break
                 else: # either 'declare' or 'foreground'
@@ -475,12 +475,12 @@ class MQTT(Moth):
 
                 ebo=1
                 while self.connect_in_progress:
+                     logger.info( f"waiting for connection to {self.o['broker']} ebo={ebo}")
                      time.sleep(0.1*ebo)
                      if self.please_stop:
                           break
                      if ebo < 512:
                           ebo *= 2
-                     logger.info( f"waiting for connection to {self.o['broker']} ebo={ebo}")
                     
 
                 if not self.connect_in_progress:
@@ -677,9 +677,6 @@ class MQTT(Moth):
         # The caller probably doesn't expect the message to get modified by this method, so use a copy of the message
         body = copy.deepcopy(body)
 
-        # The caller probably doesn't expect the message to get modified by this method, so use a copy of the message
-        body = copy.deepcopy(body)
-
         postFormat = body['_format']
 
         if '_deleteOnPost' in body:
@@ -688,7 +685,6 @@ class MQTT(Moth):
             # method to build json and _deleteOnPost would be a guide of what to skip.
             # library for that is jsonfile, but not present in repos so far.
             for k in body['_deleteOnPost']:
-                if k == 'subtopic': continue
                 if k in body:
                     del body[k]
             del body['_deleteOnPost']
@@ -728,7 +724,6 @@ class MQTT(Moth):
             topic = topic.replace('+', '%2B')
 
             del headers['topic']
-            del body['subtopic']
 
             if headers:
                 props.UserProperty=list(map( lambda x :  (x,headers[x]) , headers ))

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -35,6 +35,8 @@ class V03(PostFormat):
        """
         msg = sarracenia.Message()
         msg["_format"] = __name__.split('.')[-1].lower()
+
+
         try:
             msg.copyDict(json.loads(body))
         except Exception as ex:

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -376,6 +376,7 @@ def file_truncate(options, msg):
             fp.close()
 
         msg['subtopic'] = msg['relPath'].split(os.sep)[1:-1]
+        msg['_deleteOnPost'] |= set(['subtopic'])
         #msg.set_topic(options.post_topicPrefix,msg.target_relpath)
 
     except:


### PR DESCRIPTION
An element of getting MQTT to be reliable. At this point, the flakey test usually works, as does the dynamic, but the restart test always fails... with 29/36 tests passing.

The changes here makes it pass more tests, but does not fully resolve the issue.  It involves moving the paho.mqtt loop_start() method closer to the connection establishment, and as that caused issues in the tests, it is likely that these are good fixes.  I think it also improves the success rate of flakey... whereas before it passes sometimes, afterward it seems more reliable.

These fixes are likely to be helpful in and of themselves, and serve as a checkpoint for continued work.

Also included is the removal of *message corruption* in that some mqtt messages published included the *subtopic* field which was supposed to be removed prior to putting the message on the wire.


