### PR TITLE
V03 issue772 rename bug in subscriber.

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -807,11 +807,6 @@ class Flow:
             elif self.o.post_baseDir:
                 d = self.o.variableExpansion(self.o.post_baseDir, msg)
 
-        if d:
-            new_baseDir = d
-        else:
-            new_baseDir = new_dir
-
         # if provided, strip (integer) ... strip N heading directories
         #         or  pstrip (pattern str) strip regexp pattern from relPath
         # cannot have both (see setting of option strip in sr_config)
@@ -837,14 +832,12 @@ class Flow:
                         if fopv[0] == '':
                             strip += 1
                         elif len(fopv) == 1:
-                            msg['fileOp'][f] = new_baseDir + '/' + fopv[0]
+                            toclimb=len(token)-1
+                            msg['fileOp'][f] = '../'*(toclimb) + fopv[0]
                         if len(fopv) > strip:
                             rest=fopv[strip:]
                             toclimb=len(token)-rest.count('..')-1
-                            if toclimb > 0:
-                                msg['fileOp'][f] = '../'*(toclimb)+'/'.join(rest)
-                            else:
-                                msg['fileOp'][f] = '/'.join(rest)
+                            msg['fileOp'][f] = '../'*(toclimb)+'/'.join(rest)
                             
         # strip using a pattern
         elif pstrip:
@@ -905,7 +898,8 @@ class Flow:
                             if msg['fileOp'][f].startswith(self.o.baseDir):
                                 msg['fileOp'][f] = msg['fileOp'][f].replace(self.o.baseDir, d, 1)
                             elif os.sep not in msg['fileOp'][f]:
-                                msg['fileOp'][f] = new_baseDir + '/' + msg['fileOp'][f]
+                                toclimb=len(token)-1
+                                msg['fileOp'][f] = '../'*(toclimb) + msg['fileOp'][f]
 
         elif 'fileOp' in msg and new_dir:
             u = sarracenia.baseUrlParse(msg['baseUrl'])
@@ -915,7 +909,8 @@ class Flow:
                         if msg['fileOp'][f].startswith(u.path):
                             msg['fileOp'][f] = msg['fileOp'][f].replace(u.path, new_dir, 1)
                         elif '/' not in msg['fileOp'][f]:
-                            msg['fileOp'][f] = new_baseDir + '/' + msg['fileOp'][f]
+                            toclimb=len(token)-1
+                            msg['fileOp'][f] = '../'*(toclimb) + msg['fileOp'][f]
                             
         # add relPath to the base directory established above.
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -897,13 +897,23 @@ class Flow:
                             if msg['fileOp'][f].startswith(self.o.baseDir):
                                 msg['fileOp'][f] = msg['fileOp'][f].replace(self.o.baseDir, d, 1)
                             elif os.sep not in msg['fileOp'][f]:
-                                msg['fileOp'][f] = d + '/' + msg['fileOp'][f]
+                                if d:
+                                    msg['fileOp'][f] = d + '/' + msg['fileOp'][f]
+                                elif new_dir:
+                                    msg['fileOp'][f] = new_dir + '/' + msg['fileOp'][f]
 
         elif 'fileOp' in msg and new_dir:
             u = sarracenia.baseUrlParse(msg['baseUrl'])
             for f in ['link', 'hlink', 'rename']:
-                if (f in msg['fileOp']) and (len(u.path) > 1) and msg['fileOp'][f].startswith(u.path):
-                    msg['fileOp'][f] = msg['fileOp'][f].replace(u.path, new_dir, 1)
+                if (f in msg['fileOp']):
+                    if (len(u.path) > 1):
+                        if msg['fileOp'][f].startswith(u.path):
+                            msg['fileOp'][f] = msg['fileOp'][f].replace(u.path, new_dir, 1)
+                        elif '/' not in msg['fileOp'][f]:
+                            if d:
+                                msg['fileOp'][f] = d + '/' + msg['fileOp'][f]
+                            elif new_dir:
+                                msg['fileOp'][f] = new_dir + '/' + msg['fileOp'][f]
                             
         # add relPath to the base directory established above.
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -888,8 +888,11 @@ class Flow:
             if d:
                 if 'fileOp' in msg and len(self.o.baseDir) > 1:
                     for f in ['link', 'hlink', 'rename']:
