### PR TITLE
Fix one problem related to #639 is relative paths being absoluted...

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1694,17 +1694,13 @@ class Flow:
             u = sarracenia.baseUrlParse(msg['baseUrl']) 
             logger.debug( f"baseUrl.path= {u.path} ")
             if remote_path:
-                if u.path != '/' and remote_path:
-                    if remote_path[0] == '/':
-                        remote_path = u.path + remote_path
-                    else:
+                if u.path: 
+                    if ( u.path[-1] != '/' ) and ( remote_path[0] != '/' ) :
                         remote_path = u.path + '/' + remote_path
+                    else:
+                        remote_path = u.path + remote_path
 
-                # relPath does not contain a prefix / , add it for cdir
-                if remote_path[0] != '/':
-                    cdir = '/' + remote_path
-                else:
-                    cdir = remote_path
+                cdir = remote_path
             else:
                 if u.path:
                     cdir=u.path


### PR DESCRIPTION
fixing one problem related to #639 is relative paths being treated as absolute ones when baseUrl.path=''"  

This solves one problem with relative SFTP paths. I don't think it addresses any problem that anybody ran into, it's just I found a different problem while investigating #639.

prior to PR, tested with:
* flows: static, flakey, dynamic, no_mirror.
* C all the make shim_test (6 different mirroring config tests.)

There are two other PR's that should be merged before this one, matching ones:
* sarrac to change configuration to properly use absolute paths.
* sr_insects to put in a use case for relative paths so (test fails if this PR isn't applied.)

