### PR TITLE
Issue817 - have logRotate* apply to metrics files too.

### DIFF
--- a/docs/source/How2Guides/subscriber.rst
+++ b/docs/source/How2Guides/subscriber.rst
@@ -927,16 +927,19 @@ logLevel, and logReject:
 
 At the end of the day (at midnight), these logs are rotated automatically by
 the components, and the old log gets a date suffix. The directory in which
-the logs are stored can be overridden by the **log** option, the number of
-rotated logs to keep are set by the **logRotate** parameter. The oldest log
-file is deleted when the maximum number of logs has been reach and this
-continues for each rotation. An interval takes a duration of the interval and
-it may takes a time unit suffix, such as 'd\|D' for days, 'h\|H' for hours,
-or 'm\|M' for minutes. If no unit is provided logs will rotate at midnight.
+the logs and metrics are stored can be overridden by the **log** option, the 
+number of rotated logs to keep are set by the **logRotate** parameter. The 
+oldest log file is deleted when the maximum number of logs and metrics has been 
+reached and this continues for each rotation. An interval takes a duration of 
+the interval and it may takes a time unit suffix, such as 'd\|D' for days, 'h\|H' 
+for hours, or 'm\|M' for minutes. If no unit is provided logs will rotate at midnight.
 Here are some settings for log file management:
 
 - log <dir> ( default: ~/.cache/sarra/log ) (on Linux)
    The directory to store log files in.
+
+- logMetrics ( default: True ) 
+   whether to accumulate multiple metrics files at all.
 
 - statehost <False|True> ( default: False )
    In large data centres, the home directory can be shared among thousands of
@@ -944,10 +947,10 @@ Here are some settings for log file management:
    unique to each node. So each node has it's own statefiles and logs.
    example, on a node named goofy,  ~/.cache/sarra/log/ becomes ~/.cache/sarra/goofy/log.
 
-- logRotate <max_logs> ( default: 5 , alias: lr_backupCount)
+- logRotateCount <max_logs> ( default: 5 , alias: lr_backupCount)
    Maximum number of logs archived.
 
-- logRotate_interval <duration>[<time_unit>] ( default: 1, alias: lr_interval)
+- logRotateInterval <duration>[<time_unit>] ( default: 1, alias: lr_interval)
    The duration of the interval with an optional time unit (ie 5m, 2h, 3d)
 
 - permLog ( default: 0600 )

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1060,12 +1060,12 @@ writing to stdout.
 logRotateCount <max_logs> ( default: 5 )
 ----------------------------------------
 
-Maximum number of logs archived.
+Maximum number of logs (both messages and metrics) archived.
 
 logRotateInterval <interval>[<time_unit>] ( default: 1d )
 ---------------------------------------------------------
 
-The duration of the interval with an optional time unit (ie 5m, 2h, 3d)
+The duration of the interval with an optional time unit (ie 5m, 2h, 3d) for rotation of logs and metrics.
 
 
 messageCountMax <count> (default: 0)

--- a/docs/source/fr/CommentFaire/subscriber.rst
+++ b/docs/source/fr/CommentFaire/subscriber.rst
@@ -898,9 +898,9 @@ logLevel et logReject :
 À la fin de la journée (à minuit), ces fichiers de journalisations sont pivotées automatiquement par
 les composants, et l’ancien journal obtient un suffixe de date. Le répertoire dans lequel
 les journaux sont stockés peut être remplacé par l’option **log**, le nombre
-de journaux pivotés à conserver sont définis par le paramètre **logRotate**. Le journal le plus ancien
-est supprimé lorsque le nombre maximal de journaux a été atteint et que cela
-poursuit pour chaque rotation. Un intervalle prend une durée de l’intervalle et
+de journaux pivotés à conserver sont définis par le paramètre **logRotate**. Le journal (et metriques) 
+le plus ancien est supprimé lorsque le nombre maximal de journaux (en messages et statistiques) a été 
+atteint et que cela poursuit pour chaque rotation. Un intervalle prend une durée de l’intervalle et
 cela peut prendre un suffixe d’unité de temps, tel que 'd\|D' pour les jours, 'h\|H' pour les heures,
 ou 'm\|M' pour les minutes. Si aucune unité n’est fournie, les journaux tourneront à minuit.
 Voici quelques paramètres pour la gestion des fichiers journaux :
@@ -914,10 +914,10 @@ Voici quelques paramètres pour la gestion des fichiers journaux :
    unique à chaque nœud. Ainsi, chaque nœud a ses propres fichiers d’état et journaux.
    Par exemple, sur un nœud nommé goofy, ~/.cache/sarra/log/ devient ~/.cache/sarra/goofy/log.
 
-- logRotate <max_logs> ( par défaut: 5 , alias: lr_backupCount)
+- logRotateCount <max_logs> ( par défaut: 5 , alias: lr_backupCount)
    Nombre maximal de journaux archivés.
 
-- logRotate_interval <duration>[<time_unit>] ( par défaut: 1, alias: lr_interval)
+- logRotateInterval <duration>[<time_unit>] ( par défaut: 1, alias: lr_interval)
    La durée de l’intervalle avec une unité de temps optionnelle (ex. 5m, 2h, 3d)
 
 - permLog ( par défaut: 0600 )

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1045,12 +1045,13 @@ la vitesse d’exécution de tous les processus qui écrivent à stdout.
 logRotateCount <max_logs> ( défaut: 5 )
 ---------------------------------------
 
-Nombre maximal de journaux archivés.
+Nombre maximal de journaux de messages (logs) et statistiques (metrics) archivés.
 
 logRotateInterval <intervalle>[<unité_de_temps>] ( défaut: 1d )
 ---------------------------------------------------------------
 
 La durée de l’intervalle avec une unité de temps optionnel (soit 5m, 2h, 3d)
+entre chaque changement de fichier journal (de messages et statistiques)
 
 messageCountMax <count> (défaut: 0)
 -----------------------------------

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1,4 +1,5 @@
 import copy
+import glob
 import importlib
 import logging
 import os
@@ -554,9 +555,22 @@ class Flow:
                         with open(self.o.metricsFilename, 'w') as mfn:
                              mfn.write(metrics+"\n")
                         if self.o.logMetrics:
+                            if self.o.logRotateInterval >= 24*60*60:
+                                tslen=8
+                            elif self.o.logRotateInterval > 60:
+                                tslen=14
+                            else:
+                                tslen=16
                             timestamp=time.strftime("%Y%m%d-%H%M%S", time.gmtime())
-                            with open(self.o.metricsFilename + '.' + timestamp[0:8], 'a') as mfn:
+                            with open(self.o.metricsFilename + '.' + timestamp[0:tslen], 'a') as mfn:
                                 mfn.write( f'\"{timestamp}\" : {metrics},\n')
+
+                            # removing old metrics files
+                            logger.info( f"looking for old metrics for {self.o.metricsFilename}" )
+                            old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
+                            for o in old_metrics:
+                                logger.info( f"removing old metrics file: {o} " )
+                                os.unlink(o)
 
                     self.worklist.ok = []
                     self.worklist.directories_ok = []


### PR DESCRIPTION
* closes #817 - makes logRotate parameters also affect the metrics files when logMetrics is active.

