### PR TITLE
758 adding wiskis query support

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -2501,6 +2501,9 @@ of colon separation in files, the default in Sarracenia is WHATFN
 
 The possible keywords are :
 
+**None**
+ - no Sundew-style filename processing. Leave the filename alone.
+   (Not the same as NONE, described below.)
 
 **WHATFN**
  - the first part of the Sundew filename (string before first :)

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -749,6 +749,9 @@ of colon separation in files, the default in Sarracenia is WHATFN
 
 The possible keywords are :
 
+**None**
+ - the filename is not modified at all. (different from NONE!) 
+   turn off any Sundew compatibility filename processing.
 
 **WHATFN**
  - the first part of the Sundew filename (string before first :)

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -2491,6 +2491,10 @@ de la séparation par des deux-points dans les fichiers, le défaut dans Sarrace
 
 Les mots-clés possibles sont :
 
+**None**
+ - Aucune modification du nom de fichier (enlever toute interprétation de style Sundew)
+   N.B. différent de NONE décrit plus loin.
+
 **WHATFN**
  - la première partie du nom de fichier Sundew (chaîne de caractères avant le premier : )
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -738,6 +738,10 @@ de la séparation par des deux-points dans les fichiers, le défaut dans Sarrace
 
 Les mots-clés possibles sont :
 
+**None**
+ - Aucune modification du nom de fichier (enlever toute interprétation de style Sundew)
+   N.B. différent de NONE décrit plus loin.
+
 **WHATFN**
  - la première partie du nom de fichier Sundew (chaîne de caractères avant le premier : )
 

--- a/sarracenia/examples/flow/opg.conf
+++ b/sarracenia/examples/flow/opg.conf
@@ -22,6 +22,9 @@ post_exchange xs_tfeed_opg
 
 pollUrl https://kiwis.opg.com
 
+# to ignore colons in the filenames generated.
+filename None
+
 post_baseUrl file:/
 post_baseDir /tmp/wiski
 directory /tmp/wiski

--- a/sarracenia/examples/flow/opg.conf
+++ b/sarracenia/examples/flow/opg.conf
@@ -1,0 +1,27 @@
+#
+# Ontario Power Generation
+# a scheduled flow to bring some observations from their WISKI server.
+# 
+#wiski_ts_length 24h
+#wiski_ts_name caw_Cmd
+#wiski_ts_parameterTypeName Air Temperature
+
+
+callback scheduled.wiski
+
+callback post.message
+
+wiski_ts_length 24h
+wiski_ts_name caw_Cmd
+
+scheduled_hour 0,6,12,18
+scheduled_minute 17
+
+post_broker amqp://tfeed@localhost
+post_exchange xs_tfeed_opg
+
+pollUrl https://kiwis.opg.com
+
+post_baseUrl file:/
+post_baseDir /tmp/wiski
+directory /tmp/wiski

--- a/sarracenia/flowcb/clamav.py
+++ b/sarracenia/flowcb/clamav.py
@@ -18,13 +18,14 @@ import stat
 import time
 
 from sarracenia import nowflt
-from sarracenia.featuredetection import features
 import sarracenia
 from sarracenia.flowcb import FlowCB
 
 #
 # Support for features inventory mechanism.
 #
+from sarracenia.featuredetection import features
+
 features['clamd'] = { 'modules_needed': [ 'pyclamd' ], 'Needed': True,
         'lament' : 'cannot use clamd to av scan files transferred',
         'rejoice' : 'can use clamd to av scan files transferred' }

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -166,7 +166,7 @@ class Scheduled(FlowCB):
     def wait_until_next( self ):
 
         if self.o.scheduled_interval > 0:
-            self.wait_seconds(self.o.scheduled_interval)
+            self.wait_seconds(datetime.timedelta(seconds=self.o.scheduled_interval))
             return
 
         if ( len(self.o.scheduled_hour) > 0 ) or ( len(self.o.scheduled_minute) > 0 ):

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -65,7 +65,7 @@ class Scheduled(FlowCB):
         logger.info( f"for {when}: {json.dumps(list(map( lambda x: str(x), self.appointments))) } ")
 
 
-    def __init__(self,options):
+    def __init__(self,options,logger=logger):
         super().__init__(options,logger)
         self.o.add_option( 'scheduled_interval', 'duration', 0 )
         self.o.add_option( 'scheduled_hour', 'list', [] )

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -162,8 +162,7 @@ if __name__ == '__main__':
 
     options = sarracenia.config.default_config()
     flow = sarracenia.flow.Flow(options)
-    flow.o.scheduled_hour= [ '1','3','5',' 7',' 9',' 13','21','23']
-    flow.o.scheduled_minute= [ '1,3,5',' 7',' 9',' 13',' 15',' 51','53' ]
+    flow.o.scheduled_interval= 5
     flow.o.pollUrl = "https://kiwis.opg.com"
     flow.o.directory = "/tmp/wiski"
     logging.basicConfig(level=logging.DEBUG)

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -113,10 +113,10 @@ class Wiski(Scheduled):
 
         self.wait_until_next()
 
