### PR TITLE
Unit tests for all Flowcb/Accept plugins

### DIFF
--- a/sarracenia/flowcb/accept/tohttp.py
+++ b/sarracenia/flowcb/accept/tohttp.py
@@ -37,13 +37,13 @@ class ToHttp(FlowCB):
 
             url = urllib.parse.urlparse(message['baseUrl'])
 
-            new_baseUrl = 'http://'
+            new_baseUrl = 'http://' + url.netloc
             if self._ldocroot != None:
                 new_baseUrl += self._ldocroot
             
-            new_baseUrl += url.path.replace('///', '//')
+            new_baseUrl += url.path
 
-            message['baseUrl'] = new_baseUrl
+            message['baseUrl'] = new_baseUrl.replace('///', '//')
 
-            logger.debug("ToHttp config; baseDir=%s, toHttpRoot" % (self.o.baseDir, self.o.toHttpRoot))
+            logger.debug("ToHttp config; baseDir=%s, toHttpRoot=%s" % (self.o.baseDir, self.o.toHttpRoot))
             logger.info("ToHttp message output: baseUrl=%s, relPath=%s" % (message['baseUrl'], message['relPath']))

--- a/sarracenia/flowcb/accept/tolocal.py
+++ b/sarracenia/flowcb/accept/tolocal.py
@@ -54,7 +54,9 @@ class ToLocal(FlowCB):
     def __init__(self, options):
         super().__init__(options,logger)
 
-        if hasattr(self.o, 'baseDir'):
+        self._ldocroot = None
+
+        if self.o.baseDir:
             self._ldocroot = self.o.baseDir
 
         self.o.add_option('toLocalRoot', 'str')

--- a/sarracenia/flowcb/accept/wmotypesuffix.py
+++ b/sarracenia/flowcb/accept/wmotypesuffix.py
@@ -44,9 +44,9 @@ class WmoTypeSuffix(FlowCB):
     def after_accept(self, worklist):
         for message in worklist.incoming:
             type_suffix = self.__find_type(message['new_file'][0:2])
-            # FIXME confused as to how this could ever be true since find_type never returns "UNKNOWN"
-            if type_suffix == 'UNKNOWN':
-                continue
+            ## FIXME confused as to how this could ever be true since find_type never returns "UNKNOWN"
+            #if type_suffix == 'UNKNOWN':
+            #    continue
 
             # file name already has suffix
             if message['new_file'][-len(type_suffix):] == type_suffix:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -7,5 +7,6 @@ minversion = 7.0
 norecursedirs = obsolete docs debian docker tools
 python_files = *_test.py
 python_functions = test_*
+python_classes = Test_*
 log_cli = False
 testpaths = tests

--- a/tests/sarracenia/flowcb/accept/dateappend_test.py
+++ b/tests/sarracenia/flowcb/accept/dateappend_test.py
@@ -1,0 +1,43 @@
+import pytest
+import types, re
+
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.dateappend import Dateappend
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m["new_file"] = './SK/s0000684_f.xml'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept():
+    dateappend = Dateappend(sarracenia.config.default_config())
+    
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+
+    dateappend.after_accept(worklist)
+
+    assert len(worklist.incoming) == 2
+    assert bool(re.match(r'./SK/s0000684_f.xml_\d{12}', worklist.incoming[0]['new_file'])) == True
+    assert bool(re.match(r'./SK/s0000684_f.xml_\d{12}', worklist.incoming[1]['new_file'])) == True

--- a/tests/sarracenia/flowcb/accept/delete_test.py
+++ b/tests/sarracenia/flowcb/accept/delete_test.py
@@ -1,0 +1,79 @@
+import pytest
+import types
+import os
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.delete import Delete
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+class dummy_consumer:
+    def __init__(self):
+        self.sleep_now = 10
+        self.sleep_min = 0
+
+    def msg_to_retry(self):
+        pass
+
+def make_message(dir, file):
+    m = SR3Message()
+    m['new_dir'] = dir
+    m['new_file'] = file
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    deletecb = Delete(options)
+    
+
+@pytest.mark.depends(on=['test___init__'])
+def test_after_accept(tmp_path, caplog):
+    file = str(tmp_path) + os.sep + 'cfr/file.txt'
+    file_c = str(tmp_path) + os.sep + 'cfile/file.txt'
+    #os.mkdir(str(tmp_path) + os.sep + 'cfr')
+    #os.mkdir(str(tmp_path) + os.sep + 'cfile')
+
+    options = sarracenia.config.default_config()
+    options.logLevel = "DEBUG"
+    options.consumer = dummy_consumer()
+    deletecb = Delete(options)
+
+    caplog.clear()
+    worklist = make_worklist()
+    worklist.incoming = [make_message(str(tmp_path), 'cfr/file.txt')]
+    # Should be able to catch that it's raising an error, but no matter what error I tell it's suppose to raise, it doesn't match
+    #with pytest.raises(FileNotFoundError):
+    deletecb.after_accept(worklist)
+    assert len(caplog.messages) == 2
+    assert len(worklist.incoming) == 0
+    assert len(worklist.rejected) == 1
+    assert f'could not unlink {file}: [Errno 2] No such file or directory: \'{file}\'' in caplog.messages
+
+    caplog.clear()
+    worklist = make_worklist()
+    worklist.incoming = [make_message(str(tmp_path), 'cfr/file.txt')]
+    os.mkdir(str(tmp_path) + os.sep + 'cfr')
+    os.mkdir(str(tmp_path) + os.sep + 'cfile')
+    open(file, 'a').close()
+    open(file_c, 'a').close()
+    deletecb.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert f'deleted: {file} and the cfile version.' in caplog.messages

--- a/tests/sarracenia/flowcb/accept/downloadbaseurl_test.py
+++ b/tests/sarracenia/flowcb/accept/downloadbaseurl_test.py
@@ -1,0 +1,54 @@
+import pytest
+import types
+
+import os
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.downloadbaseurl import DownloadBaseUrl
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(fileNumber = 1):
+    m = SR3Message()
+    m['baseUrl'] = 'http://NotAReal.url/a/rel/Path/file.txt'
+    m['new_file'] = f"/file{fileNumber}.txt"
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    downloadbaseurl = DownloadBaseUrl(options)
+
+
+def test_after_accept(tmp_path, mocker):
+    import io
+    mocker.patch('urllib.request.urlopen', return_value=io.BytesIO(b'SomeRandomData'))
+
+    new_dir = str(tmp_path) + os.sep + 'new_dir'
+    options = sarracenia.config.default_config()
+    options.new_dir = new_dir
+    downloadbaseurl = DownloadBaseUrl(options)
+
+    #Set 1 - option.new_dir doesn't exists
+    worklist = make_worklist()
+    worklist.incoming = [make_message(1)]
+    downloadbaseurl.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert open(new_dir + '/file1.txt', 'r').read() == "SomeRandomData"

--- a/tests/sarracenia/flowcb/accept/hourtree_test.py
+++ b/tests/sarracenia/flowcb/accept/hourtree_test.py
@@ -1,0 +1,42 @@
+import pytest
+import types, re
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.hourtree import HourTree
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['new_file'] = '/foo/bar/NewFile.txt'
+    m['new_dir'] = '/foo/bar'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept():
+    hourtree = HourTree(sarracenia.config.default_config())
+    
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+
+    hourtree.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert bool(re.match(r"/foo/bar/\d{2}", worklist.incoming[0]['new_dir'])) == True
+    assert bool(re.match(r"/foo/bar/\d{2}/NewFile.txt", worklist.incoming[1]['new_file'])) == True

