### PR TITLE
V03 issue784 (refactored/simplified logBackup parameter parsing.) also now can rollover every 30s

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -321,7 +321,7 @@ View all configuration settings (the result of all parsing... what the flow comp
      'logLevel': 'info',
      'logReject': False,
      'logRotateCount': 5,
-     'logRotateInterval': 1,
+     'logRotateInterval': 86400.0,
      'logStdout': True,
      'log_flowcb_needed': False,
      'masks': ['accept .* into //home/peter/sarra_devdocroot/recd_by_srpoll_test1 with mirror:True strip:.*sent_by_tsource2send/'],
@@ -1891,10 +1891,10 @@ LOGS and MONITORING
    unique to each node. So each node has it's own statefiles and logs.
    example, on a node named goofy,  ~/.cache/sarra/log/ becomes ~/.cache/sarra/goofy/log.
 
-- logRotate <max_logs> ( default: 5 )
+- logRotateCount <max_logs> ( default: 5 )
    Maximum number of logs archived.
 
-- logRotate_interval <duration>[<time_unit>] ( default: 1 )
+- logRotateInterval <duration>[<time_unit>] ( default: 1d = 86,400s )
    The duration of the interval with an optional time unit (ie 5m, 2h, 3d)
 
 - permLog ( default: 0600 )

--- a/docs/source/How2Guides/Admin.rst
+++ b/docs/source/How2Guides/Admin.rst
@@ -879,7 +879,7 @@ use [0-9]{8}, but it would appear that find's regex syntax does not include repe
 
 Note that the logs will clean up themselves. By default after 5 retention the oldest log will be
 remove at midnight if you have always use the same default config since the first rotation.
-It can be shorten to a single retention by adding *logRotate 1d* to default.conf.
+It can be shorten to a single retention by adding *logRotateCount 1* to default.conf.
 
 Ensuring Things are Up
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -39,20 +39,33 @@ Installation Instructions
 git
 ---
 
+3.0.45
+------
+
+*CHANGE*: config option: logRotateInterval units was days, is now 
+     a time interval (seconds) like all other intervals.
+
+
+
 3.0.41
 ------
 
-*CHANGE*: v03 postformat field renamed: "integrity" is now "identity"
+*CHANGE*: v03 post format field renamed: "integrity" is now "identity"
 
     * current version will read messsages with *integrity* and map them to *identity*.
     * current version will post with *identity*, so older versions will miss them.
     * https://github.com/MetPX/sarracenia/issues/703
-    * metpx-sr3c >= v3.23.06 
-    * metpx-sarracenia >= v2.23.06
+    * metpx-sr3c >= v3.23.06  (equivalent compatible C implementation)
+    * metpx-sarracenia >= v2.23.06 (equivalent v2 compatible (legacy) version.)
 
 
 3.0.40
 ------
+
+*CHANGE*: the default format in which messages are posted is v03, but as of this
+    version, to override the format, one must use *post_format v02*
+    prior to this version, setting of post_topicPrefix was sufficient.
+    Now both settings are needed.
 
 *CHANGE*:  Python API breaking changes
 
@@ -206,6 +219,11 @@ V2 to Sr3
 **CHANGE**: log messages look completely different. Any log parsing will have to be reviewed.
           New log format includes a prefix with process-id and the routine generating the notification message.
 
+**CHANGE**: default message format in sr3 is v03. in v2, the default format was v2.
+
+**CHANGE**: default topicPrefix and post_topicPrefix in sr3 is 'v03' ... in v2 it 
+          was 'v02.post'
+        
 *NOTICE*: When migrating from v2 to sr3, simple configurations will mostly "just work."
           However, cases relying on user built plugins will require effort to port.
           The built-in plugins provided with Sarracenia have been ported as updated

--- a/docs/source/fr/CommentFaire/Admin.rst
+++ b/docs/source/fr/CommentFaire/Admin.rst
@@ -959,7 +959,7 @@ regex n'inclut pas les répétitions. )
 
 Il est à noter que les logs se nettoieront par eux-mêmes, par défaut, après 5 rotations le log
 le plus ancien sera enlevé à minuit, seulement si la configuration par défaut a été utilisée
-depuis la première rotation. Il est possible de racourcir ce nombre en ajoutant *logrotate 1d*
+depuis la première rotation. Il est possible de racourcir ce nombre en ajoutant *logRotateCount 3*
 à default.conf.
 
 S’assurer que les choses sont en place

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -38,15 +38,33 @@ Instructions d’installation
 git
 ---
 
-*CHANGE*: v03 postformat field renamded: "integrity" is now "identity"
+3.0.45
+------
 
-    * current version will read messsages with integrity and map them to identity.
-    * current version will post with "Identity", so older versions will miss them.
+*CHANGEMENT*: l´unité dans l´option *logRotateInterval* est rendu
+    secondes, comme toute autre intervalle dans la configuration.
+    Dans les versions antérieurs, c´était une quantité de jours.
+
+
+3.0.41
+------
+
+*CHANGEMENT*: champs de message v03 renommé: "integrity" est devenu "identity"
+
+    * version actuel va accepter est convertir les anciens messages.
+    * version actuel va publier le nouveau champ et est donc incompatible avec toute version antérieur.
     * https://github.com/MetPX/sarracenia/issues/703
+    * metpx-sr3c >= v3.23.06   (versio compatible de l´implantation en C)
+    * metpx-sarracenia >= v2.23.06 (version v2 (ancien) compatible.)
+
+
 
 3.0.40
 ------
 
+*CHANGEMENT*: l´option *post_format v02* est nécessaire pour que sr3 émet des
+    messages en format v02.  Avant cette version, l´option *post_topicPrefix v02.post*
+    était suffisant.  Avec la version actuel, les deux options doivent être spécifiés.
 
 *CHANGEMENT*:  l'interface de programmation (API) python a subit un changement de rupture
 

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -323,7 +323,7 @@ Afficher tous les paramètres de configuration (le résultat de toutes les analy
      'logLevel': 'info',
      'logReject': False,
      'logRotateCount': 5,
-     'logRotateInterval': 1,
+     'logRotateInterval': 86400,
      'logStdout': True,
      'log_flowcb_needed': False,
      'masks': ['accept .* into //home/peter/sarra_devdocroot/recd_by_srpoll_test1 with mirror:True strip:.*sent_by_tsource2send/'],
@@ -1878,10 +1878,10 @@ Fichiers journal et Suivi
    unique à chaque nœud. Ainsi, chaque nœud a ses propres fichiers d’état et journaux.
    Par exemple, sur un nœud nommé goofy, ~/.cache/sarra/log/ devient ~/.cache/sarra/goofy/log.
 
-- logRotate <max_logs> ( défaut: 5 )
+- logRotateCount <max_logs> ( défaut: 5 )
    Nombre maximal de journaux archivés.
 
-- logRotate_interval <duration>[<time_unit>] ( défaut: 1 )
+- logRotateInterval <duration>[<time_unit>] ( défaut: 1 jour == 86,400 secondes )
    La durée de l’intervalle avec une unité de temps optionnelle (c’est-à-dire 5m, 2h, 3d)
 
 - permLog ( défaut: 0600 )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -234,12 +234,12 @@ class Flow:
                 logger.debug( "details:", exc_info=True )
                 return False
 
-            logger.debug( f'flowCallback plugin loading: {c} an instance of: {plugin}' )
+            #logger.debug( f'flowCallback plugin loading: {c} an instance of: {plugin}' )
             for entry_point in sarracenia.flowcb.entry_points:
                 if hasattr(plugin, entry_point):
                     fn = getattr(plugin, entry_point)
                     if callable(fn):
-                        logger.debug( f'registering {c}/{entry_point}' )
+                        #logger.debug( f'registering {c}/{entry_point}' )
                         if entry_point in self.plugins:
                             self.plugins[entry_point].append(fn)
                         else:

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -31,10 +31,7 @@ class Message(FlowCB):
         """
            return a current list of messages.
         """
-        if not hasattr(self,'consumer'):
-            return []
-
-        if hasattr(self.consumer,'newMessages'):
+        if hasattr(self,'consumer') and hasattr(self.consumer,'newMessages'):
             return self.consumer.newMessages()
         else:
             logger.warning( f'not connected. Trying to connect to {self.o.broker}')

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -20,9 +20,10 @@ class Message(FlowCB):
 
         super().__init__(options,logger)
 
+        self.od = sarracenia.moth.default_options
+        self.od.update(self.o.dictify())
+
         if hasattr(self.o, 'broker') and self.o.broker:
-            self.od = sarracenia.moth.default_options
-            self.od.update(self.o.dictify())
             self.consumer = sarracenia.moth.Moth.subFactory(self.od)
         else:
             logger.critical('missing required broker specification')

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -31,6 +31,9 @@ class Message(FlowCB):
         """
            return a current list of messages.
         """
+        if not hasattr(self,'consumer'):
+            return []
+
         if hasattr(self.consumer,'newMessages'):
             return self.consumer.newMessages()
         else:
@@ -39,6 +42,10 @@ class Message(FlowCB):
             return []
 
     def ack(self, mlist) -> None:
+
+        if not hasattr(self,'consumer'):
+            return
+
         for m in mlist:
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
             self.consumer.ack(m)
@@ -51,6 +58,9 @@ class Message(FlowCB):
 
     def on_housekeeping(self) -> None:
 
+        if not hasattr(self,'consumer'):
+            return
+
         if hasattr(self.consumer, 'metricsReport'):
             m = self.consumer.metricsReport()
             average = (m['rxByteCount'] /
@@ -61,6 +71,6 @@ class Message(FlowCB):
             self.consumer.metricsReset()
 
     def on_stop(self) -> None:
-        if hasattr(self.consumer, 'close'):
+        if hasattr(self,'consumer') and hasattr(self.consumer, 'close'):
             self.consumer.close()
         logger.info('closing')

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -132,21 +132,13 @@ class instance:
 
         cfg_preparse = sarracenia.config.one_config(component, config)
 
-        # FIXME: do we put explicit error handling here for bad input?
-        #        probably worth exploring.
-        #
-        lr_when = 'midnight'
-        if (type(cfg_preparse.logRotateInterval) == str) and (
-                cfg_preparse.logRotateInterval[-1] in 'mMhHdD'):
-            lr_when = cfg_preparse.logRotateInterval[-1]
-            logRotateInterval = int(float(cfg_preparse.logRotateInterval[:-1]))
+        if cfg_preparse.logRotateInterval < (24*60*60):
+            logRotateInterval=int(cfg_preparse.logRotateInterval)
+            lr_when='s'
         else:
-            logRotateInterval = int(float(cfg_preparse.logRotateInterval))
-
-        if type(cfg_preparse.logRotateCount) == str:
-            logRotateCount = int(float(cfg_preparse.logRotateCount))
-        else:
-            logRotateCount = cfg_preparse.logRotateCount
+            logRotateInterval = int(cfg_preparse.logRotateInterval/(24*60*60))
+            lr_when='midnight'
+            
 
         # init logs here. need to know instance number and configuration and component before here.
         if cfg_preparse.action in ['start','run'] and not cfg_preparse.logStdout:
@@ -183,7 +175,7 @@ class instance:
                 logfilename,
                 when=lr_when,
                 interval=logRotateInterval,
-                backupCount=logRotateCount)
+                backupCount=cfg_preparse.logRotateCount)
             handler.setFormatter(logging.Formatter(log_format))
 
             logger.addHandler(handler)

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1503,6 +1503,8 @@ class sr_GlobalState:
                         component_path) + os.sep + 'instance.py'
                     cmd = [sys.executable, component_path, '--no', "0"]
                     cmd.extend(sys.argv[1:])
