### PR TITLE
one way of addressing #827, making dangerWillRobinson a number that m…

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -2339,8 +2339,8 @@ class Config:
                             nargs='?',
                             help=' specifical configuration to select ')
         parser.add_argument('--dangerWillRobinson',
-                            action='store_true',
-                            default=False,
+                            type=int,
+                            default=0,
                             help='Confirm you want to do something dangerous')
         parser.add_argument('--debug',
                             action='store_true',

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1828,8 +1828,6 @@ class sr_GlobalState:
             logging.error("No configuration matched")
             return
 
-        logging.error( f" configs matched: {len(self.filtered_configurations)} ")
-
         if len(self.filtered_configurations) > 1 :
             if len(self.filtered_configurations) != self.options.dangerWillRobinson:
                 logging.error(

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1577,11 +1577,11 @@ class sr_GlobalState:
 
     def cleanup(self):
 
-        if len(self.filtered_configurations
-               ) > 1 and not self.options.dangerWillRobinson:
-            logging.error(
-                "specify --dangerWillRobinson to cleanup > 1 config at a time")
-            return
+        if len(self.filtered_configurations) > 1 :
+            if len(self.filtered_configurations) != self.options.dangerWillRobinson:
+                logging.error(
+                "specify --dangerWillRobinson=<number> of configs to cleanup  when cleaning more than one")
+                return
 
         queues_to_delete = []
         for f in self.filtered_configurations:
@@ -1828,11 +1828,13 @@ class sr_GlobalState:
             logging.error("No configuration matched")
             return
 
-        if len(self.filtered_configurations
-               ) > 1 and not self.options.dangerWillRobinson:
-            logging.error(
-                "specify --dangerWillRobinson to remove > 1 config at a time")
-            return
+        logging.error( f" configs matched: {len(self.filtered_configurations)} ")
+
+        if len(self.filtered_configurations) > 1 :
+            if len(self.filtered_configurations) != self.options.dangerWillRobinson:
+                logging.error(
+                    "specify --dangerWillRobinson=<n> of configs to remove when > 1 involved.")
+                return
 
         for f in self.filtered_configurations:
             if self.please_stop:
@@ -2128,7 +2130,7 @@ class sr_GlobalState:
                 print('All stopped after try %d' % attempts)
                 if len(fg_instances) > 0:
                     print(f"Foreground instances {fg_instances} are running and were not stopped.")
-                    print("Use --dangerWillRobinson to force stop foreground instances with sr3 stop.")
+                    print("Use --dangerWillRobinson=1 to force stop foreground instances with sr3 stop.")
                 return 0
             attempts += 1
 
@@ -2187,7 +2189,7 @@ class sr_GlobalState:
             print('All stopped after KILL')
             if len(fg_instances) > 0:
                 print(f"Foreground instances {fg_instances} are running and were not stopped.")
-                print("Use --dangerWillRobinson to force stop foreground instances with sr3 stop.")
+                print("Use --dangerWillRobinson=1 to force stop foreground instances with sr3 stop.")
             return 0
         else:
             print('not responding to SIGKILL:')


### PR DESCRIPTION
This is a first shot at #827... I think getting a count that matches what is being done is a good thing.  I don't think y/n prompts help, because the analyst will then ask for a -y option, and in any event if the analyst didn't notice the problem immediately, they could answer yes anyways.  having to supply a number that matches the number of configs affected is almost like a 2nd factor.  Correlation is a good thing.

So this patch does that, but more is needed prior to merging this:
* documenting the change in behaviour  (cleanup and remove want the number, other ops just require --dangerWillRobinson=1 ) 
* when doing sr3 stop and you want to stop even foreground tasks, currently that requires --dangerWillRobinson.  That's not super dangerous, so just ask for --dangerWillRobinson=1 for that.