-        if self.stop_requested:
-            return messages
-        
         while (1):
+            if self.stop_requested:
+                return messages
+        
             self.token = self.submit_tokenization_request()
             authenticated_url = self.main_url
             headers = {
@@ -131,8 +131,7 @@ class Wiski(Scheduled):
             if response.status_code == 200:
                 break
             else:
-                logger.info("request failed. Status code: " + response.status_code)
-                logger.info("response: " + response.text)
+                logger.info( f"request failed. Status code: {response.status_code}: {response.text}" )
         
         k = KIWIS(self.main_url, headers=headers )
 
@@ -142,6 +141,9 @@ class Wiski(Scheduled):
         logger.info( f"stations: {k.get_station_list().station_id} " )
 
         for station_id in k.get_station_list().station_id:
+
+            if self.stop_requested:
+                return messages
 
             timeseries = k.get_timeseries_list(station_id = station_id ).ts_id
             #logger.info( f"looping over the timeseries: {timeseries}" )

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -38,8 +38,9 @@ class Wiski(Scheduled):
     """
       
        Plugin to Poll a WISKIS server that uses  ( https://www.kisters.net/wiski )
+       Uses the kiwis_pie ( https://github.com/amacd31/kiwis_pie ) to do that.
 
-       In the credentials.conf file, have an entry like:
+       In the credentials.conf file, need an authentication  entry like:
 
        https://user:password@theserver.com
 
@@ -47,6 +48,11 @@ class Wiski(Scheduled):
 
        pollUrl https://theserver.com
 
+       wiski polling parametrization (these are defined by and passed to kiwis_pie):
+
+       wiski_ts_length -- how long a timeseries to request (default is 24 hours)
+       wiski_ts_name   -- name of the timeseries (not used currently.)
+       wiski_ts_parameterTypeName -- Air Temperature.
 
        inherits the following settings from Scheduled (interval overrides the other two.)
 

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -8,13 +8,31 @@ import sys
 import time
 
 from datetime import date
-from kiwis_pie import KIWIS
 
 import sarracenia
-
 from sarracenia.flowcb.scheduled import Scheduled
 
+#
+# Support for features inventory mechanism.
+#
+from sarracenia.featuredetection import features
+
+features['wiski'] = { 'modules_needed': [ 'kiwis_pie' ], 'Needed': True,
+        'lament' : 'cannot poll sites that provide data using WISKI API' ,
+        'rejoice' : 'can poll sites that provide data with WISKI API' }
+
+try:
+    from kiwis_pie import KIWIS
+    sarracenia.features['wiski']['present'] = True
+except:
+    sarracenia.features['wiski']['present'] = False
+
+
+
 logger = logging.getLogger(__name__)
+
+
+
 
 class Wiski(Scheduled):
     """

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -1,0 +1,173 @@
+import logging
+import requests
+import base64
+
+import datetime
+import os
+import time
+
+from datetime import date
+from kiwis_pie import KIWIS
+
+import pandas as pd
+
+import sarracenia
+
+from sarracenia.flowcb.scheduled import Scheduled
+
+logger = logging.getLogger(__name__)
+
+class Wiski(Scheduled):
+    """
+      
+       Plugin to Poll a WISKIS server that uses  ( https://www.kisters.net/wiski )
+
+       In the credentials.conf file, have an entry like:
+
+       https://user:password@theserver.com
+
+       and in the config file:
+
+       pollUrl https://theserver.com
+
+
+       inherits the following settings from Scheduled (interval overrides the other two.)
+
+       scheduled_hour    -- a list of hours (0-59) to poll.
+       scheduled_minute -- a list of minutes (0-59) to poll. 
+       scheduled_interval  -- just a time interval between polls.
+
+       2023/09 plugin by Peter Silva, based on original proof of concept work by Mohamed Rehouma.
+    """
+
+    def __init__(self,options):
+        super().__init__(options,logger)
+
+        # use self.o.PollUrl for credentials.
+        self.details = None
+        if self.o.pollUrl is not None:
+            ok, self.details = sarracenia.config.Config.credentials.get(
+                self.o.pollUrl)
+
+        if self.o.pollUrl is None or self.details == None:
+            logger.error("pollUrl option incorrect or missing\n")
+            sys.exit(1)
+
+        # assert: now self.details.url.username/password are set.
+        self.basic_auth = "Basic " + base64.b64encode(f"{self.details.url.username}:{self.details.url.password}".encode()).decode()
+        if self.details.url.port:
+            self.main_url = self.details.url.scheme + "://" + self.details.url.hostname + ":" + self.details.url.port + "/KiWIS/KiWIS"
+        else:
+            self.main_url = self.details.url.scheme + "://" + self.details.url.hostname + "/KiWIS/KiWIS"
+
+        self.token = None
+        #self.token = self.submit_tokenization_request()
+
+        # meteorological parameter settings.
+        self.o.add_option( 'wiski_ts_length', 'duration', '24h' )
+        self.o.add_option( 'wiski_ts_name', 'str', 'caw_Cmd' )
+        self.o.add_option( 'wiski_ts_parameterTypeName', 'str', 'Air Temperature' )
+        
+        self.ts_length = datetime.timedelta( seconds=self.o.wiski_ts_length )
+        
+        logger.info( f"main_url: {self.main_url} timeseries_length={self.ts_length}, writing to {self.o.directory}" )
+
+
+    
+    def submit_tokenization_request(self):
+        # ECCC User Definition
+       
+        logger.info("requesting a new token")
+
+        body_string = "grant_type=client_credentials&scope=empty"
+        
+        # Request Token using HTTP POST request
+        token_url = self.main_url + "/KiWebPortal/rest/auth/oidcServer/token"
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": "Basic " + self.basic_auth,
+            "Host": "kiwis.opg.com",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        }
+        
+        response = requests.post(token_url, data=body_string, headers=headers)
+        
+        str_response_status = response.status_code
+        str_response_text = response.text
+        
+        # Process response
+        token_array = str_response_text.split('"')
+        if str_response_status == 201:
+            submit_tokenization_request = token_array[3]
+        else:
+            submit_tokenization_request = "Error"
+        
+        return submit_tokenization_request
+    
+    def gather(self): # placeholder
+        
+        
+        messages=[]
+
+        self.wait_until_next()
+
+        if self.stop_requested:
+            return messages
+        
+        while (1):
+            authenticated_url = "https://kiwis.opg.com/KiWIS/KiWIS"
+            headers = {
+                "Authorization" : f"Bearer {self.token}",
+                "Content-Type" : "application/json"
+            }
+        
+            response = requests.get(authenticated_url,headers=headers)
+        
+            logger.info(response)
+
+            if response.status_code == 200:
+                break
+            elif str_response_status == 403:
+                # Call the function and save in variable
+                logger.info( f"permission denied" )
+                self.token = self.submit_tokenization_request()
+            else:
+                logger.info("request failed. Status code: " + response.status_code)
+                logger.info("response: " + response.text)
+        
+        k = KIWIS('https://kiwis.opg.com/KiWIS/KiWIS')
+
+        now = datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
+        then = now - self.ts_length
+
+        for station_id in k.get_station_list().station_id:
+            fname = f"{self.o.directory}/ts_{station_id}_{str(then).replace(' ','h')}_{str(now).replace(' ','h')}.csv" 
+            f=open(fname,'w')
+            logger.warning( f"station_ids: {station_id} writing to: {fname}" )
+            for ts_id in k.get_timeseries_list(station_id = station_id, ts_name =self.o.wiski_ts_name, parametertype_name = self.o.wiski_ts_parameterTypeName ).ts_id:
+                #print(k.get_timeseries_values(ts_id = ts_id, to = date(2023,1,31), **{'from': date(2023,1,1)}))
+                #print(k.get_timeseries_values(ts_id = ts_id, to = now, **{'from': then}))
+                (k.get_timeseries_values(ts_id = ts_id, to = now, **{'from': then})).to_csv(f)
+            f.close() 
+            messages.append( sarracenia.Message.fromFileData( fname, self.o, os.stat(fname) ) )
+    
+        return messages
+
+if __name__ == '__main__':
+
+    import sarracenia.config
+    import types
+    import sarracenia.flow
+
+    options = sarracenia.config.default_config()
+    flow = sarracenia.flow.Flow(options)
+    flow.o.scheduled_hour= [ '1','3','5',' 7',' 9',' 13','21','23']
+    flow.o.scheduled_minute= [ '1,3,5',' 7',' 9',' 13',' 15',' 51','53' ]
+    flow.o.pollUrl = "https://kiwis.opg.com"
+    flow.o.directory = "/tmp/wiski"
+    logging.basicConfig(level=logging.DEBUG)
+
+    me = Wiski(flow.o)
+    me.gather()
+


### PR DESCRIPTION
as per #758 , add a proof of concept WISKI web services polling thing, supporting the token management needed by Ontario Power Generation.

* Generates tokens, supplies them to kiwis_pie (python wrapper module to access WISKI)
* polls the server given by *pollUrl*
* writes timeseries to a local directory given by *directory*
* generates posts using provided baseUrl etc... as per normal post/poll.
* implemented as a flowcb/scheduled plugin.  
* example configuration file provided.
* for testing, can be invoked on command line.
* works on linux and/or windows (different file naming conventions due restrictions on windows.)


generic items:
* noticed a bug in scheduled_intervals (applies to most of the ones deployed) fixed.
* found a bug in scheduled/init as well (missing argument would be found by derived classes.)
* documented use of None (as opposed to NONE) for filename setting... needed when filenames have colons in them.