-                        if (f in msg['fileOp']) and msg['fileOp'][f].startswith(self.o.baseDir):
-                             msg['fileOp'][f] = msg['fileOp'][f].replace(self.o.baseDir, d, 1)
+                        if (f in msg['fileOp']) :
+                            if msg['fileOp'][f].startswith(self.o.baseDir):
+                                msg['fileOp'][f] = msg['fileOp'][f].replace(self.o.baseDir, d, 1)
+                            elif os.sep not in msg['fileOp'][f]:
+                                msg['fileOp'][f] = d + '/' + msg['fileOp'][f]
 
         elif 'fileOp' in msg and new_dir:
             u = sarracenia.baseUrlParse(msg['baseUrl'])

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -739,7 +739,12 @@ class Flow:
     # how will the download file land on this server
     # with all options, this is really tricky
     # ==============================================
+    """
+        to test changes to updateFieldsAccepted, run:  make test_shim in the SarraC package...
+        because it tickles a lot of these settings, in addition to the flow_tests before
+        trying to PR changes here.
 
+    """
     def updateFieldsAccepted(self, msg, urlstr, pattern, maskDir,
                              maskFileOption, mirror, path_strip_count, pstrip, flatten) -> None:
         """
@@ -753,6 +758,7 @@ class Flow:
            * pstrip: pattern strip regexp to apply instead of a count.
            * flatten: a character to replace path separators with toe change a multi-directory 
              deep file name into a single long file name
+
         """
 
         # resolve source.
@@ -801,6 +807,11 @@ class Flow:
             elif self.o.post_baseDir:
                 d = self.o.variableExpansion(self.o.post_baseDir, msg)
 
+        if d:
+            new_baseDir = d
+        else:
+            new_baseDir = new_dir
+
         # if provided, strip (integer) ... strip N heading directories
         #         or  pstrip (pattern str) strip regexp pattern from relPath
         # cannot have both (see setting of option strip in sr_config)
@@ -826,10 +837,7 @@ class Flow:
                         if fopv[0] == '':
                             strip += 1
                         elif len(fopv) == 1:
-                            if d:  #no path in field, need a dir...
-                               msg['fileOp'][f] = d + '/' + fopv[0]
-                            elif new_dir:
-                               msg['fileOp'][f] = new_dir + '/' + fopv[0]
+                            msg['fileOp'][f] = new_baseDir + '/' + fopv[0]
                         if len(fopv) > strip:
                             rest=fopv[strip:]
                             toclimb=len(token)-rest.count('..')-1
@@ -897,10 +905,7 @@ class Flow:
                             if msg['fileOp'][f].startswith(self.o.baseDir):
                                 msg['fileOp'][f] = msg['fileOp'][f].replace(self.o.baseDir, d, 1)
                             elif os.sep not in msg['fileOp'][f]:
-                                if d:
-                                    msg['fileOp'][f] = d + '/' + msg['fileOp'][f]
-                                elif new_dir:
-                                    msg['fileOp'][f] = new_dir + '/' + msg['fileOp'][f]
+                                msg['fileOp'][f] = new_baseDir + '/' + msg['fileOp'][f]
 
         elif 'fileOp' in msg and new_dir:
             u = sarracenia.baseUrlParse(msg['baseUrl'])
@@ -910,10 +915,7 @@ class Flow:
                         if msg['fileOp'][f].startswith(u.path):
                             msg['fileOp'][f] = msg['fileOp'][f].replace(u.path, new_dir, 1)
                         elif '/' not in msg['fileOp'][f]:
-                            if d:
-                                msg['fileOp'][f] = d + '/' + msg['fileOp'][f]
-                            elif new_dir:
-                                msg['fileOp'][f] = new_dir + '/' + msg['fileOp'][f]
+                            msg['fileOp'][f] = new_baseDir + '/' + msg['fileOp'][f]
                             
         # add relPath to the base directory established above.
 


### PR DESCRIPTION
there is a small/rare case where the mirroring is not picking the right file as the source to be copied or renamed.
it is detailed in #772 . This problem is reported by the client doing the HPC mirroring.

The problem is that:
* when we create messages on the source, we do so with a current working directory at the root of the tree being copied.
* when we create files on the destinations, we chdir to the directory where we will create the file before writing it.
* when the path in a "link" or "rename" file operation is just a name, it refers to a file in the root (or baseDir) on the source side.
* on the destination need to add "../" to correct from the directory where the file is being created to find the same directory on the destination.

There was alreayd code for when the path had subdirectories in it, but when the path was just a file name, it did not to the right thing.

There are a bunch of test cases in the https://github.com/MetPX/sarrac package (make test_shim) to do what the HPC mirroring does, in five different ways. The problem operations reported were added to the test cases, and the issue the client was complaining about was reproduced. This series of commits gradually increased the number of cases that were passed in the make test_shim use cases.  All of them also pass the flow_tests.
