### PR TITLE
V03 foreground with patterns won't start/is broken.

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1503,6 +1503,8 @@ class sr_GlobalState:
                         component_path) + os.sep + 'instance.py'
                     cmd = [sys.executable, component_path, '--no', "0"]
                     cmd.extend(sys.argv[1:])
+                    if c not in [ 'post', 'watch' ]:
+                        cmd[-1] = f"{c}/{cfg}"
 
                 elif c[0] != 'c':  # python components
                     if cfg is None:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1503,8 +1503,16 @@ class sr_GlobalState:
                         component_path) + os.sep + 'instance.py'
                     cmd = [sys.executable, component_path, '--no', "0"]
                     cmd.extend(sys.argv[1:])
-                    if c not in [ 'post', 'watch' ]:
-                        cmd[-1] = f"{c}/{cfg}"
+                    """
+                    FIXME... replace 'sub*/*amis*' on invocation with the resolved thing.
+                         this feels hacky... but I can't think of a case that won't work.
+                    """
+                    if '--config' in cmd:
+                        cmd[ cmd.index( '--config' )+1 ] = f
+                    elif '-c' in cmd:
+                        cmd[ cmd.index( '-c' )+1 ] = f
+                    elif c not in [ 'post', 'watch' ]:
+                        cmd[-1] = f
 
                 elif c[0] != 'c':  # python components
                     if cfg is None:


### PR DESCRIPTION
command line args to the launch of the flow were passed without the expansion already done in the code.  Need to replace with expanded values.

fix for:
```
fractal% sr3 foreground 'subsc*/*amis*'
.Traceback (most recent call last):
  File "/home/peter/Sarracenia/sr3/sarracenia/instance.py", line 242, in <module>
    i.start()
  File "/home/peter/Sarracenia/sr3/sarracenia/instance.py", line 133, in start
    cfg_preparse = sarracenia.config.one_config(component, config)
  File "/home/peter/Sarracenia/sr3/sarracenia/config.py", line 2524, in one_config
    os.chdir(component)
FileNotFoundError: [Errno 2] No such file or directory: 'subsc*'
2023-10-22 10:51:01,172 1853685 [CRITICAL] root run_command subprocess.run failed err=Command '['/usr/bin/python3', '/home/peter/Sarracenia/sr3/sarracenia/instance.py', '--no', '0', 'foreground', 'subsc*/*amis*']' returned non-zero exit status 1.

fractal%

```
and:

```

fractal% sr3 --config 'subsc*/*amis*' foreground
.Traceback (most recent call last):
  File "/home/peter/Sarracenia/sr3/sarracenia/instance.py", line 242, in <module>
    i.start()
  File "/home/peter/Sarracenia/sr3/sarracenia/instance.py", line 133, in start
    cfg_preparse = sarracenia.config.one_config(component, config)
  File "/home/peter/Sarracenia/sr3/sarracenia/config.py", line 2524, in one_config
    os.chdir(component)
FileNotFoundError: [Errno 2] No such file or directory: 'subsc*'


```

expected behaviour: it should launch the configuration specified.

explanation:   there is a defined configuration called *subscribe/hpfx_amis* on the system, which shows up on sr3 status, so the pattern matching should find it, and start it up.  The pattern matching logic is actually invoked and the list obtained, but instead of passing it to the process to be launched, it pass the resolved value.   This only affects *foreground*.
