### PR TITLE
fixes for mirror off and relPath settings from it.

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -26,7 +26,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       which_test: [ static_flow, flakey_broker, dynamic_flow, restart_server ]
+       which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
        osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
 
     runs-on: ${{ matrix.osver }}

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -23,7 +23,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       which_test: [ static_flow, flakey_broker, dynamic_flow ]
+       which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow ]
        osver: [ "ubuntu-22.04" ]
 
     runs-on: ${{ matrix.osver }}

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -23,7 +23,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       which_test: [ static_flow, flakey_broker, dynamic_flow, restart_server ]
+       which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
        osver: [ "ubuntu-22.04" ]
 
     runs-on: ${{ matrix.osver }}

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2425,6 +2425,33 @@ class Flow:
 
         for msg in self.worklist.incoming:
 
+            # weed out non-file transfer operations that are configured to not be done.
+            if 'fileOp' in msg:
+                if ('directory' in msg['fileOp']) and ('remove' in msg['fileOp']) and ( 'rmdir' not in self.o.fileEvents ):
+                    msg.setReport(202, "skipping rmdir here." )
+                    self.worklist.ok.append(msg)
+                    continue
+
+                elif ('remove' in msg['fileOp']) and ( 'delete' not in self.o.fileEvents ):
+                    msg.setReport(202, "skipping delete here." )
+                    self.worklist.ok.append(msg)
+                    continue
+
+                if ('directory' in msg['fileOp']) and ( 'mkdir' not in self.o.fileEvents ):
+                    msg.setReport(202, "skipping mkdir here." )
+                    self.worklist.ok.append(msg)
+                    continue
+
+                if ('hlink' in msg['fileOp']) and ( 'link' not in self.o.fileEvents ):
+                    msg.setReport(202, "skipping hlink here." )
+                    self.worklist.ok.append(msg)
+                    continue
+
+                if ('link' in msg['fileOp']) and ( 'link' not in self.o.fileEvents ):
+                    msg.setReport(202, "skipping link here." )
+                    self.worklist.ok.append(msg)
+                    continue
+
             #=================================
             # proceed to send :  has to work
             #=================================

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1494,9 +1494,8 @@ class Flow:
                             continue
 
                 elif ('directory' in msg['fileOp']) and ('remove' in msg['fileOp'] ): 
-                    if  'rmdir' in self.o.fileEvents:
-                        msg.setReport(202, "skipping rmdir %s" % new_path)
-                        self.worklist.ok.append(msg)
+                    if  'rmdir' not in self.o.fileEvents:
+                        self.reject(msg, 202, "skipping rmdir %s" % new_path)
                         continue
 
                     if self.removeOneFile(new_path):
@@ -1512,8 +1511,7 @@ class Flow:
 
                 elif ('remove' in msg['fileOp']):
                     if 'delete' not in self.o.fileEvents:
-                        msg.setReport(202, "skipping delete %s" % new_path)
-                        self.worklist.ok.append(msg)
+                        self.reject(msg, 202, "skipping delete %s" % new_path)
                         continue
 
                     if self.removeOneFile(new_path):
@@ -1531,8 +1529,7 @@ class Flow:
                 # need to retry as ordinary creation, similar to normal file copy case.
                 if 'directory' in msg['fileOp']:
                     if 'mkdir' not in self.o.fileEvents:
-                        msg.setReport(202, "skipping mkdir %s" % new_path)
-                        self.worklist.ok.append(msg)
+                        self.reject(msg, 202, "skipping mkdir %s" % new_path)
                         continue
 
                     if self.mkdir(msg):
@@ -1546,8 +1543,7 @@ class Flow:
 
                 elif 'link' in msg['fileOp'] or 'hlink' in msg['fileOp']:
                     if 'link' not in self.o.fileEvents:
-                        msg.setReport(202, "skipping link %s" % new_path)
-                        self.worklist.ok.append(msg)
+                        self.reject(msg, 202, "skipping link %s" % new_path)
                         continue
 
                     if self.link1file(msg):
@@ -2423,28 +2419,23 @@ class Flow:
             # weed out non-file transfer operations that are configured to not be done.
             if 'fileOp' in msg:
                 if ('directory' in msg['fileOp']) and ('remove' in msg['fileOp']) and ( 'rmdir' not in self.o.fileEvents ):
-                    msg.setReport(202, "skipping rmdir here." )
-                    self.worklist.ok.append(msg)
+                    self.reject(msg, 202, "skipping rmdir here." )
                     continue
 
                 elif ('remove' in msg['fileOp']) and ( 'delete' not in self.o.fileEvents ):
-                    msg.setReport(202, "skipping delete here." )
-                    self.worklist.ok.append(msg)
+                    self.reject(msg, 202, "skipping delete here." )
                     continue
 
                 if ('directory' in msg['fileOp']) and ( 'mkdir' not in self.o.fileEvents ):