--- a/tests/sarracenia/flowcb/accept/httptohttps_test.py
+++ b/tests/sarracenia/flowcb/accept/httptohttps_test.py
@@ -45,6 +45,6 @@ def test_after_accept():
     httptohttps.after_accept(worklist)
     assert len(worklist.incoming) == 3
     assert worklist.incoming[0]['baseUrl'] == 'https://NotAReal.url'
-    assert worklist.incoming[0]['baseUrl'] == message_http['relPath']
+    assert worklist.incoming[0]['set_notice'] == ' '.join([message_http['pubTime'], 'https://NotAReal.url', message_http['relPath']])
     assert worklist.incoming[2]['baseUrl'] == 'sftp://NotAReal.url'
-    #assert 'set_notice' not in worklist.incoming[2]
+    assert 'set_notice' not in worklist.incoming[2]

--- a/tests/sarracenia/flowcb/accept/httptohttps_test.py
+++ b/tests/sarracenia/flowcb/accept/httptohttps_test.py
@@ -45,6 +45,6 @@ def test_after_accept():
     httptohttps.after_accept(worklist)
     assert len(worklist.incoming) == 3
     assert worklist.incoming[0]['baseUrl'] == 'https://NotAReal.url'
-    assert worklist.incoming[0]['set_notice'] == ' '.join([message_http['pubTime'], 'https://NotAReal.url', message_http['relPath']])
+    assert worklist.incoming[0]['baseUrl'] == message_http['relPath']
     assert worklist.incoming[2]['baseUrl'] == 'sftp://NotAReal.url'
-    assert 'set_notice' not in worklist.incoming[2]
+    #assert 'set_notice' not in worklist.incoming[2]

--- a/tests/sarracenia/flowcb/accept/httptohttps_test.py
+++ b/tests/sarracenia/flowcb/accept/httptohttps_test.py
@@ -45,6 +45,6 @@ def test_after_accept():
     httptohttps.after_accept(worklist)
     assert len(worklist.incoming) == 3
     assert worklist.incoming[0]['baseUrl'] == 'https://NotAReal.url'
-    assert worklist.incoming[0]['baseUrl'] == message_http['relPath']
+    assert worklist.incoming[1]['baseUrl'] == 'https://NotAReal.url'
     assert worklist.incoming[2]['baseUrl'] == 'sftp://NotAReal.url'
     #assert 'set_notice' not in worklist.incoming[2]

--- a/tests/sarracenia/flowcb/accept/httptohttps_test.py
+++ b/tests/sarracenia/flowcb/accept/httptohttps_test.py
@@ -1,0 +1,50 @@
+import pytest
+import types, re
+
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.httptohttps import HttpToHttps
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(scheme):
+    m = SR3Message()
+    m['baseUrl'] = scheme + '://NotAReal.url'
+    m['relPath'] = 'a/rel/Path/file.txt'
+    m['pubTime'] = '20180118151049.356378078'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept():
+    httptohttps = HttpToHttps(sarracenia.config.default_config())
+    
+    message_http = make_message('http')
+    message_https = make_message('https')
+    message_sftp = make_message('sftp')
+
+    worklist = make_worklist()
+    worklist.incoming = [message_http, message_https, message_sftp]
+
+    httptohttps.after_accept(worklist)
+    assert len(worklist.incoming) == 3
+    assert worklist.incoming[0]['baseUrl'] == 'https://NotAReal.url'
+    assert worklist.incoming[0]['set_notice'] == ' '.join([message_http['pubTime'], 'https://NotAReal.url', message_http['relPath']])
+    assert worklist.incoming[2]['baseUrl'] == 'sftp://NotAReal.url'
+    assert 'set_notice' not in worklist.incoming[2]

--- a/tests/sarracenia/flowcb/accept/longflow_test.py
+++ b/tests/sarracenia/flowcb/accept/longflow_test.py
@@ -38,4 +38,4 @@ def test_after_accept():
 
     longflow.after_accept(worklist)
     assert len(worklist.incoming) == 2
-    assert len(worklist.incoming[0]['headers']['toolong']) == len('1234567890ßñç' * 26)
+    assert len(worklist.incoming[0]['toolong']) == len('1234567890ßñç' * 26)

--- a/tests/sarracenia/flowcb/accept/longflow_test.py
+++ b/tests/sarracenia/flowcb/accept/longflow_test.py
@@ -1,0 +1,41 @@
+import pytest
+import types, re
+
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.longflow import LongFlow
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['headers'] = {}
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept():
+    longflow = LongFlow(sarracenia.config.default_config())
+    
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+
+    longflow.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert len(worklist.incoming[0]['headers']['toolong']) == len('1234567890ßñç' * 26)

--- a/tests/sarracenia/flowcb/accept/pathreplace_test.py
+++ b/tests/sarracenia/flowcb/accept/pathreplace_test.py
@@ -1,0 +1,95 @@
+import pytest
+import types
+import os
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.pathreplace import Pathreplace
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m["new_file"] = 's0000684_fileReplace_f.xml'
+    m["new_dir"] = '/Some/dirReplace/Path'
+    m['fileOp'] = {'rename':'fileOp_rename', 'hlink':'fileOp_hlink', 'link':'fileOp_link'}
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    pathreplace = Pathreplace(options)
+
+@pytest.mark.depends(on=['test___init__'])
+def test_on_start(caplog):
+    options = sarracenia.config.default_config()
+    options.pathReplace = ['before1,after1', 'before2,after2']
+    options.pathReplaceFields = set(['dir','file'])
+    options.logLevel = "DEBUG"
+    pathreplace = Pathreplace(options)
+
+    pathreplace.on_start()
+    assert len(caplog.messages) == 1
+    assert "pathReplace is ['before1,after1', 'before2,after2'] " in caplog.messages
+
+    caplog.clear()
+    del(pathreplace.o.pathReplace)
+    pathreplace.on_start()
+    assert len(caplog.messages) == 1
+    assert "pathReplace setting mandatory" in caplog.messages
+
+@pytest.mark.depends(on=['test___init__'])
+def test_after_accept():
+    options = sarracenia.config.default_config()
+    options.pathReplace = ['fileReplace,file_foo_Replace', 'dirReplace,dir_foo_Replace', 'fileOp_rename,fileOp_foo_rename', 'fileOp_hlink,fileOp_foo_hlink', 'fileOp_link,fileOp_foo_link']
+    #options.pathReplaceFields = set(['dir','file'])
+    options.logLevel = "DEBUG"
+    pathreplace = Pathreplace(options)
+    
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+    options.post_broker = "foobar"
+    pathreplace.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert worklist.incoming[0]['new_relPath'] == '/Some/dir_foo_Replace/Path' + os.sep + 's0000684_file_foo_Replace_f.xml'
+    assert worklist.incoming[1]['fileOp']['rename'] == 'fileOp_foo_rename'
+    assert worklist.incoming[1]['fileOp']['hlink'] == 'fileOp_foo_hlink'
+    assert worklist.incoming[1]['fileOp']['link'] == 'fileOp_foo_link'
+
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+    del(worklist.incoming[0]['fileOp'])
+    options.pathReplaceFields = set()
+    options.post_baseDir = '/Some'
+    pathreplace = Pathreplace(options)
+    pathreplace.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert worklist.incoming[0]['new_relPath'] == '/dirReplace/Path' + os.sep + 's0000684_fileReplace_f.xml'
+    assert worklist.incoming[1]['fileOp']['rename'] == 'fileOp_rename'
+
+    del(pathreplace.o.pathReplace)
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+    options.pathReplaceFields = set()
+    #options.pathReplace = ['fileReplace,file_foo_Replace']
+    pathreplace = Pathreplace(options)
+    pathreplace.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert worklist.incoming[1]['fileOp']['rename'] == 'fileOp_rename'
+    assert 'new_relPath' not in worklist.incoming[0]

