### PR TITLE
for #803: remove setup command, it is just an undocumented alias

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -61,7 +61,6 @@ the broker, or manage the configurations.
 
  - cleanup:       deletes the component's resources on the server.
  - declare:       creates the component's resources on the server.
- - setup:         like declare, additionally does queue bindings.
  - add:           copy to the list of available configurations.
  - list:          list all the configurations available.
  - list plugins:  list all the plugins available. 
@@ -92,9 +91,9 @@ To have components run all the time, on Linux one can use `systemd <https://www.
 as described in the `Admin Guide <../How2Guides/Admin.rst>`_ On Windows, one can configure a service,
 as described in the `Windows user manual <../Tutorials/Windows.html>`_
 
-The actions **cleanup**, **declare**, **setup** can be used to manage resources on
+The actions **cleanup**, **declare**, can be used to manage resources on
 the rabbitmq server. The resources are either queues or exchanges. **declare** creates
-the resources. **setup** creates and additionally binds the queues.
+the resources.
 
 The **add, remove, list, edit, enable & disable** actions are used to manage the list 
 of configurations.  One can see all of the configurations available using the **list**
@@ -114,8 +113,8 @@ with *sr3 convert component/config*.
 ACTIONS
 -------
 
-declare|setup
-~~~~~~~~~~~~~
+declare
+~~~~~~~
 
 Call the corresponding function for each configuration::
 

--- a/docs/source/Reference/sr3.1.rst
+++ b/docs/source/Reference/sr3.1.rst
@@ -75,7 +75,6 @@ The type of action to take. One of:
  - restart: stop and then start the configuration.
  - run:  run as a master process (like start, but don't return.)
  - sanity: looks for instances which have crashed or gotten stuck and restarts them.
- - setup:         like declare, additionally does queue bindings.
  - show           view an interpreted version of a configuration file.
  - start:  start the configuration running
  - status: check if the configuration is running.

--- a/docs/source/Reference/sr3_cpump.1.rst
+++ b/docs/source/Reference/sr3_cpump.1.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 ========
 
 **sr_cpump** foreground|start|stop|restart|reload|status configfile
-**sr_cpump** cleanup|declare|setup configfile
+**sr_cpump** cleanup|declare configfile
 
 DESCRIPTION
 ===========
@@ -61,9 +61,9 @@ run the program and its configfile interactively...   The **foreground** instanc
 is not concerned by other actions.  The user would stop using the **foreground** instance 
 by simply <ctrl-c> on linux or use other means to send SIGINT or SIGTERM to the process.
 
-The actions **cleanup**, **declare**, **setup** can be used to manage resources on
+The actions **cleanup**, **declare**, can be used to manage resources on
 the rabbitmq server. The resources are either queues or exchanges. **declare** creates
-the resources. **setup** creates and additionally does the bindings of queues.
+the resources. creates and additionally does the bindings of queues.
 
 The actions **add**, **remove**, **edit**, **list**, **enable**, **disable** act
 on configurations.

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -61,7 +61,6 @@ le courtier ou pour gérer les configurations.
 
  - cleanup:       supprime les ressources du composant sur le serveur
  - declare:       crée les ressources du composant sur le serveur.
- - setup:         comme declare, fait en plus des liaisons de fil d'attente.
  - add:           copie une configuration à la liste des configurations disponibles.
  - list:          Énumérer toutes les configurations disponibles.
  - list plugins:  Énumérer toutes les *plugins* disponibles.
@@ -93,10 +92,9 @@ Pour que les composants roulent tous en meme temps,sur Linux on peut utiliser l'
 `Admin Guide <../How2Guides/Admin.html>`_ . Sur Windows, il est possible de configurer un service,
 comme décrit dans `Windows user manual <../Tutorials/Windows.html>`_
 
-Les actions **cleanup**, **declare**, **setup** peuvent être utilisées pour gérer les
+Les actions **cleanup**, **declare**, peuvent être utilisées pour gérer les
 ressources sur le courtier rabbitmq. Les ressources sont soit des files d'attente,
-soit des échanges. **declare** crée les ressources. **setup** crée les files
-d'attente et les liaisons.
+soit des échanges. **declare** crée les ressources.
 
 Les actions **add, remove, list, edit, enable & disable** sont utilisées pour gérer la liste
 de configurations et *plugins*. On peut voir toutes les configurations disponibles en utilisant l´action **list**.
@@ -115,8 +113,8 @@ dans le répertoire *~/.config/sr3/composant/v3_config.conf*. Pas exemple, cette
 ACTIONS
 -------
 
-declare|setup
-~~~~~~~~~~~~~
+declare
+~~~~~~~
 
 Appeler la fonction correspondante pour chacune des configurations::
 

--- a/docs/source/fr/Reference/sr3.1.rst
+++ b/docs/source/fr/Reference/sr3.1.rst
@@ -74,7 +74,6 @@ Les types d'actions disponible. Une seule parmi:
  - run:           comme *start* mais on attend que les sous-processus reviennent.
  - restart:       arrêter et ensuite commencer une configuration.
  - sanity:        cherche des instances qui sont perdus/coincées/en panne et les redémarres.
- - setup:         comme declare, et fait également des queue bindings.
  - show           afficher une version interprétée d’un fichier de configuration.
  - start:         partir l'execution d'une ensemble de configurations
  - status:        vérifier si une configuration est en train de rouler.

--- a/docs/source/fr/Reference/sr3_cpump.1.rst
+++ b/docs/source/fr/Reference/sr3_cpump.1.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 ========
 
 **sr_cpump** foreground|start|stop|restart|reload|status configfile
-**sr_cpump** cleanup|declare|setup configfile
+**sr_cpump** cleanup|declare configfile
 
 DESCRIPTION
 ===========
@@ -61,13 +61,9 @@ exécuter le programme et son fichier de configuration de manière interactive..
 n'est pas concerné par d'autres actions. L'utilisateur cesserait d'utiliser l'instance **foreground**
 en simplement <ctrl-c> sous linux ou utilisez d'autres moyens pour envoyer SIGINT ou SIGTERM au processus.
 
-Les actions **cleanup**, **declare**, **setup** peuvent être utilisées pour gérer les ressources sur
+Les actions **cleanup**, **declare**, peuvent être utilisées pour gérer les ressources sur
 le serveur rabbitmq. Les ressources sont soit des files d'attente, soit des échanges. **déclarer** crée
-les ressources. **setup** crée et met en place les liaisons des files d'attente.
-
-The actions **cleanup**, **declare**, **setup** can be used to manage resources on
-the rabbitmq server. The resources are either queues or exchanges. **declare** creates
-the resources. **setup** creates and additionally does the bindings of queues.
+les ressources. 
 
 Les actions **ajouter**, **supprimer**, **modifier**, **lister**, **activer**, **désactiver** agissent
 sur les configurations.


### PR DESCRIPTION
closes #803

just remove all documentation of a setup command, which used to do something different than *declare* but today is just a synonym.
