### PR TITLE
First attempt at switching to AMQP consumers instead of using basic_get

### DIFF
--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -42,27 +42,21 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
+      # 2023-11-13 RS Added SSH config changes to see if it makes the tests more reliable
         run: |
           travis/flow_autoconfig.sh
           travis/ssh_localhost.sh
+          sudo sh -c 'echo "MaxSessions 750" >> /etc/ssh/sshd_config'
+          sudo sh -c 'echo "MaxStartups 750" >> /etc/ssh/sshd_config'
+          sudo systemctl restart ssh
           echo "amqp_consumer True" >> ${HOME}/.config/sr3/default.conf
           echo "set sarracenia.moth.amqpconsumer.AMQPConsumer.logLevel debug" >> ${HOME}/.config/sr3/default.conf
-         
+      
       - name: Setup ${{ matrix.which_test }} test.
         run: |
           cd ${HOME}; pwd; ls ; 
           echo hoho
           cd ${HOME}/sr_insects/${{ matrix.which_test }}; ./flow_setup.sh
-
-      # Enable tmate debugging of manually-triggered workflows if the input option was provided
-      # https://github.com/marketplace/actions/debugging-with-tmate
-      # 2023/07/22 PAS, removed because when manually invoking test it always enables in spite
-      # of the github box not being checked, so cannot invoke the tests manually.
-      # 
-      #- name: Setup tmate session
-      #  uses: mxschmitt/action-tmate@v3
-      #  if: ${{ github.event.inputs.debug_enabled }}
-      #  #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
       - name: Limit ${{ matrix.which_test }} test.
         run: |

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -1,0 +1,89 @@
+name: sr_insects Flow Tests using AMQP Consumer.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+  push:
+    branches:
+      - development
+      - stable
+      - issue_457_amqp_consumer
+
+    paths-ignore:
+      - '.github/**'
+      - 'debian/changelog'
+      - 'TODO.txt'
+
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
+
+jobs:
+
+  run_sr_insects_tests:
+
+    strategy:
+      # Don't cancel the entire matrix when one job fails
+      fail-fast: false
+      matrix:
+       which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
+       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+
+    runs-on: ${{ matrix.osver }}
+  
+    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    timeout-minutes: 40
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          travis/flow_autoconfig.sh
+          travis/ssh_localhost.sh
+          echo "amqp_consumer True" >> ${HOME}/.config/sr3/default.conf
+          echo "set sarracenia.moth.amqpconsumer.AMQPConsumer.logLevel debug" >> ${HOME}/.config/sr3/default.conf
+         
+      - name: Setup ${{ matrix.which_test }} test.
+        run: |
+          cd ${HOME}; pwd; ls ; 
+          echo hoho
+          cd ${HOME}/sr_insects/${{ matrix.which_test }}; ./flow_setup.sh
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      # https://github.com/marketplace/actions/debugging-with-tmate
+      # 2023/07/22 PAS, removed because when manually invoking test it always enables in spite
+      # of the github box not being checked, so cannot invoke the tests manually.
+      # 
+      #- name: Setup tmate session
+      #  uses: mxschmitt/action-tmate@v3
+      #  if: ${{ github.event.inputs.debug_enabled }}
+      #  #if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
+      - name: Limit ${{ matrix.which_test }} test.
+        run: |
+          cd ${HOME}/sr_insects/${{ matrix.which_test }}; ./flow_limit.sh
+
+      - name: Check results of ${{ matrix.which_test }} test.
+        run: |
+          cd ${HOME}/sr_insects/${{ matrix.which_test }}; ./flow_check.sh
+        
+      - name: Compress log files for artifacts
+        if: always()
+        continue-on-error: true
+        run: |
+          sr3 stop --dangerWillRobinson
+          cd ${HOME}/.cache/sr3/
+          tar -czf ${HOME}/cache_sr3.tar.gz *
+      
+      - name: Save run artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}
+          path: ~/cache_sr3.tar.gz

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -67,6 +67,7 @@ import sarracenia.instance
 default_options = {
     'acceptSizeWrong': False,
     'acceptUnmatched': True,
+    'amqp_consumer': False,
     'attempts': 3,
     'batch' : 100,
     'baseDir': None,
@@ -111,7 +112,7 @@ count_options = [
 ]
 
 # all the boolean settings.
-flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'baseUrl_relPath', 'debug', \
+flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl_relPath', 'debug', \
     'delete', 'discard', 'download', 'dry_run', 'durable', 'exchangeDeclare', 'exchangeSplit', 'logReject', 'realpathFilter', \
     'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logMetrics', 'logStdout', 'logReject', 'restore', \
     'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \

--- a/sarracenia/moth/amqpconsumer.py
+++ b/sarracenia/moth/amqpconsumer.py
@@ -40,7 +40,7 @@ class AMQPConsumer(AMQP):
         Set amqp_consumer True in the config to use this instead of the regular AMQP class.
 
         TODO: 
-          - how does this work with the batch and prefetch options?
+          - how does this work with the batch and prefetch options? 
     """
 
     def __init__(self, props, is_subscriber) -> None:

--- a/sarracenia/moth/amqpconsumer.py
+++ b/sarracenia/moth/amqpconsumer.py
@@ -1,0 +1,161 @@
+# This file is part of sarracenia.
+# The sarracenia suite is Free and is proudly provided by the Government of Canada
+# Copyright (C) Her Majesty The Queen in Right of Canada, 2008-2020
+#
+# Sarracenia repository: https://github.com/MetPX/sarracenia
+# Documentation: https://github.com/MetPX/sarracenia
+#
+########################################################################
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; version 2 of the License.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#
+#
+
+import logging
+
+import sarracenia
+from sarracenia.moth.amqp import AMQP, amqp_ss_maxlen, default_options
+
+import time
+import queue
+import threading
+
+logger = logging.getLogger(__name__)
+
+class AMQPConsumer(AMQP):
+    """
+        Extension of the existing AMQP implementation, replacing basic_get with a consumer.
+        https://github.com/celery/py-amqp#quick-overview
+
+        Set amqp_consumer True in the config to use this instead of the regular AMQP class.
+
+        TODO: 
+          - how does this work with the batch and prefetch options?
+    """
+
+    def __init__(self, props, is_subscriber) -> None:
+        super().__init__(props, is_subscriber)
+        self._raw_msg_q = queue.Queue() # Queue is thread safe
+        self._consumer_thread = None
+        self._thread_please_stop = False
+        logger.setLevel("DEBUG") # TODO test if the normal log level syntax works, if not, implement
+
+    def __get_on_message(self, msg):
+        """ Callback for AMQP basic_consume, called when the broker sends a new message.
+        """
+        logger.debug(f"new message pushed from broker: {msg.body}")
+        # This will block until the msg can be put in the queue
+        self._raw_msg_q.put(msg)
+
+    def __drain_events(self):
+        """ Calls drain_events on the connection until told to stop.
+        """
+        logger.debug("thread starting")
+        # need to handle signals so it doesn't get killed...
+        while not self._thread_please_stop:
+            # This blocks until there's an event to deal with
+            try:
+                self.connection.drain_events(timeout=2)
+            except TimeoutError:
+                pass
+            except Exception as e:
+                logger.error(f"exception occurred: {e}")
+                logger.debug('Exception details: ', exc_info=True)
+        logger.debug("thread stopping")
+        self._consumer_thread = None
+
+    def __stop_thread(self):
+        # need to stop consuming - tell the thread to stop, then join it and wait
+        self._thread_please_stop = True
+        if self._consumer_thread:
+            self._consumer_thread.join()
+        self._consumer_thread = None
+        self._thread_please_stop = False # if True, the thread won't start again
+
+    def _amqp_setup_signal_handler(self, signum, stack):
+        logger.info("ok, asked to stop")
+        self.please_stop=True
+        self.__stop_thread()
+
+    def getSetup(self) -> None:
+        """
+        Setup so we can consume messages.
+        """
+        super().getSetup()
+        # docs.celeryq.dev/projects/amqp/en/latest/reference/amqp.channel.html#amqp.channel.Channel.basic_consume
+        self.channel.basic_consume(self.o['queueName'], no_ack=False, callback=self.__get_on_message)
+        self.__stop_thread() # make sure it's not already running
+        self._consumer_thread = threading.Thread(target=self.__drain_events)
+        self._consumer_thread.start()
+
+    def getCleanUp(self) -> None:
+        self.__stop_thread()
+        super().getCleanUp()
+
+    def getNewMessage(self) -> sarracenia.Message:
+        """ Mostly a copy of moth.amqp.AMQP's getNewMessage.
+        """
+
+        if not self.is_subscriber:  #build_consumer
+            logger.error("getting from a publisher")
+            return None
+
+        try:
+            if not self.connection:
+                self.getSetup()
+
+            try:
+                # don't block waiting for the queue to be available, better to just try again later
+                raw_msg = self._raw_msg_q.get_nowait()
+            except queue.Empty:
+                raw_msg = None
+            
+            if (raw_msg is None) and (self.connection.connected):
+                return None
+            else:
+                self.metrics['rxByteCount'] += len(raw_msg.body)
+                try: 
+                    msg = self._msgRawToDict(raw_msg)
+                except Exception as err:
+                    logger.error("message decode failed. raw message: %s" % raw_msg.body )
+                    logger.debug('Exception details: ', exc_info=True)
+                    msg = None
+                if msg is None:
+                    self.metrics['rxBadCount'] += 1
+                    return None
+                else:
+                    self.metrics['rxGoodCount'] += 1
+                if hasattr(self.o, 'fixed_headers'):
+                    for k in self.o.fixed_headers:
+                        msg[k] = self.o.fixed_headers[k]
+                logger.debug("new msg: %s" % msg)
+                return msg
+        except Exception as err:
+            logger.warning("failed %s: %s" %
+                           (self.o['queueName'], err))
+            logger.debug('Exception details: ', exc_info=True)
+
+        if not self.o['message_strategy']['stubborn']:
+            return None
+
+        logger.warning('lost connection to broker')
+        self.close()
+        time.sleep(1)
+        return None
+
+    def close(self) -> None:
+        try: 
+            self.__stop_thread()
+        except:
+            pass
+        super().close()


### PR DESCRIPTION
Adds a new Moth implementation that uses consumers instead of basic_get.

Enabled by setting `amqp_consumer True` in the config.