### PR TITLE
Issue816 - poll improve how permCopy/timeCopy work

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -658,8 +658,9 @@ class Message(dict):
         if lstat is None: return msg
 
         if (lstat.st_mode is not None) :
-            if (o.permCopy and lstat.st_mode):
-                msg['mode'] = "%o" % (lstat.st_mode & 0o7777)
+            msg['mode'] = "%o" % (lstat.st_mode & 0o7777)
+            if not o.permCopy:
+                msg['_deleteOnPost'] |= set(['mode'])
             
             if os_stat.S_ISDIR(lstat.st_mode):
                 msg['fileOp'] = { 'directory': '' }
@@ -668,11 +669,13 @@ class Message(dict):
         if lstat.st_size is not None:
             msg['size'] = lstat.st_size
 
-        if o.timeCopy:
-            if lstat.st_mtime is not None:
-                msg['mtime'] = timeflt2str(lstat.st_mtime)
-            if lstat.st_atime is not None:
-                msg['atime'] = timeflt2str(lstat.st_atime)
+        if lstat.st_mtime is not None:
+            msg['mtime'] = timeflt2str(lstat.st_mtime)
+        if lstat.st_atime is not None:
+            msg['atime'] = timeflt2str(lstat.st_atime)
+
+        if not o.timeCopy:
+            msg['_deleteOnPost'] |= set([ 'atime', 'mtime' ])
 
         return msg
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2566,6 +2566,7 @@ class sr_GlobalState:
                     if k == 'destination':
                         if component == 'poll':
                             k = 'pollUrl'
+                            v3_cfg.write('permCopy off\n')
                         else:
                             k = 'sendTo'
                     elif (k == 'get' ) and (component == 'poll'):


### PR DESCRIPTION
closes #816 

Before this patch, if **timeCopy** was off, then a message would be created without *ctime* and *mtime* headers.  Now it is created, but the two headers are added to the *_deleteOnPost* header so they will not be forwarded.  The same thing was done for **permCopy**

So the code can validate that permissions in the poll are readable (because mode bits will be present), even though permCopy is off.   Code can also use the mtime/ctime as part of duplicate suppression or other time based filtering, even though timeCopy is off.
