### PR TITLE
Correct metrics miscalculations. #783

### DIFF
--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -360,7 +360,7 @@ class Moth():
         self.metrics['txBadCount'] = 0
 
     def metricsReport(self) -> tuple:
-        if not self.metrics['connected']:
+        if not self.metrics['connected'] and (self.metrics['disconnectLast'] > 0):
             down_time = time.time() - self.metrics['disconnectLast']
             self.metrics['disconnectTime'] += down_time
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2369,7 +2369,7 @@ class sr_GlobalState:
                         if 'disconnectTime' in m:
                             connectPercent= int(100*(time_base-m['disconnectTime'])/time_base)
                         else:
-                            connectPercent= -1 
+                            connectPercent= 0
 
                         txCumulativeMessageRate +=  (m["txGoodCount"]+m["txBadCount"])/time_base
                     else:
@@ -2377,7 +2377,7 @@ class sr_GlobalState:
                         byteTotal=0
                         byteRate=0
                         msgRate=0
-                        connectPercent=-1
+                        connectPercent=0
                         byteConnectPercent= 0
 
                     if m["rxGoodCount"] > 0:


### PR DESCRIPTION
fixes the display issues, there was an error calculating disconnection time making it a really large negative number if no connection had occurred.

also... -1 values were meant to be defaults for %ages when no data is available, but they look odd. replacing with 0%.

