### PR TITLE
Issue649 - create a metric for broker side queued message count, and report in sr3 status

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -233,7 +233,7 @@ class AMQP(Moth):
             next_time = self.last_qDeclare + 30
             now=time.time()
             if next_time <= now:
-                self._queueDeclare(True)
+                self._queueDeclare(passive=True)
                 self.last_qDeclare=now
 
         super().metricsReport()

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -233,14 +233,14 @@ class AMQP(Moth):
             next_time = self.last_qDeclare + 30
             now=time.time()
             if next_time <= now:
-                self._queueDeclare()
+                self._queueDeclare(True)
                 self.last_qDeclare=now
 
         super().metricsReport()
 
         return self.metrics
 
-    def _queueDeclare(self) ->  int:
+    def _queueDeclare(self,passive=False) ->  int:
 
         try:
             # from sr_consumer.build_connection...
@@ -272,7 +272,7 @@ class AMQP(Moth):
                 else:
                     qname, msg_count, consumer_count = self.management_channel.queue_declare(
                         self.o['queueName'],
-                        passive=False,
+                        passive=passive,
                         durable=self.o['durable'],
                         exclusive=False,
                         auto_delete=self.o['auto_delete'],

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2338,6 +2338,8 @@ class sr_GlobalState:
         print(underline)
 
         configs_running = 0
+        rxCumulativeMessagesQueued=0
+        rxCumulativeMessagesRetry=0
         rxCumulativeMessageByteRate=0
         rxCumulativeMessageRate=0
         txCumulativeMessageRate=0
@@ -2393,9 +2395,11 @@ class sr_GlobalState:
                         lagMean = 0
                     
                     retry = m[ "msgs_in_download_retry" ] + m["msgs_in_post_retry" ]
+                    rxCumulativeMessagesRetry += retry
 
                     if 'brokerQueuedMessageCount' in m:
                         brokerQdmCount = m['brokerQueuedMessageCount']
+                        rxCumulativeMessagesQueued += brokerQdmCount
 
                     if "last_housekeeping" in m and m["last_housekeeping"] > 0:
                         time_base = now - m[ "last_housekeeping" ] 
@@ -2512,11 +2516,12 @@ class sr_GlobalState:
         print('                   CPU Time: User:%.2fs System:%.2fs ' % ( \
               self.resources['user_cpu'] , self.resources['system_cpu'] \
               ))
-        print( '\t   Pub/Sub Received: %s/s (%s/s), Sent:  %s/s (%s/s)' % ( 
+        print( '\t   Pub/Sub Received: %s/s (%s/s), Sent:  %s/s (%s/s) Queued: %d Retry: %d' % ( 
                 naturalSize(rxCumulativeMessageRate).replace("B","m").replace("myte","msg"), \
                 naturalSize(rxCumulativeMessageRate),\
                 naturalSize(txCumulativeMessageRate).replace("B","m").replace("myte","msg"),\
-                naturalSize(txCumulativeMessageRate)
+                naturalSize(txCumulativeMessageRate),
+                rxCumulativeMessagesQueued, rxCumulativeMessagesRetry
             ))
         print( '\t      Data Received: %s/s (%s/s), Sent: %s/s (%s/s) ' % (
                naturalSize(rxCumulativeFileRate).replace("B","F").replace("Fyte","File") ,

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -899,6 +899,9 @@ class sr_GlobalState:
                             continue
 
                         for j in self.states[c][cfg]['instance_metrics'][i]:
+                            #print( f"i={i}, j={j}, c={c}, cfg={cfg}" )
+                            #print( f"states of c/cfg: {self.states[c][cfg]} " )
+                            #print( f"instance metrics states of c/cfg: {self.states[c][cfg]['instance_metrics']} " )
                             for k in self.states[c][cfg]['instance_metrics'][i][j]:
                                 if k in metrics:
                                     newval = self.states[c][cfg]['instance_metrics'][i][j][k]

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -975,7 +975,7 @@ class sr_GlobalState:
                                         if not i in self.states[c][cfg]['instance_pids']:
                                              self.states[c][cfg]['missing_instances'].append(i)
                     elif observed_instances == 0:
-                        self.configs[c][cfg]['status'] = 'stopped' if len(self.states[c][cfg]['instance_pids']) == 0 else "missing"
+                        self.configs[c][cfg]['status'] = "stopped" if len(self.states[c][cfg]['instance_pids']) == 0 else "missing"
                     elif self.states[c][cfg]['noVip']:
                         self.configs[c][cfg]['status'] = 'waitVip'
                     else:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2338,6 +2338,8 @@ class sr_GlobalState:
         print(underline)
 
         configs_running = 0
+        rxCumulativeLagTime=0
+        rxCumulativeLagCount=0
         rxCumulativeMessagesQueued=0
         rxCumulativeMessagesRetry=0
         rxCumulativeMessageByteRate=0
@@ -2391,6 +2393,8 @@ class sr_GlobalState:
                     m = self.states[c][cfg]['metrics']
                     if m[ "lagMessageCount" ] > 0:
                         lagMean = m[ "lagTotal" ] / m[ "lagMessageCount" ]
+                        rxCumulativeLagTime += m[ "lagTotal" ]
+                        rxCumulativeLagCount +=  m[ "lagMessageCount" ]
                     else:
                         lagMean = 0
                     
@@ -2516,12 +2520,17 @@ class sr_GlobalState:
         print('                   CPU Time: User:%.2fs System:%.2fs ' % ( \
               self.resources['user_cpu'] , self.resources['system_cpu'] \
               ))
-        print( '\t   Pub/Sub Received: %s/s (%s/s), Sent:  %s/s (%s/s) Queued: %d Retry: %d' % ( 
+        if rxCumulativeLagCount  > 0:
+            CumulativeMeanLag = rxCumulativeLagTime / rxCumulativeLagCount 
+        else:
+            CumulativeMeanLag = 0
+
+        print( '\t   Pub/Sub Received: %s/s (%s/s), Sent:  %s/s (%s/s) Queued: %d Retry: %d, Mean lag: %02.2fs' % ( 
                 naturalSize(rxCumulativeMessageRate).replace("B","m").replace("myte","msg"), \
                 naturalSize(rxCumulativeMessageRate),\
                 naturalSize(txCumulativeMessageRate).replace("B","m").replace("myte","msg"),\
                 naturalSize(txCumulativeMessageRate),
-                rxCumulativeMessagesQueued, rxCumulativeMessagesRetry
+                rxCumulativeMessagesQueued, rxCumulativeMessagesRetry, CumulativeMeanLag
             ))
         print( '\t      Data Received: %s/s (%s/s), Sent: %s/s (%s/s) ' % (
                naturalSize(rxCumulativeFileRate).replace("B","F").replace("Fyte","File") ,


### PR DESCRIPTION
* closes #649
* had to have the moth/amqp declare a second management channel... this one is synchronous, whereas on the normal data channel, there can be a lot of messages in flight.
* now every subscriber has two channels the normal one and the *management* one.
* plugged a call to queue declare in the metricsReport routine, but found it was called more often than I liked.
* added a timer to keep it from declaring the queue more than once every 30 seconds.