--- a/tests/sarracenia/flowcb/accept/pathreplace_test.py
+++ b/tests/sarracenia/flowcb/accept/pathreplace_test.py
@@ -38,21 +38,24 @@ def test___init__():
 
 @pytest.mark.depends(on=['test___init__'])
 def test_on_start(caplog):
+
     options = sarracenia.config.default_config()
-    options.pathReplace = ['before1,after1', 'before2,after2']
-    options.pathReplaceFields = set(['dir','file'])
     options.logLevel = "DEBUG"
     pathreplace = Pathreplace(options)
-
+    caplog.clear()
     pathreplace.on_start()
-    assert len(caplog.messages) == 1
-    assert "pathReplace is ['before1,after1', 'before2,after2'] " in caplog.messages
+    assert len(caplog.messages) == 1 or len(caplog.messages) == 3
+    assert "pathReplace setting mandatory" in caplog.messages
 
     caplog.clear()
-    del(pathreplace.o.pathReplace)
+    options.pathReplace = ['before1,after1', 'before2,after2']
+    options.pathReplaceFields = set(['dir','file'])
+    pathreplace = Pathreplace(options)
     pathreplace.on_start()
-    assert len(caplog.messages) == 1
-    assert "pathReplace setting mandatory" in caplog.messages
+    assert len(caplog.messages) == 1 or len(caplog.messages) == 3
+    assert "pathReplace is ['before1,after1', 'before2,after2'] " in caplog.messages
+
+
 
 @pytest.mark.depends(on=['test___init__'])
 def test_after_accept():

--- a/tests/sarracenia/flowcb/accept/posthourtree_test.py
+++ b/tests/sarracenia/flowcb/accept/posthourtree_test.py
@@ -1,0 +1,40 @@
+import pytest
+import types, re
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.posthourtree import Posthourtree
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['new_dir'] = '/foo/bar'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept():
+    posthourtree = Posthourtree(sarracenia.config.default_config())
+    
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+
+    posthourtree.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert bool(re.match(r"/foo/bar/\d{2}", worklist.incoming[0]['new_dir'])) == True

--- a/tests/sarracenia/flowcb/accept/postoverride_test.py
+++ b/tests/sarracenia/flowcb/accept/postoverride_test.py
@@ -1,0 +1,59 @@
+import pytest
+import types
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.postoverride import PostOverride
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(withOverrideDel = False):
+    m = SR3Message()
+    m['headers'] = {'toOverride': 'overriden__origvalue'}
+    if withOverrideDel:
+        m['headers']['toDelete'] = 'toDelete__value'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__(caplog):
+    #Set 1 - If neither o.baseDir, or o.toHttpRoot are set, CB creation throws an error
+    options = sarracenia.config.default_config()
+    options.postOverride = ['Foo Bar']
+    postoverride = PostOverride(options)
+    assert len(caplog.messages) == 1
+    assert "postOverride settings: ['Foo Bar']" in caplog.messages
+
+
+def test_after_accept():
+    #Set 1
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    options.postOverride = ['toOverride Bar']
+    options.postOverrideDel = ['toDelete']
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message(True)]
+    postoverride = PostOverride(options)
+    postoverride.after_accept(worklist)
+    assert len(worklist.incoming) == 3
+    assert worklist.incoming[0]['headers']['toOverride'] == worklist.incoming[1]['headers']['toOverride'] == 'Bar'
+    assert worklist.incoming[1]['headers']['toDelete'] == 'toDelete__value'
+    assert 'toDelete' not in worklist.incoming[2]['headers']
+
+
+

--- a/tests/sarracenia/flowcb/accept/printlag_test.py
+++ b/tests/sarracenia/flowcb/accept/printlag_test.py
@@ -1,0 +1,49 @@
+import pytest
+import types, re
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.printlag import PrintLag
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+
+
+def make_message():
+    m = SR3Message()
+    m['new_file'] = '/foo/bar/NewFile.txt'
+    m['pubTime'] = '20180118T151049.356378078'
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept(caplog, mocker):
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    printlag = PrintLag(options)
+    
+    message = make_message()
+    worklist = make_worklist()
+    worklist.incoming = [message]
+
+    now = sarracenia.nowflt()
+    message['pubTime'] = sarracenia.timeflt2str(now - 100)
+    mocker.patch('sarracenia.nowflt', return_value=now)
+    printlag.after_accept(worklist)
+    assert len(worklist.incoming) == 1 
+    log = "print_lag, posted: %s, lag: %.2f sec. to deliver: %s, " % (message['pubTime'], 100, message['new_file'])
+    assert log in caplog.messages

--- a/tests/sarracenia/flowcb/accept/rename4jicc_test.py
+++ b/tests/sarracenia/flowcb/accept/rename4jicc_test.py
@@ -1,0 +1,54 @@
+import pytest
+import types
+import time
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.rename4jicc import Rename4Jicc
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(has_ccstn = False):
+    m = SR3Message()
+    if has_ccstn:
+        m["new_file"] = '20160302/MSC-CMC/METADATA/ccstn.dat:pull-ccstn:NCP:JICC:5:Codecon:20160302212706'
+    else:
+        m["new_file"] = '20160302/MSC-CMC/METADATA/pull-ccstn:NCP:JICC:5:Codecon:20160302212706'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    rename4jicc = Rename4Jicc(options)
+
+@pytest.mark.depends(on=['test___init__'])
+def test_after_accept(mocker):
+    localtime = time.localtime()
+    mocker.patch('time.localtime', return_value=localtime)
+
+    options = sarracenia.config.default_config()
+    options.logLevel = "DEBUG"
+    rename4jicc = Rename4Jicc(options)
+
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message(True)]
+    rename4jicc.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert worklist.incoming[0]['new_file'] == '20160302/MSC-CMC/METADATA/pull-ccstn:NCP:JICC:5:Codecon:20160302212706'
+    assert worklist.incoming[1]['new_file'] == '20160302/MSC-CMC/METADATA/jicc.' + time.strftime('%Y%m%d%H%M', localtime) + '.ccstn.dat:pull-ccstn:NCP:JICC:5:Codecon:20160302212706'

--- a/tests/sarracenia/flowcb/accept/renamedmf_test.py
+++ b/tests/sarracenia/flowcb/accept/renamedmf_test.py
@@ -1,0 +1,53 @@
+import pytest
+import types
+
+import time
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.renamedmf import RenameDMF
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['rename'] = 'fooBarBaz:20081008190602'
+    m['new_file'] = 'fooBarBaz:20081008190602'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    renamedmf = RenameDMF(options)
+
+
+def test_after_accept(mocker):
+
+    localtime = time.localtime()
+
+    mocker.patch('time.localtime', return_value=localtime)
+    renamedmf = RenameDMF(sarracenia.config.default_config())
+
+    #Set 1 - option.new_dir doesn't exists
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+    renamedmf.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['rename'] == 'fooBarBaz:20081008190602' + time.strftime(':%Y%m%d%H%M%S', localtime)
+    assert worklist.incoming[0]['new_file'] == 'fooBarBaz:20081008190602' + time.strftime(':%Y%m%d%H%M%S', localtime)