-                    msg.setReport(202, "skipping mkdir here." )
-                    self.worklist.ok.append(msg)
+                    self.reject(msg, 202, "skipping mkdir here." )
                     continue
 
                 if ('hlink' in msg['fileOp']) and ( 'link' not in self.o.fileEvents ):
-                    msg.setReport(202, "skipping hlink here." )
-                    self.worklist.ok.append(msg)
+                    self.reject(msg, 202, "skipping hlink here." )
                     continue
 
                 if ('link' in msg['fileOp']) and ( 'link' not in self.o.fileEvents ):
-                    msg.setReport(202, "skipping link here." )
-                    self.worklist.ok.append(msg)
+                    self.reject(msg, 202, "skipping link here." )
                     continue
 
             #=================================

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1511,7 +1511,7 @@ class Flow:
                     continue
 
                 elif ('remove' in msg['fileOp']):
-                    if 'delete' in self.o.fileEvents:
+                    if 'delete' not in self.o.fileEvents:
                         msg.setReport(202, "skipping delete %s" % new_path)
                         self.worklist.ok.append(msg)
                         continue

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -912,7 +912,7 @@ class Flow:
                             toclimb=len(token)-1
                             msg['fileOp'][f] = '../'*(toclimb) + msg['fileOp'][f]
                             
-        if len(token) > 1:
+        if self.o.mirror and len(token) > 1:
             new_dir = new_dir + '/' + '/'.join(token[:-1])
 
         new_dir = self.o.variableExpansion(new_dir, msg)

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -926,11 +926,6 @@ class Flow:
         if maskFileOption:
             msg['new_file'] = self.sundew_getDestInfos(msg, maskFileOption, filename)
             msg['new_relPath'] = '/'.join(  msg['new_relPath'].split('/')[0:-1] + [ msg['new_file'] ]  )
-        # not mirroring
-
-        if not mirror:
-            msg['new_relPath'] = msg['new_file']
-
 
 
     def filter(self) -> None:

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -103,8 +103,12 @@ class Log(FlowCB):
             return msg.dumps()
 
         s = "to "
-        if ('exchange' in msg) and ('post_topic' in msg) and not msg['post_topic'].startswith(msg['exchange'][0]):
-            s+= f"exchange: {msg['exchange'][0]} " 
+        if 'exchange' in msg: 
+            if ('post_topic' in msg) and not msg['post_topic'].startswith(msg['exchange'][0]):
+                if type(msg['exchange']) is list:
+                    s+= f"exchange: {msg['exchange'][0]} " 
+                else:
+                    s+= f"exchange: {msg['exchange']} " 
         if 'post_topic' in msg:
             s+= f"topic: {msg['post_topic']} "
 

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -513,9 +513,15 @@ class Poll(FlowCB):
         msg = sarracenia.Message.fromFileInfo(post_relPath, self.o, desc)
 
         if stat.S_ISDIR(desc.st_mode):
-             msg['fileOp'] = { 'directory':'' }
+            if 'mkdir' not in self.o.fileEvents:
+                return None
+
+            msg['fileOp'] = { 'directory':'' }
              
         elif stat.S_ISLNK(desc.st_mode):
+            if 'link' not in self.o.fileEvents:
+                return None
+
             if not self.o.follow_symlinks:
                 try: 
                     msg['fileOp'] = { 'link': self.dest.readlink(path) }
@@ -523,6 +529,9 @@ class Poll(FlowCB):
                     logger.error("cannot read link %s message dropped" % post_relPath)
                     logger.debug('Exception details: ', exc_info=True)
                     return None
+
+        if 'create' not in self.o.fileEvents and 'modify' not in self.o.fileEvents:
+            return None
 
         if self.o.identity_method and (',' in self.o.identity_method):
             m, v = self.o.identity_method.split(',')

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2574,8 +2574,11 @@ class sr_GlobalState:
                         line[0] = k
 
                     if k in [ 'logEvents', 'fileEvents' ]: # set option semantics changed as per https://github.com/MetPX/sarracenia/issues/608 
-                        line[1]= '+' + line[1]
-                        v=line[1]
+                        if 'none' in line[1].lower():
+                            v=line[1]
+                        else:
+                            line[1]= '+' + line[1]
+                            v=line[1]
 
                     if k == 'continue':
                         continue


### PR DESCRIPTION

There mirror processing in sarracenia/flow/__init__.py ... updateFieldsAccepted(...) routine had two problems with the mirror processing, that broke it quite thoroughly.
The real tragedy was that none of the flow tests caught it.

* closes #796 
* closes #791 

With the changes here, It will pass the tests in https://github.com/MetPX/sr_insects/pull/27

Things that were done:
* there was one line that didn't set relPath correctly for the mirror case.
* there was a second line that incorrectly override new_relPath.

Other stuff that had to be done to get working test cases:
* support of the self.o.fileEvents to choose which fileEvents to act one and forward was missing.
* had to fix up gaps in fileEvents processing in the built in downloading, the sender, and the poll.
