### PR TITLE
posts with too short topics (just v02.post)

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -775,7 +775,7 @@ class Flow:
 
             if source:
                 msg['source'] = source
-                m['_deleteOnPost'] |= set(['source'])
+                msg['_deleteOnPost'] |= set(['source'])
 
         # relative path by default mirror
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -914,7 +914,6 @@ class Flow:
 
         if maskFileOption:
             msg['new_file'] = self.sundew_getDestInfos(msg, maskFileOption, filename)
-            logger.warning( f" dir_list: {msg['new_relPath'].split('/')[0:-1]} .. filename {msg['new_file']} " )
             msg['new_relPath'] = '/'.join(  msg['new_relPath'].split('/')[0:-1] + [ msg['new_file'] ]  )
         # not mirroring
 

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -392,6 +392,10 @@ class V2Wrapper(FlowCB):
 
     def restoreMsg(self, m, v2msg):
 
+        if 'topic' in m:
+            if m['topic'][0:2] == ['v02', 'post' ]:
+               m['topic'] = self.o.post_topicPrefix + m['topic'][2:]      
+
         if ('link' in v2msg.headers):
             if not 'fileOp' in m:
                m['fileOp'] = {}

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -603,7 +603,6 @@ class AMQP(Moth):
 
         raw_body, headers, content_type = PostFormat.exportAny( body, version, self.o['topicPrefix'], self.o )
 
-        logger.info( f" topic is {headers['topic']}" )
         topic = '.'.join(headers['topic'])
         topic = topic.replace('#', '%23')
         topic = topic.replace('*', '%22')
@@ -620,6 +619,8 @@ class AMQP(Moth):
                              (version, type(raw_body),  raw_body))
             logger.info('raw message headers: type: %s value: %s' % (type(headers),  headers))
 
+        message['post_topic'] = topic
+        message['_deleteOnPost'] |= set( ['post_topic'] )
         del headers['topic']
 
         if headers :  
@@ -651,8 +652,7 @@ class AMQP(Moth):
         body=raw_body
         ebo = 1
         try:
-            logger.debug("trying to publish body: {} headers: {} to {} under: {} ".format(
-                          body, headers, exchange, topic))
+            logger.debug( f"trying to publish body: {body} headers: {headers} to {exchange} under: {topic} " )
             self.channel.basic_publish(AMQP_Message, exchange, topic, timeout=pub_timeout)
             # Issue #732: tx_commit can get stuck forever
             self.channel.tx_commit()

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -80,6 +80,7 @@ class PostFormat:
            Sarracenia standard topic derivation.
 
            https://metpx.github.io/sarracenia/Explanation/Concepts.html#amqp-v09-rabbitmq-settings
+
         """
 
         if options['broker'].url.scheme.startswith('mqtt'):
@@ -96,7 +97,10 @@ class PostFormat:
             topic_separator='.'
 
         if 'topic' in msg:
-            topic = msg['topic'] 
+            if type(msg['topic']) is list:
+                topic = msg['topic']
+            else:
+                topic = msg['topic'].split(topic_separator)
         elif 'topic' in options and options['topic'] and (type(options['topic']) is not list):
             topic = options['topic'].split(topic_separator)
         else:

--- a/sarracenia/postformat/__init__.py
+++ b/sarracenia/postformat/__init__.py
@@ -95,14 +95,17 @@ class PostFormat:
             topic_prefix = options['topicPrefix']
             topic_separator='.'
 
-        if 'topic' in options and options['topic'] and (type(options['topic']) is not list):
+        if 'topic' in msg:
+            topic = msg['topic'] 
+        elif 'topic' in options and options['topic'] and (type(options['topic']) is not list):
             topic = options['topic'].split(topic_separator)
         else:
             if 'relPath' in msg: 
                 topic = topic_prefix + msg['relPath'].split('/')[0:-1]
+            elif 'subtopic' in msg:
+                topic = topic_prefix + msg['subtopic']  
             else:
                 topic = topic_prefix
-
         return topic
 
    


### PR DESCRIPTION
When Daniel was working on a plugin to to minify input json files, it was publishing files
with a topic of just *v02.post* (stripping out the rest of the topic) so the consumers, being bound to a much longer topic, were not receiving the plugin's products. 

Last winter, there was code done to introduce postformat, so that networks other than native sarracenia messages could be supported (e.g. WMO WIS, ICAO SWIM) those protocols have different topic hierarchies, so need to make sarracenia able to flexibly deal with different postformats' topic schemes.

One way of doing that would be to have plugins set topics.  There is logic in postformat for to accept a topic header if it is provided.

It turned out that, when we have plugins from v2, we need to convert the message to v2, and that required changing the message to a v2 one (with topic v02.post) ... when the message is reconverted back to internal format, there was missing logic to convert the topic back to original.

I'm suspicious that there root cause of having the wrong topic is actually that the messages don't have a relPath in them (where relPath is normally used to calculate the topic.) but this masks the problem and is correct (in the sense that I want to be able to override the topic by specifying the header) so while this patch is a good thing, it might not be the end of the story.