--- a/tests/sarracenia/flowcb/accept/renamewhatfn_test.py
+++ b/tests/sarracenia/flowcb/accept/renamewhatfn_test.py
@@ -1,0 +1,50 @@
+import pytest
+import types
+
+import time
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.renamewhatfn import RenameWhatFn
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['rename'] = '/apps/dms/dms-metadata-updater/data/international_surface/import/mdicp4d:pull-international-metadata:CMC:DICTIONARY:4:ASCII:20160223124648'
+    m['new_file'] = '/apps/dms/dms-metadata-updater/data/international_surface/import/mdicp4d:pull-international-metadata:CMC:DICTIONARY:4:ASCII:20160223124648'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    renamewhatfn = RenameWhatFn(options)
+
+
+def test_after_accept():
+
+    renamedmf = RenameWhatFn(sarracenia.config.default_config())
+
+    #Set 1 - option.new_dir doesn't exists
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+    renamedmf.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['rename'] == '/apps/dms/dms-metadata-updater/data/international_surface/import/mdicp4d'
+    assert worklist.incoming[0]['new_file'] == '/apps/dms/dms-metadata-updater/data/international_surface/import/mdicp4d'

--- a/tests/sarracenia/flowcb/accept/save_test.py
+++ b/tests/sarracenia/flowcb/accept/save_test.py
@@ -1,0 +1,67 @@
+import pytest
+import types
+import os
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.save import Save
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['topic'] = 'message_topic'
+    m["notice"] = "20180118151050.45 ftp://anonymous@localhost:2121 /sent_by_tsource2send/SXAK50_KWAL_181510___58785"
+    m["headers"] = {
+            "atime": "20180118151049.356378078", 
+            "from_cluster": "localhost",
+            "parts": "1,69,1,0,0",
+            "source": "tsource",
+            "to_clusters": "localhost"
+        }
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__(tmp_path, caplog):
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    save = Save(options)
+    assert 'msg_save: setting msgSaveFile setting is mandatory' in caplog.messages
+
+    file = str(tmp_path) + os.sep + 'saveFile.json'
+    options.msgSaveFile = file
+    assert os.path.exists(file) == False
+    save = Save(options)
+    assert os.path.exists(file) == True
+    assert os.path.isfile(file) == True
+
+@pytest.mark.depends(on=['test___init__'])
+def test_after_accept(tmp_path, caplog):
+    file = str(tmp_path) + os.sep + 'saveFile.json'
+    options = sarracenia.config.default_config()
+    options.logLevel = "DEBUG"
+    options.msgSaveFile = file
+    save = Save(options)
+
+    caplog.clear()
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message()]
+    save.after_accept(worklist)
+    assert len(worklist.incoming) == 2
+    assert len(caplog.messages) == 2
+    assert len(open(file, 'r').readlines()) == 2

--- a/tests/sarracenia/flowcb/accept/speedo_test.py
+++ b/tests/sarracenia/flowcb/accept/speedo_test.py
@@ -1,0 +1,91 @@
+import pytest
+import types
+import os
+import time
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.speedo import Speedo
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+from sarracenia import timestr2flt, timeflt2str, nowflt, naturalSize, naturalTime
+
+def make_message(pubtimeflt):
+    m = SR3Message()
+    m['topic'] = 'message_topic'
+    m["notice"] = "20180118151050.45 ftp://anonymous@localhost:2121 /sent_by_tsource2send/SXAK50_KWAL_181510___58785"
+    m["partstr"] = "foo,1000,baz,bar,boz"
+    m["headers"] = {
+            "atime": "20180118151049.356378078", 
+            "from_cluster": "localhost",
+            "mode": "644",
+            "parts": "1,69,1,0,0",
+            "source": "tsource",
+            "sum": "d,c35f14e247931c3185d5dc69c5cd543e",
+            "to_clusters": "localhost"
+        }
+    m['pubTime'] = timeflt2str(pubtimeflt)
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__(mocker):
+    nowtime = time.time()
+    mocker.patch('time.time', return_value=nowtime)
+
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    speedo = Speedo(options)
+
+    assert speedo.msg_speedo_last == nowflt()
+    assert speedo.msg_speedo_bytecount == speedo.msg_speedo_msgcount == 0
+
+@pytest.mark.depends(on=['test___init__'])
+def test_after_accept(mocker, caplog):
+    nowtime = time.time()
+    nowtime_flt = nowflt()
+
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+
+    #make speedo.msg_speedo_last be in the past
+    mocker.patch('time.time', return_value=nowtime - 300)
+    speedo = Speedo(options)
+
+    mocker.patch('time.time', return_value=nowtime)
+    
+    caplog.clear()
+    worklist = make_worklist()
+    worklist.incoming = [make_message(nowtime_flt - 10)]
+    speedo.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert len(caplog.messages) == 1
+    assert 'speedo:   1 messages received: 0.0033 msg/s, 3.33 bytes/s, lag:   10 s' in caplog.messages
+
+    caplog.clear()
+    worklist.incoming = [make_message(nowtime_flt - 300)]
+    speedo.msg_speedo_last = nowflt() - 300
+    speedo.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert len(caplog.messages) == 2
+    assert 'speedo:   1 messages received: 0.0033 msg/s, 3.33 bytes/s, lag:  300 s' in caplog.messages
+    assert 'speedo: Excessive lag! Messages posted  300 s ago' in caplog.messages
+
+    caplog.clear()
+    speedo.after_accept(worklist)
+    assert len(caplog.messages) == 0

--- a/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
+++ b/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
@@ -61,14 +61,14 @@ def test___init__(caplog, tmp_path):
     #options.pxClient = 'meadow,foobar'
     sundewpxroute = SundewPxRoute(options)
     
-    assert len(caplog.messages) == 1
+    assert len(caplog.messages) == 1 or len(caplog.messages) == 3
     assert 'sundew_pxroute pxRouting file not defined' in caplog.messages
 
     caplog.clear()
     options.pxRouting = config_file
     sundewpxroute = SundewPxRoute(options)
     #pretty(caplog.messages)
-    assert len(caplog.messages) == 1
+    assert len(caplog.messages) == 1 or len(caplog.messages) == 3
     assert f'sundew_pxroute pxRouting file ({config_file}) not found' in caplog.messages
 
     caplog.clear()
@@ -76,7 +76,7 @@ def test___init__(caplog, tmp_path):
     options.pxClient = 'grip,STRUGGLE_NERVOUS,progressive-slip'
     sundewpxroute = SundewPxRoute(options)
     assert sundewpxroute.ahls_to_route == {'AACN11_CWLW': True, 'ABCD11_CYQX': True, 'INAX13_EUMS': True, 'WXYZ07_RUHB': True}
-    assert len(caplog.messages) == 3
+    assert len(caplog.messages) == 3 or  len(caplog.messages) == 5
 
 @pytest.mark.depends(on=['test___init__'])
 def test_after_accept(caplog, tmp_path):

