### PR TITLE
save fileOp so that relative path name changes are not forwarded down…

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -531,8 +531,11 @@ class Flow:
                             m['old_format'] = m['_format']
                             m['_deleteOnPost'] |= set(['old_format'])
                         m['_format'] = m['post_format']
-                        
 
+                        # restore adjustment to fileOp
+                        if 'post_fileOp' in m:
+                            m['fileOp'] = m['post_fileOp']
+                        
                     self._runCallbacksWorklist('after_work')
 
                     self.ack(self.worklist.rejected)
@@ -807,6 +810,14 @@ class Flow:
                 d = new_dir
             elif self.o.post_baseDir:
                 d = self.o.variableExpansion(self.o.post_baseDir, msg)
+
+        # to get locally resolvable links and renames, need to mangle the pathnames.
+        # to get something to restore for downstream consumers, need to put the original
+        # names back.
+
+        if 'fileOp' in msg:
+            msg['post_fileOp'] = copy.deepcopy(msg['fileOp'])
+            msg['_deleteOnPost'] |= set( [ 'post_fileOp' ] )
 
         # if provided, strip (integer) ... strip N heading directories
         #         or  pstrip (pattern str) strip regexp pattern from relPath

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -20,7 +20,7 @@ pip3 install pyftpdlib paramiko net-tools
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
 # See issue #407, #445.
-for PKG in amqp appdirs dateparser watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr ; do
+for PKG in amqp appdirs dateparser watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr rangehttpserver; do
     PKG_INSTALLED="`pip3 list | grep ${PKG}`"
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"


### PR DESCRIPTION
last part of renaming... the changes to relative paths for arguments to rename and link operations must not be re-published as modified, but modified by each consumer.

This is the last change needed to close off #772
