### PR TITLE
Issue834 change default filename setting.

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -300,7 +300,7 @@ View all configuration settings (the result of all parsing... what the flow comp
      'feeder': ParseResult(scheme='amqp', netloc='tfeed@localhost', path='/', params='', query='', fragment=''),
      'fileEvents': {'create', 'link', 'modify', 'delete', 'mkdir', 'rmdir' },
      'file_total_interval': '0',
-     'filename': 'WHATFN',
+     'filename': None,
      'fixed_headers': {},
      'flatten': '/',
      'hostdir': 'fractal',

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -121,8 +121,11 @@ In the rename option, the time to be substituted is one hour in the past.
 One can also specify variable substitutions to be performed on arguments to the directory
 option, with the use of *${..}* notation:
 
-* %...     - a `datetime.strftime() <https://docs.python.org/3/library/datetime.html#datetime.date.strftime>`_ compatible date/time formatting string augmented by an offset duration suffix (- for in the past, + for in the future)
-  example:  ${%Y/%m/%d_%Hh%M:%S.%f} --> 2022/12/04_17h36:34.014412 
+* %...     - a `datetime.strftime() <https://docs.python.org/3/library/datetime.html#datetime.date.strftime>`_ compatible date/time formatting string augmented by an offset duration prefix (- for in the past, + for in the future)
+
+  * example (complex date):  ${%Y/%m/%d_%Hh%M:%S.%f} --> 2022/12/04_17h36:34.014412 
+  * example (add offset):  ${%o-1h%Y/%m/%d_%Hh%M:%S.%f} --> 2022/12/04_16h36:34.014412 
+
 * SOURCE   - the amqp user that injected data (taken from the notification message.)
 * BD       - the base directory
 * BUP      - the path component of the baseUrl (or: baseUrlPath) 
@@ -738,7 +741,7 @@ and in early use (when default was 1 week) brokers would often get overloaded wi
 long queues for left-over experiments.
 
 
-filename <keyword> (default:WHATFN)
+filename <keyword> (default:None)
 -----------------------------------
 
 From **metpx-sundew**, the support of this option give all sorts of possibilities

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -2477,7 +2477,7 @@ pour la livraison du produit. Le script reçoit une instance de la classe sender
 Le script prends le parent comme argument, et par exemple, une
 modification de **parent.msg.new_file** changera le nom du fichier écrit localement.
 
-filename <mots-clé> (défaut:WHATFN)
+filename <mots-clé> (défaut:None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 De **MetPX Sundew**, le support de cette option donne toutes sortes de possibilités

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -727,7 +727,7 @@ assigné au courtier, et dans les premières utilisations (lorsque le défaut é
 étaient souvent surchargés de très longues files d’attente pour les tests restants.
 
 
-filename <mots-clé> (défaut:WHATFN)
+filename <mots-clé> (défaut:None)
 -----------------------------------
 
 De **MetPX Sundew**, le support de cette option donne toutes sortes de possibilités

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -93,7 +93,7 @@ default_options = {
     'documentRoot': None,
     'download': False,
     'dry_run': False,
-    'filename': 'WHATFN',
+    'filename': None,
     'flowMain': None,
     'inflight': None,
     'inline': False,
@@ -973,7 +973,7 @@ class Config:
             fn = arguments[1]
         else:
             fn = self.filename
-        if re.compile('DESTFNSCRIPT=.*').match(fn):
+        if fn and re.compile('DESTFNSCRIPT=.*').match(fn):
             script=fn[13:]
             self.destfn_scripts.append(script)
 
@@ -1622,6 +1622,8 @@ class Config:
 
             elif k in str_options:
                 v = ' '.join(line[1:])
+                if v == 'None':
+                    v=None
                 setattr(self, k, v)
             else:
                 #FIXME: with _options lists for all types and addition of declare, this is probably now dead code.


### PR DESCRIPTION
* closes #834 

The *filename* setting in sr3 is set to 'WHATFN' at the moment. This causes names to be mangled when they contain a colon, for compatibility with Sundew.  When one is not working with Sundew, this split is surprising, and confusing. Users are befuddled and confused by this behaviour.

I looked at v2 source code and the default there is None already, so, this should provide better compatibility with sarra v2. It is unclear why the default is set the way it is.  Should there be a need for further discussion, can always re-open this issue for further discussion.