### PR TITLE
error in docs from #811 acceptUnmatched default value.

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -812,7 +812,7 @@ accept, reject and accept_unmatch
 
 - **accept    <regexp pattern> (optional)**
 - **reject    <regexp pattern> (optional)**
-- **acceptUnmatched   <boolean> (default: False)**
+- **acceptUnmatched   <boolean> (default: True)**
 - **baseUrl_relPath   <boolean> (default: False)**
 
 The  **accept**  and  **reject**  options process regular expressions (regexp).

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -812,7 +812,7 @@ accept, reject and accept_unmatch
 
 - **accept    <expression régulière (regexp)>  (facultatif)**
 - **reject    <expression régulière (regexp)>  (facultatif)**
-- **acceptUnmatched   <booléen> (par défaut: False)**
+- **acceptUnmatched   <booléen> (par défaut: True)**
 - **baseUrl_relPath   <booléen> (par défaut: False)**
 
 Les options **accept** et **reject** traitent des expressions régulières (regexp).


### PR DESCRIPTION
acceptUnmatched default is now true everywhere, but some documentation shows it as false.
it's an error.