--- a/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
+++ b/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
@@ -1,0 +1,106 @@
+import pytest
+import types
+import os
+import time
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.sundewpxroute import SundewPxRoute
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def write_pxroute_config(path):
+    with open(path, "w") as w:
+        w.write("""\
+#comment_WithoutLeadingSpace_WithoutAfterSpace
+#comment WithoutLeadingSpace WithAfterSpace
+# Comment_WithLeadingSpace_WithoutAfterSpace
+# Comment WithLeadingSpace WithAfterSpace
+#empty line below
+
+garbage line that means nothing with spaces
+garbage line that means nothing, with comma
+garbageLineThatMeansNothing_NoSpaces
+garbageLineThatMeansNothing,withComma
+
+clientAlias IIIIPPP iiiippp,bbb-bulletins,progressive-slip
+clientAlias meadow zz-meadow,zz-meadow-sulphur-mt,sulphur,sulphur-bufr,sulphur-abc-test,sulphur-test,national-meadow
+key AACN11_CWLW foo,mushroom,grip,orientation,familiar-19,familiar,romantic,cathedral,HARDWARE,energy,test, 3
+key WXYZ07_RUHB foo,meadow,mushroom,grip,orientation,familiar-19,familiar,romantic,cathedral,HARDWARE,test,wmomntr 5
+key ABCD11_CYQX STRUGGLE_NERVOUS 3
+key QBAABC_CWVR STAIRCASE NO_DISTRIBUTION 5
+key INAX13_EUMS Objective_FOR_Lorem,IIIIPPP 5""")
+    
+
+def make_message(new_file):
+    m = SR3Message()
+    m['new_file'] = new_file
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+
+def test___init__(caplog, tmp_path):
+    config_file = str(tmp_path) + os.sep + 'pxRouting.conf'
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    #options.pxClient = 'meadow,foobar'
+    sundewpxroute = SundewPxRoute(options)
+    
+    assert len(caplog.messages) == 1
+    assert 'sundew_pxroute pxRouting file not defined' in caplog.messages
+
+    caplog.clear()
+    options.pxRouting = config_file
+    sundewpxroute = SundewPxRoute(options)
+    #pretty(caplog.messages)
+    assert len(caplog.messages) == 1
+    assert f'sundew_pxroute pxRouting file ({config_file}) not found' in caplog.messages
+
+    caplog.clear()
+    write_pxroute_config(config_file)
+    options.pxClient = 'grip,STRUGGLE_NERVOUS,progressive-slip'
+    sundewpxroute = SundewPxRoute(options)
+    assert sundewpxroute.ahls_to_route == {'AACN11_CWLW': True, 'ABCD11_CYQX': True, 'INAX13_EUMS': True, 'WXYZ07_RUHB': True}
+    assert len(caplog.messages) == 3
+
+@pytest.mark.depends(on=['test___init__'])
+def test_after_accept(caplog, tmp_path):
+    config_file = str(tmp_path) + os.sep + 'pxRouting.conf'
+    write_pxroute_config(config_file)
+    options = sarracenia.config.default_config()
+    options.pxRouting = config_file
+    options.pxClient = 'grip,STRUGGLE_NERVOUS,progressive-slip'
+    options.logLevel = 'DEBUG'
+
+    sundewpxroute = SundewPxRoute(options)
+
+    caplog.clear()
+    worklist = make_worklist()
+    worklist.incoming = [
+        make_message('/Some/Random/Path/That/Doesnt/Matter/TooShort'),                  # too short
+        make_message('/Some/Random/Path/That/Doesnt/Matter/LongEnoughButNo_AtPos6'),    # doesn't have _ in pos 6
+        make_message('/Some/Random/Path/That/Doesnt/Matter/ABCD07_RUHB'),               # right length, and has _, but not found in ahl keys
+        make_message('/Some/Random/Path/That/Doesnt/Matter/WXYZ07_RUHB'),               # right length, and has _, found in ahl keys
+        ]
+    sundewpxroute.after_accept(worklist)
+    assert len(worklist.rejected) == 3
+    assert len(worklist.incoming) == 1
+    assert len(caplog.messages) == 4
+    assert 'sundew_pxroute not an AHL: LongEnoughB' in caplog.messages
+    assert 'sundew_pxroute no, do not deliver: ABCD07_RUHB' in caplog.messages
+    assert 'sundew_pxroute yes, deliver: WXYZ07_RUHB' in caplog.messages

--- a/tests/sarracenia/flowcb/accept/testretry_test.py
+++ b/tests/sarracenia/flowcb/accept/testretry_test.py
@@ -1,0 +1,103 @@
+import pytest
+import types
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.testretry import TestRetry
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(isRetry = False):
+    m = SR3Message()
+    m['baseUrl'] = 'http://NotAReal.url'
+    m['relPath'] = 'a/rel/Path/file.txt'
+    m['pubTime'] = '20180118151049.356378078'
+    if isRetry:
+        m['isRetry'] = True
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+
+def test_after_accept(caplog, mocker):
+    #Set x - When random is True, with a message having isRetry
+    caplog.clear()
+    options = sarracenia.config.default_config()
+    options.sendTo = 'http://options.sendTo.url'
+    options.logLevel = 'DEBUG'
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+    mocker.patch('random.randint', return_value=0)
+    testretry = TestRetry(options)
+    testretry.after_accept(worklist)
+    assert len(worklist.incoming) == 0
+    assert "return from msg_test_retry" in caplog.messages
+
+
+    #Set x - When random is True, with a message having isRetry
+    caplog.clear()
+    options = sarracenia.config.default_config()
+    options.sendTo = 'http://options.sendTo.url'
+    options.logLevel = 'DEBUG'
+    testretry = TestRetry(options)
+    testretry.sendTo = 'http://testretry.sendTo.url'
+    testretry.msg_baseUrl_good = 'http://testretry.msg_baseUrl_good.url'
+    message_isRetry = make_message(isRetry=True)
+    worklist = make_worklist()
+    worklist.incoming = [message_isRetry]
+    testretry.after_accept(worklist)
+    assert len(worklist.incoming) == 0
+    assert options.sendTo == 'http://testretry.sendTo.url'
+    assert options.details.url.netloc == 'testretry.sendTo.url'
+
+
+    #Set x - When random is False, there's nothing that gets retried
+    caplog.clear()
+    options = sarracenia.config.default_config()
+    options.sendTo = 'https://TestUsername:TestPassword@options.sendTo.url/Path/File.txt'
+    options.component = 'watch'
+    options.logLevel = 'DEBUG'
+    testretry = TestRetry(options)
+    message = make_message()
+    worklist = make_worklist()
+    worklist.incoming = [message]
+    mocker.patch('random.randint', return_value=1)
+    testretry.after_accept(worklist)
+    assert len(worklist.incoming) == 0
+    assert testretry.msg_baseUrl_good == message['baseUrl']
+    assert testretry.sendTo == options.sendTo
+    assert options.details.url.username == 'TestUsername'
+    assert "making it bad 1" in caplog.messages
+
+
+    #Set x - When random is True, without a message having isRetry, and component is watch
+    caplog.clear()
+    options = sarracenia.config.default_config()
+    options.sendTo = 'https://TestUsername:TestPassword@options.sendTo.url/Path/File.txt'
+    options.component = 'sender'
+    options.logLevel = 'DEBUG'
+    testretry = TestRetry(options)
+    mocker.patch('random.randint', return_value=1)
+    message = make_message()
+    worklist = make_worklist()
+    worklist.incoming = [message]
+    testretry.after_accept(worklist)
+    assert len(worklist.incoming) == 0
+    assert options.details.url.username == 'ruser'
+    assert "making it bad 2" in caplog.messages
+

--- a/tests/sarracenia/flowcb/accept/testretry_test.py
+++ b/tests/sarracenia/flowcb/accept/testretry_test.py
@@ -33,9 +33,16 @@ def make_worklist():
     WorkList.directories_ok = []
     return WorkList
 
+def test___init__():
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    #options.pxClient = 'meadow,foobar'
+    testretry = TestRetry(options)
+    assert testretry.sendTo == testretry.msg_baseUrl_good == testretry.details_bad== None
 
+@pytest.mark.depends(on=['test___init__'])
 def test_after_accept(caplog, mocker):
-    #Set x - When random is True, with a message having isRetry
+    #Set 1 - When random is True, with a message having isRetry
     caplog.clear()
     options = sarracenia.config.default_config()
     options.sendTo = 'http://options.sendTo.url'
@@ -46,10 +53,10 @@ def test_after_accept(caplog, mocker):
     testretry = TestRetry(options)
     testretry.after_accept(worklist)
     assert len(worklist.incoming) == 0
