### PR TITLE
Issue825 - fix crashes for disk inconsistencies.

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -67,6 +67,13 @@ import sarracenia.instance
 
 class octal_number(int):
 
+    def __new__(cls, value):
+        if type(value) is str:
+            self = int(value,base=8)
+        elif type(value) is int:
+            self = value
+        return self
+
     def __str__(self) -> str:
         return f"0o{self:o}"
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1920,7 +1920,7 @@ class sr_GlobalState:
                 for i in range(1, numi + 1):
                     if pcount % 10 == 0: print('.', end='', flush=True)
                     pcount += 1
-            if len(self.states[c][cfg]['hung_instances']) > 0:
+            if 'hung_instances' in self.states[c][cfg] and len(self.states[c][cfg]['hung_instances']) > 0:
                 for i in self.states[c][cfg]['hung_instances']:
                     kill_pid=self.states[c][cfg]['instance_pids'][i]
                     print( f'\nfound hung {c}/{cfg}/{i} pid: {kill_pid}' )

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1395,7 +1395,7 @@ class sr_GlobalState:
             if not 'options' in self.configs[c][cfg]:
                 continue
 
-            if len(self.states[c][cfg]['instance_pids']) > 0:
+            if 'instance_pids' in self.states[c][cfg] and len(self.states[c][cfg]['instance_pids']) > 0:
                 logging.error("cannot disable %s while it is running! " % f)
                 continue
 


### PR DESCRIPTION
closes #825 

sr3 disable would crash because some configurations have inconsistencies between .config directory and the state files in the .cache directory.  these patches just put a guard around the statements using the missing values.

After looking at the code, no better way to deal with this is obvious, so keeping the initial approach.