+                    if c not in [ 'post', 'watch' ]:
+                        cmd[-1] = f"{c}/{cfg}"
 
                 elif c[0] != 'c':  # python components
                     if cfg is None:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1503,8 +1503,16 @@ class sr_GlobalState:
                         component_path) + os.sep + 'instance.py'
                     cmd = [sys.executable, component_path, '--no', "0"]
                     cmd.extend(sys.argv[1:])
-                    if c not in [ 'post', 'watch' ]:
-                        cmd[-1] = f"{c}/{cfg}"
+                    """
+                    FIXME... replace 'sub*/*amis*' on invocation with the resolved thing.
+                         this feels hacky... but I can't think of a case that won't work.
+                    """
+                    if '--config' in cmd:
+                        cmd[ cmd.index( '--config' )+1 ] = f
+                    elif '-c' in cmd:
+                        cmd[ cmd.index( '-c' )+1 ] = f
+                    elif c not in [ 'post', 'watch' ]:
+                        cmd[-1] = f
 
                 elif c[0] != 'c':  # python components
                     if cfg is None:

--- a/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
+++ b/tests/sarracenia/flowcb/accept/sundowpxroute_test.py
@@ -61,7 +61,7 @@ def test___init__(caplog, tmp_path):
     #options.pxClient = 'meadow,foobar'
     sundewpxroute = SundewPxRoute(options)
     
-    assert len(caplog.messages) in [ 1, 3, 6 ]
+    assert len(caplog.messages) in [ 1, 3, 5, 6 ]
     assert 'sundew_pxroute pxRouting file not defined' in caplog.messages
 
     caplog.clear()


### PR DESCRIPTION
Have not been able to reproduce the problem. #784

The parsing of options for logBackup controlling rollover date to before there was option parsing.  It looks like there was some kind of typed parsing, and somehow a string was being passed to an option that expected an integer.

Revamped out the parsing is done, to just use the existing standard option parsing.  That involved changing the units of logBackupInterval, from days to being an ordinary interval (defaults to seconds, but can put 1d to get days.)

The commits here have the side effect of letting the client do something like:

```
logBackupInterval 30s
logBackupCount 3
```

to have the logs rollover every 30 seconds.  I need That to work on #785 

Before accepting the PR, should probably test on the system where it failed.