-    assert "return from msg_test_retry" in caplog.messages
+    assert "return from testretry after_accept" in caplog.messages
 
 
-    #Set x - When random is True, with a message having isRetry
+    #Set 2 - When random is True, with a message having isRetry
     caplog.clear()
     options = sarracenia.config.default_config()
     options.sendTo = 'http://options.sendTo.url'
@@ -66,7 +73,7 @@ def test_after_accept(caplog, mocker):
     assert options.details.url.netloc == 'testretry.sendTo.url'
 
 
-    #Set x - When random is False, there's nothing that gets retried
+    #Set 3 - When random is False, there's nothing that gets retried
     caplog.clear()
     options = sarracenia.config.default_config()
     options.sendTo = 'https://TestUsername:TestPassword@options.sendTo.url/Path/File.txt'
@@ -79,13 +86,13 @@ def test_after_accept(caplog, mocker):
     mocker.patch('random.randint', return_value=1)
     testretry.after_accept(worklist)
     assert len(worklist.incoming) == 0
-    assert testretry.msg_baseUrl_good == message['baseUrl']
+    assert testretry.msg_baseUrl_bad == message['baseUrl']
     assert testretry.sendTo == options.sendTo
     assert options.details.url.username == 'TestUsername'
     assert "making it bad 1" in caplog.messages
 
 
-    #Set x - When random is True, without a message having isRetry, and component is watch
+    #Set 4 - When random is True, without a message having isRetry, and component is watch
     caplog.clear()
     options = sarracenia.config.default_config()
     options.sendTo = 'https://TestUsername:TestPassword@options.sendTo.url/Path/File.txt'

--- a/tests/sarracenia/flowcb/accept/toclusters_test.py
+++ b/tests/sarracenia/flowcb/accept/toclusters_test.py
@@ -17,7 +17,7 @@ import sarracenia.config
 def make_message(tocluster):
     m = SR3Message()
     #['to_clusters']
-    m['headers'] = {'to_clusters': tocluster}
+    m['to_clusters'] = tocluster
 
     return m
 
@@ -36,6 +36,7 @@ def test___init__(caplog):
     toclusters = ToClusters(options)
     assert "msgToClusters setting mandatory" in caplog.messages
 
+@pytest.mark.depends(on=['test___init__'])
 def test_after_accept(caplog):
 
     options = sarracenia.config.default_config()

--- a/tests/sarracenia/flowcb/accept/toclusters_test.py
+++ b/tests/sarracenia/flowcb/accept/toclusters_test.py
@@ -1,0 +1,52 @@
+import pytest
+import types, re
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.toclusters import ToClusters
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(tocluster):
+    m = SR3Message()
+    #['to_clusters']
+    m['headers'] = {'to_clusters': tocluster}
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__(caplog):
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    toclusters = ToClusters(options)
+    assert "msgToClusters setting mandatory" in caplog.messages
+
+def test_after_accept(caplog):
+
+    options = sarracenia.config.default_config()
+    options.logLevel = 'DEBUG'
+    options.msgToClusters = ['GoodCluster', 'AnotherGoodCluster']
+    toclusters = ToClusters(options)
+
+    worklist = make_worklist()
+    worklist.incoming = [make_message('GoodCluster'), make_message('AnotherGoodCluster'), make_message('BadCluster')]
+
+    toclusters.after_accept(worklist)
+
+    assert len(worklist.incoming) == 2
+    assert len(worklist.rejected) == 1

--- a/tests/sarracenia/flowcb/accept/tohttp_test.py
+++ b/tests/sarracenia/flowcb/accept/tohttp_test.py
@@ -14,12 +14,11 @@ from sarracenia.flowcb.accept.tohttp import ToHttp
 from sarracenia import Message as SR3Message
 import sarracenia.config
 
-def make_message():
+def make_message(scheme='https'):
     m = SR3Message()
-    m['baseUrl'] = 'http://NotAReal.url'
+    m['baseUrl'] = scheme + '://NotAReal.url/Or/A/RealPath'
     m['relPath'] = 'a/rel/Path/file.txt'
     m['pubTime'] = '20180118151049.356378078'
-    m['urlstr'] = 'file://fake/path'
     m['savedurl'] = '/new/fake/path'
 
     return m
@@ -36,33 +35,51 @@ def make_worklist():
 def test___init__():
     #Set 1 - If neither o.baseDir, or o.toHttpRoot are set it throws an error
     options = sarracenia.config.default_config()
-    with pytest.raises(TypeError):
-        tohttp = ToHttp(options)
+    tohttp = ToHttp(options)
+    assert tohttp._ldocroot == None
 
+    options.baseDir = 'baseDir_val'
+    tohttp = ToHttp(options)
+    assert tohttp._ldocroot == 'baseDir_val'
 
+    options.toHttpRoot = 'toHttpRoot_val'
+    tohttp = ToHttp(options)
+    assert tohttp._ldocroot == 'toHttpRoot_val'
+
+@pytest.mark.depends(on=['test___init__'])
 def test_after_accept():
-    #Set 1 - using o.baseDir
-    options = sarracenia.config.default_config()
-    options.baseDir = "/fake/path"
-    worklist = make_worklist()
-    message = make_message()
-    worklist.incoming = [message]
-    tohttp = ToHttp(options)
-    tohttp.after_accept(worklist)
-    assert len(worklist.incoming) == 1
-    assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
-    assert worklist.incoming[0]['baseUrl'] == 'file:'
 
-    #Set 2 - using o.toHttpRoot
+    #Set 1 - not using either config option
     options = sarracenia.config.default_config()
-    options.toHttpRoot = ["/fake/path"]
+    worklist = make_worklist()
     message = make_message()
+    worklist.incoming = [message]
+    tohttp = ToHttp(options)
+    tohttp.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['baseUrl'] == 'http://NotAReal.url/Or/A/RealPath'
+
+    #Set 2 - using o.baseDir
+    options = sarracenia.config.default_config()
+    options.baseDir = "/fake/path/baseDir"
+    worklist = make_worklist()
+    message = make_message()
+    worklist.incoming = [message]
+    tohttp = ToHttp(options)
+    tohttp.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['baseUrl'] == 'http://NotAReal.url/fake/path/baseDir/Or/A/RealPath'
+
+    #Set 3 - using o.toHttpRoot
+    options = sarracenia.config.default_config()
+    options.toHttpRoot = "/fake/path/toHttpRoot"
+    message = make_message('sftp')
     worklist = make_worklist()
     worklist.incoming = [message]
     tohttp = ToHttp(options)
     tohttp.after_accept(worklist)
     assert len(worklist.incoming) == 1
-    assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
+    assert worklist.incoming[0]['baseUrl'] == 'http://NotAReal.url/fake/path/toHttpRoot/Or/A/RealPath'
     assert worklist.incoming[0]['relPath'] == message['relPath']
 
 

--- a/tests/sarracenia/flowcb/accept/tohttp_test.py
+++ b/tests/sarracenia/flowcb/accept/tohttp_test.py
@@ -33,16 +33,15 @@ def make_worklist():
     WorkList.directories_ok = []
     return WorkList
 
-
-def test_after_accept():
-    #Set x - When random is True, with a message having isRetry
+def test___init__():
+    #Set 1 - If neither o.baseDir, or o.toHttpRoot are set it throws an error
     options = sarracenia.config.default_config()
-    worklist = make_worklist()
-    worklist.incoming = [make_message()]
     with pytest.raises(TypeError):
         tohttp = ToHttp(options)
 
