### PR TITLE
Issue828 - log message printing the wrong exchange.

### DIFF
--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -103,12 +103,9 @@ class Log(FlowCB):
             return msg.dumps()
 
         s = "to "
-        if 'exchange' in msg: 
-            if ('post_topic' in msg) and not msg['post_topic'].startswith(msg['exchange'][0]):
-                if type(msg['exchange']) is list:
-                    s+= f"exchange: {msg['exchange'][0]} " 
-                else:
-                    s+= f"exchange: {msg['exchange']} " 
+        if 'post_exchange' in msg and ('post_topic' in msg) and \
+            not msg['post_topic'].startswith(msg['post_exchange']) :
+            s+= f"exchange: {msg['post_exchange']} " 
         if 'post_topic' in msg:
             s+= f"topic: {msg['post_topic']} "
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -681,7 +681,8 @@ class AMQP(Moth):
             logger.info('raw message headers: type: %s value: %s' % (type(headers),  headers))
 
         message['post_topic'] = topic
-        message['_deleteOnPost'] |= set( ['post_topic'] )
+        message['post_exchange'] = exchange
+        message['_deleteOnPost'] |= set( ['post_exchange', 'post_topic'] )
         del headers['topic']
 
         if headers :  

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -55,4 +55,6 @@ def test_variableExpansion():
      good = re.compile( options.post_baseDir + '/smorgasbord/[0-9]{8}/' )
      assert good.match(result)
 
-
+     # to get stuff to print out, make it fail.
+     #assert False 
+     

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -1,0 +1,60 @@
+import pytest
+#from unittest.mock import Mock
+
+import os
+from base64 import b64decode
+#import urllib.request
+import logging
+import re
+
+import sarracenia
+import sarracenia.config
+
+#useful for debugging tests
+import pprint
+pretty = pprint.PrettyPrinter(indent=2, width=200).pprint
+
+
+logger = logging.getLogger('sarracenia.config')
+logger.setLevel('DEBUG')
+
+def test_variableExpansion():
+
+     options = sarracenia.config.default_config()
+     options.baseDir = '/data/whereIcameFrom'
+     options.documentRoot = options.baseDir
+     options.post_baseDir = '/data/whereIamGoingTo'
+     options.varTimeOffset= 0
+
+     message = sarracenia.Message()
+     message['source'] = 'WhereDataComesFrom'
+     message['baseUrl'] = 'https://localhost/smorgasbord'
+
+     result = options.variableExpansion( "${PDR}/${%Y%m%d}/", message );
+     logger.debug( f"result: {result}" )
+     good = re.compile( options.post_baseDir + '/[0-9]{8}/' )
+     assert good.match(result)
+
+     result = options.variableExpansion( "${PBD}/${%Y%m%d}/", message );
+     logger.debug( f"result: {result}" )
+     good = re.compile( options.post_baseDir + '/[0-9]{8}/' )
+     assert good.match(result)
+
+     result = options.variableExpansion( "${PBD}/${SOURCE}/${%Y%m%d}/boughsOfHolly", message );
+     logger.debug( f"result: {result}" )
+     good = re.compile( options.post_baseDir + '/' + message['source'] + '/[0-9]{8}/boughsOfHolly' )
+     assert good.match(result)
+
+     result = options.variableExpansion( "${PBD}/${BUPL}/${%Y%m%d}/falala", message );
+     logger.debug( f"result: {result}" )
+     good = re.compile( options.post_baseDir + '/smorgasbord/[0-9]{8}/falala' )
+     assert good.match(result)
+
+     result = options.variableExpansion( "${PBD}/${BUPL}/${%Y%m%d}/", message );
+     logger.debug( f"result: {result}" )
+     good = re.compile( options.post_baseDir + '/smorgasbord/[0-9]{8}/' )
+     assert good.match(result)
+
+     assert False 
+     
+     


### PR DESCRIPTION
* closes #828 

@andreleblanc11 ran into a case where it became obvious that when a component is subscribing and republishing, the post message prints the name of the exchange the message was received from, rather than the one it was posted to.
