### PR TITLE
Issue809

### DIFF
--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -11,6 +11,12 @@ on:
 
 
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
 
@@ -35,6 +41,11 @@ jobs:
           travis/flow_autoconfig.sh
           travis/ssh_localhost.sh
          
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
       - name: Add and Remove configs, 
         run: |
           pwd

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -549,7 +549,7 @@ class Flow:
                     self._runCallbacksWorklist('report')
                     self._runCallbackMetrics()
 
-                    if hasattr(self.o, 'metricsFilename' ):
+                    if hasattr(self.o, 'metricsFilename' ) and os.path.isdir(os.path.dirname(self.o.metricsFilename)):
                         metrics=json.dumps(self.metrics)
                         with open(self.o.metricsFilename, 'w') as mfn:
                              mfn.write(metrics+"\n")

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -141,7 +141,7 @@ class instance:
             
 
         # init logs here. need to know instance number and configuration and component before here.
-        if cfg_preparse.action in ['start','run'] and not cfg_preparse.logStdout:
+        if cfg_preparse.action in ['start','run'] :
             if cfg_preparse.statehost:
                 hostdir = cfg_preparse.hostdir
             else:
@@ -162,45 +162,46 @@ class instance:
 
             cfg_preparse.metricsFilename = metricsfilename
 
+            if not cfg_preparse.logStdout:
 
-            logfilename = sarracenia.config.get_log_filename( hostdir, component, config, cfg_preparse.no)
+                logfilename = sarracenia.config.get_log_filename( hostdir, component, config, cfg_preparse.no)
 
-            dir_not_there = not os.path.exists(os.path.dirname(logfilename))
-            while dir_not_there:
-                try:
-                    os.makedirs(os.path.dirname(logfilename), exist_ok=True)
-                    dir_not_there = False
-                except FileExistsError:
-                    dir_not_there = False
-                except Exception as ex:
-                    logging.error( "makedirs {} failed err={}".format(os.path.dirname(logfilename),ex))
-                    logging.debug("Exception details:", exc_info=True)
-                    os.sleep(1)
+                dir_not_there = not os.path.exists(os.path.dirname(logfilename))
+                while dir_not_there:
+                    try:
+                        os.makedirs(os.path.dirname(logfilename), exist_ok=True)
+                        dir_not_there = False
+                    except FileExistsError:
+                        dir_not_there = False
+                    except Exception as ex:
+                        logging.error( "makedirs {} failed err={}".format(os.path.dirname(logfilename),ex))
+                        logging.debug("Exception details:", exc_info=True)
+                        os.sleep(1)
 
-            log_format = '%(asctime)s [%(levelname)s] %(name)s %(funcName)s %(message)s'
-            if logging.getLogger().hasHandlers():
-                for h in logging.getLogger().handlers:
-                    h.close()
-                    logging.getLogger().removeHandler(h)
-            logger = logging.getLogger()
-            logger.setLevel(logLevel)
+                log_format = '%(asctime)s [%(levelname)s] %(name)s %(funcName)s %(message)s'
+                if logging.getLogger().hasHandlers():
+                    for h in logging.getLogger().handlers:
+                        h.close()
+                        logging.getLogger().removeHandler(h)
+                logger = logging.getLogger()
+                logger.setLevel(logLevel)
 
-            handler = RedirectedTimedRotatingFileHandler(
-                logfilename,
-                when=lr_when,
-                interval=logRotateInterval,
-                backupCount=cfg_preparse.logRotateCount)
-            handler.setFormatter(logging.Formatter(log_format))
+                handler = RedirectedTimedRotatingFileHandler(
+                    logfilename,
+                    when=lr_when,
+                    interval=logRotateInterval,
+                    backupCount=cfg_preparse.logRotateCount)
+                handler.setFormatter(logging.Formatter(log_format))
 
-            logger.addHandler(handler)
+                logger.addHandler(handler)
 
-            if hasattr(cfg_preparse, 'permLog'):
-                os.chmod(logfilename, cfg_preparse.permLog)
+                if hasattr(cfg_preparse, 'permLog'):
+                    os.chmod(logfilename, cfg_preparse.permLog)
 
-            # FIXME: https://docs.python.org/3/library/contextlib.html portable redirection...
-            if sys.platform != 'win32':
-                os.dup2(handler.stream.fileno(), 1)
-                os.dup2(handler.stream.fileno(), 2)
+                # FIXME: https://docs.python.org/3/library/contextlib.html portable redirection...
+                if sys.platform != 'win32':
+                    os.dup2(handler.stream.fileno(), 1)
+                    os.dup2(handler.stream.fileno(), 2)
 
         else:
             logger.setLevel(logLevel)


### PR DESCRIPTION
closes #809 

The use of the API alone was failing in the flow_basic.yml regression tests.
aka "sr_insects test basic declare/cleanup, and python API" tests were regularly failing.
It turns out that, when using only the python API, the directory to write the metrics file
in was not being created.  did two fixes:

* if not metrics directory exists, don't write it.
* the reason it wasn't created was because lof the logStdOut option, which was controlling creation of both log and metrics directories... the metrics directory creation should not depend on how the logging is done.