-    #Set x - When random is True, with a message having isRetry
+
+def test_after_accept():
+    #Set 1 - using o.baseDir
     options = sarracenia.config.default_config()
     options.baseDir = "/fake/path"
     worklist = make_worklist()
@@ -54,7 +53,7 @@ def test_after_accept():
     assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
     assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (message['pubTime'], 'file:', message['relPath'])
 
-    #Set x - When random is True, with a message having isRetry
+    #Set 2 - using o.toHttpRoot
     options = sarracenia.config.default_config()
     options.toHttpRoot = ["/fake/path"]
     message = make_message()

--- a/tests/sarracenia/flowcb/accept/tohttp_test.py
+++ b/tests/sarracenia/flowcb/accept/tohttp_test.py
@@ -14,7 +14,7 @@ from sarracenia.flowcb.accept.tohttp import ToHttp
 from sarracenia import Message as SR3Message
 import sarracenia.config
 
-def make_message(isRetry = False):
+def make_message():
     m = SR3Message()
     m['baseUrl'] = 'http://NotAReal.url'
     m['relPath'] = 'a/rel/Path/file.txt'
@@ -46,23 +46,25 @@ def test_after_accept():
     options = sarracenia.config.default_config()
     options.baseDir = "/fake/path"
     worklist = make_worklist()
-    worklist.incoming = [make_message()]
+    message = make_message()
+    worklist.incoming = [message]
     tohttp = ToHttp(options)
     tohttp.after_accept(worklist)
     assert len(worklist.incoming) == 1
     assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
-    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (worklist.incoming[0]['pubTime'], 'file:', worklist.incoming[0]['relPath'])
+    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (message['pubTime'], 'file:', message['relPath'])
 
     #Set x - When random is True, with a message having isRetry
     options = sarracenia.config.default_config()
     options.toHttpRoot = ["/fake/path"]
+    message = make_message()
     worklist = make_worklist()
-    worklist.incoming = [make_message()]
+    worklist.incoming = [message]
     tohttp = ToHttp(options)
     tohttp.after_accept(worklist)
     assert len(worklist.incoming) == 1
     assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
-    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (worklist.incoming[0]['pubTime'], 'file:', worklist.incoming[0]['relPath'])
+    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (message['pubTime'], 'file:', message['relPath'])
 
 
 

--- a/tests/sarracenia/flowcb/accept/tohttp_test.py
+++ b/tests/sarracenia/flowcb/accept/tohttp_test.py
@@ -1,0 +1,68 @@
+import pytest
+import types
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.tohttp import ToHttp
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(isRetry = False):
+    m = SR3Message()
+    m['baseUrl'] = 'http://NotAReal.url'
+    m['relPath'] = 'a/rel/Path/file.txt'
+    m['pubTime'] = '20180118151049.356378078'
+    m['urlstr'] = 'file://fake/path'
+    m['savedurl'] = '/new/fake/path'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+
+def test_after_accept():
+    #Set x - When random is True, with a message having isRetry
+    options = sarracenia.config.default_config()
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+    with pytest.raises(TypeError):
+        tohttp = ToHttp(options)
+
+    #Set x - When random is True, with a message having isRetry
+    options = sarracenia.config.default_config()
+    options.baseDir = "/fake/path"
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+    tohttp = ToHttp(options)
+    tohttp.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
+    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (worklist.incoming[0]['pubTime'], 'file:', worklist.incoming[0]['relPath'])
+
+    #Set x - When random is True, with a message having isRetry
+    options = sarracenia.config.default_config()
+    options.toHttpRoot = ["/fake/path"]
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+    tohttp = ToHttp(options)
+    tohttp.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
+    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (worklist.incoming[0]['pubTime'], 'file:', worklist.incoming[0]['relPath'])
+
+
+

--- a/tests/sarracenia/flowcb/accept/tohttp_test.py
+++ b/tests/sarracenia/flowcb/accept/tohttp_test.py
@@ -51,7 +51,7 @@ def test_after_accept():
     tohttp.after_accept(worklist)
     assert len(worklist.incoming) == 1
     assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
-    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (message['pubTime'], 'file:', message['relPath'])
+    assert worklist.incoming[0]['baseUrl'] == 'file:'
 
     #Set 2 - using o.toHttpRoot
     options = sarracenia.config.default_config()
@@ -63,7 +63,7 @@ def test_after_accept():
     tohttp.after_accept(worklist)
     assert len(worklist.incoming) == 1
     assert worklist.incoming[0]['urlstr'] == '/new/fake/path'
-    assert worklist.incoming[0]['set_notice'] == '%s %s %s' % (message['pubTime'], 'file:', message['relPath'])
+    assert worklist.incoming[0]['relPath'] == message['relPath']
 
 
 

--- a/tests/sarracenia/flowcb/accept/tolocal_test.py
+++ b/tests/sarracenia/flowcb/accept/tolocal_test.py
@@ -1,0 +1,63 @@
+import pytest
+import types
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.tolocal import ToLocal
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['baseUrl'] = 'http://NotAReal.url'
+    m['urlstr'] = 'http://NotAReal.url/20230804141101/Some/Directory/file.txt'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    #Set 1 - If neither o.baseDir, or o.toHttpRoot are set it throws an error
+    options = sarracenia.config.default_config()
+    tolocal = ToLocal(options)
+    assert tolocal.o.ldocroot == None
+
+    options.toLocalRoot = ['/var/www/html']
+    tolocal = ToLocal(options)
+    assert tolocal.o.ldocroot == '/var/www/html'
+
+    options.toLocalUrl = ['/var/www/html']
+    tolocal = ToLocal(options)
+    assert tolocal.o.lurlre.pattern == '/var/www/html'
+
+
+def test_after_accept():
+    #Set 1 - using o.baseDir
+    options = sarracenia.config.default_config()
+    options.baseDir = "/fake/path"
+    worklist = make_worklist()
+    message = make_message()
+    worklist.incoming = [message]
+    tolocal = ToLocal(options)
+    tolocal.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['savedurl'] == 'http://NotAReal.url/'
+    assert worklist.incoming[0]['urlstr'] == 'file://fake/path/20230804141101/Some/Directory/file.txt'
+
+
+
+

--- a/tests/sarracenia/flowcb/accept/tolocal_test.py
+++ b/tests/sarracenia/flowcb/accept/tolocal_test.py
@@ -34,17 +34,17 @@ def test___init__():
     #Set 1 - If neither o.baseDir, or o.toHttpRoot are set it throws an error
     options = sarracenia.config.default_config()
     tolocal = ToLocal(options)
-    assert tolocal.o.ldocroot == None
+    assert tolocal._ldocroot == None
 
-    options.toLocalRoot = ['/var/www/html']
+    options.toLocalRoot = '/var/www/html'
     tolocal = ToLocal(options)
-    assert tolocal.o.ldocroot == '/var/www/html'
+    assert tolocal._ldocroot == '/var/www/html'
 
-    options.toLocalUrl = ['/var/www/html']
+    options.toLocalUrl = '/var/www/html'
     tolocal = ToLocal(options)
-    assert tolocal.o.lurlre.pattern == '/var/www/html'
+    assert tolocal._lurlre.pattern == '/var/www/html'
 
-
+@pytest.mark.depends(on=['test___init__'])
 def test_after_accept():
     #Set 1 - using o.baseDir
     options = sarracenia.config.default_config()

