### PR TITLE
match new PR for python library. https://github.com/eclipse/paho.mqtt…

### DIFF
--- a/tests/sarracenia/flowcb/accept/postoverride_test.py
+++ b/tests/sarracenia/flowcb/accept/postoverride_test.py
@@ -37,7 +37,7 @@ def test___init__(caplog):
     options.logLevel = 'DEBUG'
     options.postOverride = ['Foo Bar']
     postoverride = PostOverride(options)
-    assert len(caplog.messages) == 1 or len(caplog.messages) == 3
+    assert len(caplog.messages) in [ 1, 3, 5, 6 ] 
     assert "postOverride settings: ['Foo Bar']" in caplog.messages
 
 

--- a/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
+++ b/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
@@ -61,7 +61,7 @@ def test___init__(caplog, tmp_path):
     #options.pxClient = 'meadow,foobar'
     sundewpxroute = SundewPxRoute(options)
     
-    assert len(caplog.messages) == 1 or len(caplog.messages) == 3
+    assert len(caplog.messages) in [ 1, 3, 6 ]
     assert 'sundew_pxroute pxRouting file not defined' in caplog.messages
 
     caplog.clear()


### PR DESCRIPTION

Fix manual_ack support in sr3/moth/mqtt to reflect new PR (code used to support the previous paho PR, but it was never merged.  I have closed that other PR now, hopefully this new one gets merged.)

Match the PR below: https://github.com/eclipse/paho.mqtt.python/pull/753
The current python library acknowledges receipt of messages (in QoS=1 or 2) before calling the on_message(..) callback, and so leaves a vulnerability where messages may be acknowledged before they are properly received by the application.

The Java implementation behaves the same way by default, but has a manualAck mode boolean flag available to allow the application to take over responsibility should it choose to do so.   There was a lot of discussion around the original PR, so created
this second one to be easier to accept ;-) it literally just brings the functionality existing in the Java implementation as-is to the python one.

I think a lot of people want this feature, it would be great to have it reviewed. 

Two years ago, I submitted https://github.com/eclipse/paho.mqtt.python/pull/554 to address the issue from 2018: https://github.com/eclipse/paho.mqtt.python/issues/348  There was a lot of discussion,
but it never got merged.
