### PR TITLE
V2 issue639

### DIFF
--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -2807,10 +2807,15 @@ class sr_config:
 
         if flgs == self.lastflg : return
 
-        if flgs in [ '0', 'L', 'R' ]:
+        if flgs in [ '0', 'L', 'R'  ]:
            self.sumalgo = self.sumalgos['0']
            self.lastflg = flgs
            return
+
+        if flgs in [ 'm', 'r' ]:
+            self.sumalgo = flgs
+            self.lastflg = flgs
+            return  
 
         try   : 
                 self.sumalgo = self.sumalgos[flgs]

--- a/sarra/sr_message.py
+++ b/sarra/sr_message.py
@@ -283,7 +283,8 @@ class sr_message():
            self.topic     = msg.delivery_info['routing_key']
            self.topic     = self.topic.replace('%20',' ')
            self.topic     = self.topic.replace('%23','#')
-           sum_algo_v3tov2 = { "arbitrary":"a", "md5":"d", "sha512":"s", "md5name":"n", "random":"0", "link":"L", "remove":"R", "cod":"z" }
+           sum_algo_v3tov2 = { "arbitrary":"a", "md5":"d", "sha512":"s", "md5name":"n", "random":"0", "link":"L", "remove":"R", "cod":"z", 
+                   "directory": "m" }
            if msg.body[0] == '[' :
                self.logger.debug("from_amqplib transitional v03" )
                self.pubtime, self.baseurl, self.relpath, self.headers = json.loads(msg.body)
@@ -320,6 +321,12 @@ class sr_message():
                        self.event = 'link'
                    elif sa == 'R':
                        self.event = 'delete'
+                   elif sa == 'm':
+                       if "remove" in self.headers["fileOp"]:
+                           sa="r"
+                           self.event='rmdir'
+                       else:
+                           self.event = 'mkdir'
                    else:
                        self.event = 'modify'
 
@@ -344,8 +351,15 @@ class sr_message():
                        self.event = 'link'
                        sa='L'
                    elif 'remove' in self.headers['fileOp']:
-                       self.event = 'delete'
-                       sa='R'
+                       if 'directory' in self.headers['fileOp']:
+                           self.event = 'rmdir'
+                           sa='r'
+                       else:
+                           self.event = 'delete'
+                           sa='R'
+                   elif 'directory' in self.headers['fileOp']:
+                       self.event = 'mkdir'
+                       sa='m'
                    elif 'rename' in self.headers['fileOp']:
                        self.headers['oldname'] = self.headers['fileOp']['rename']
                        self.event = 'modify'

--- a/sarra/sr_subscribe.py
+++ b/sarra/sr_subscribe.py
@@ -1322,6 +1322,10 @@ class sr_subscribe(sr_instances):
            if self.msg.isRetry: self.consumer.msg_worked()
            return True
 
+        if (self.msg.headers['sum'][0] in ['m', 'r']):
+           self.logger.info("skipping unimplemented mkdir and rmdir events")
+           return True
+
         #=================================
         # prepare download 
         # the post_base_dir should exists : it the starting point of the downloads

--- a/sarra/sr_util.py
+++ b/sarra/sr_util.py
@@ -414,6 +414,12 @@ class sr_transport():
         self.logger.debug("%s_transport download" % self.scheme)
 
         token       = msg.relpath.split('/')
+
+        if (self.scheme == 'sftp'):
+            baseurl_parsed = urllib.parse.urlparse( msg.baseurl )
+            if baseurl_parsed.path:
+                token = baseurl_parsed.path.split('/')[1:] + token
+
         cdir        = '/'.join(token[:-1])
         remote_file = token[-1]
         urlstr      = msg.baseurl + '/' + msg.relpath


### PR DESCRIPTION
these are fixes for v2 to:
* ignore unimplemented mkdir and rmdir events, rather than having failures and putting them on a retry list.
* understand sftp messages produced by v03.   There is a bug in v2 where all *relPaths* are absolute instead of relative, and there is no connection to the baseUrl.  this branch looks at sftp urls and grabs the path from the baseUrl to interpret it correctly.

The v2 dynamic flow tests are messed up.  I confirmed they were messed up before I changed anything.  they are still badly broken.  