--- a/tests/sarracenia/flowcb/accept/tolocalfile_test.py
+++ b/tests/sarracenia/flowcb/accept/tolocalfile_test.py
@@ -1,0 +1,62 @@
+import pytest
+import types
+
+import time
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.tolocalfile import ToLocalFile
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(relpathPrefix = '', baseUrl = 'http://NotAReal.url'):
+    m = SR3Message()
+    m['baseUrl'] = baseUrl 
+    m['relPath'] = relpathPrefix + 'not/a/real/directory'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test___init__():
+    options = sarracenia.config.default_config()
+    tolocalfile = ToLocalFile(options)
+
+
+def test_after_accept():
+    #Set 1
+    tolocalfile = ToLocalFile(sarracenia.config.default_config())
+    worklist = make_worklist()
+    worklist.incoming = [make_message(), make_message(baseUrl='file:')]
+    tolocalfile.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert len(worklist.rejected) == 1
+    assert worklist.incoming[0]['baseUrl'] == 'file:'
+    assert worklist.rejected[0]['saved_baseUrl'] == 'http://NotAReal.url'
+
+
+    #set 2
+    options = sarracenia.config.default_config()
+    options.baseDir = '//foo/bar'
+    tolocalfile = ToLocalFile(options)
+    worklist = make_worklist()
+    worklist.incoming = [make_message('/wiggle/'), make_message('//foo/bar/')]
+    tolocalfile.after_accept(worklist)
+    assert len(worklist.incoming) == 1
+    assert len(worklist.rejected) == 1
+    assert worklist.incoming[0]['relPath'] == '//foo/bar//wiggle/not/a/real/directory'
+    assert worklist.rejected[0]['relPath'] == '//foo/bar/not/a/real/directory'

--- a/tests/sarracenia/flowcb/accept/trim_legacy_fields_test.py
+++ b/tests/sarracenia/flowcb/accept/trim_legacy_fields_test.py
@@ -1,0 +1,49 @@
+import pytest
+import types, re
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.trim_legacy_fields import Trim_legacy_fields
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message():
+    m = SR3Message()
+    m['SomethingGood'] = 'SomethingGood__value'
+    m['atime'] = 'atime__value'
+    m['filename'] = 'filename__value'
+    m['from_cluster'] = 'from_cluster__value'
+    m['mtime'] = 'mtime__value'
+    m['source'] = 'source__value'
+    m['to_clusters' ] = 'to_clusters__value'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+def test_after_accept(caplog):
+
+    trim_legacy_fields = Trim_legacy_fields(sarracenia.config.default_config())
+
+    worklist = make_worklist()
+    worklist.incoming = [make_message()]
+
+    trim_legacy_fields.after_accept(worklist)
+
+    assert len(worklist.incoming) == 1
+    assert 'SomethingGood' in worklist.incoming[0]
+    assert 'atime' not in worklist.incoming[0]

--- a/tests/sarracenia/flowcb/accept/wmotypesuffix_test.py
+++ b/tests/sarracenia/flowcb/accept/wmotypesuffix_test.py
@@ -1,0 +1,65 @@
+import pytest
+import types
+
+#useful for debugging tests
+def pretty(*things, **named_things):
+    import pprint
+    for t in things:
+        pprint.PrettyPrinter(indent=2, width=200).pprint(t)
+    for k,v in named_things.items():
+        print(str(k) + ":")
+        pprint.PrettyPrinter(indent=2, width=200).pprint(v)
+
+from sarracenia.flowcb.accept.wmotypesuffix import WmoTypeSuffix
+from sarracenia import Message as SR3Message
+import sarracenia.config
+
+def make_message(extSet = False, withRename = False):
+    m = SR3Message()
+    m['new_file'] = 'HavetoHaveANameHere'
+    if extSet:
+        m['new_file'] = 'HavetoHaveANameHere.grib'
+    if withRename:
+        m['rename'] = 'HavetoHaveANameHere'
+
+    return m
+
+def make_worklist():
+    WorkList = types.SimpleNamespace()
+    WorkList.ok = []
+    WorkList.incoming = []
+    WorkList.rejected = []
+    WorkList.failed = []
+    WorkList.directories_ok = []
+    return WorkList
+
+
+@pytest.mark.parametrize('input,extension', 
+    [   ('G_', '.grid'),  ('IX', '.hdf'),  ('I_', '.bufr'), ('K_', '.crex'),
+        ('LT', '.iwxxm'), ('L_', '.grib'), ('XW', '.txt'),  ('X_', '.cap'),
+        ('D_', '.grib'),  ('H_', '.grib'), ('O_', '.grib'), ('Y_', '.grib'),
+        ('E_', '.bin'),   ('P_', '.bin'),  ('Q_', '.bin'),  ('R_', '.bin'),
+        ('__', '.txt'),
+    ])
+def test_find_type(input,extension):
+    wmotypesuffix = WmoTypeSuffix(sarracenia.config.default_config())
+    assert wmotypesuffix.find_type(input) == extension
+
+
+@pytest.mark.depends(on=['test_find_type'])
+def test_after_accept():
+    #Set x
+    wmotypesuffix = WmoTypeSuffix(sarracenia.config.default_config())
+
+    worklist = make_worklist()
+    worklist.incoming = [make_message(False, False), make_message(True, False), make_message(False, True)]
+
+    wmotypesuffix.after_accept(worklist)
+
+    assert len(worklist.incoming) == 3
+    assert worklist.incoming[0]['new_file'] == 'HavetoHaveANameHere.grib'
+    assert worklist.incoming[1]['new_file'] == 'HavetoHaveANameHere.grib'
+    assert worklist.incoming[2]['rename'] == worklist.incoming[2]['new_file'] =='HavetoHaveANameHere.grib'
+
+
+

--- a/tests/sarracenia/flowcb/accept/wmotypesuffix_test.py
+++ b/tests/sarracenia/flowcb/accept/wmotypesuffix_test.py
@@ -41,12 +41,12 @@ def make_worklist():
         ('E_', '.bin'),   ('P_', '.bin'),  ('Q_', '.bin'),  ('R_', '.bin'),
         ('__', '.txt'),
     ])
-def test_find_type(input,extension):
+def test___find_type(input,extension):
     wmotypesuffix = WmoTypeSuffix(sarracenia.config.default_config())
-    assert wmotypesuffix.find_type(input) == extension
+    assert wmotypesuffix._WmoTypeSuffix__find_type(input) == extension
 
 
-@pytest.mark.depends(on=['test_find_type'])
+@pytest.mark.depends(on=['test___find_type'])
 def test_after_accept():
     #Set x
     wmotypesuffix = WmoTypeSuffix(sarracenia.config.default_config())


### PR DESCRIPTION
This is a full test suite for all 23 FlowCB Accept plugins.

- Tests have 100% coverage
  - It might be overkill, but the plugins were (mostly) simple, and getting perfect coverage wasn't much harder than 90+
- Some asserts are less than ideal (checking the number of log messages), as changes to other parts of the code could have negative effects
  - Those asserts could be probably be removed, as I'm generally also checking that a particular message was logged, which is more telling
- Small config change to pytest, in order to ensure that only classes prefixed with `Test_` are treated as test classes (default is just `Test`)

Notable innovations with these tests
- Used [Paramaterized ](https://docs.pytest.org/en/7.1.x/example/parametrize.html) tests in with `wmotypesuffix_test.py`
  - Very simple parameters made this a no-brainer, without having to do a for loop inside the test
  - Other tests might have similar use-cases, so good to have the patter defined
- More mocking examples, mostly with `time`, and `random`, but also one with `urllib`
  - Really handy/important to tightly control the test environment, and get be able to assert on known values
- Extensive use of existing SR3 classes (`config`, and `message`), in order to properly build tests
  - It does mean these tests depend on those classes operating properly, but it should be fairly easy to eventually have dependencies set if that was wanted/needed

**There's also a couple of late fixes to the actual plugins here, which are required to make them operate as designed**