### PR TITLE
fixing Issue #839 - fixing positional grouping in sr3

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1713,6 +1713,30 @@ One can turn off queue binding as follows::
 
 (False, or off will also work.)
 
+sundew_compat_regex_first_match_is_zero (default: off)
+------------------------------------------------------
+
+When numbering groups in match patterns, Sundew groups start from 0.
+Python regular expressions use the zeroth group to represent the entire string, and each match
+group starts from 1. It is considered less surprising to conform to Python conventions,
+but doing so unilaterally would break compatbility.  So here is a switch to use
+when bridging between Sundew, sarra v2 and sr3.  Eventually, this should always be off.
+Examples:
+
+* sundew_compat_regex_first_match_is_zero: True
+* input url:  https://hpfx.collab.science.gc.ca/20231127/WXO-DD/meteocode/que/cmml/TRANSMIT.FPCN71.11.27.1000Z.xml
+* accept pattern: .*/WXO-DD/meteocode/(atl|ont|pnr|pyr|que)/.*/TRANSMIT\.FP([A-Z][A-Z]).*([0-2][0-9][0-6][0-9]Z).*
+* directory setting: /tmp/meteocode/${2}/${0}/${1}
+* resulting directory:  /tmp/meteocode/1000Z/que/CN
+
+in contrast, to get the same result:
+
+* sundew_compat_regex_first_match_is_zero: False
+* directory setting: /tmp/meteocode/${3}/${1}/${2}
+* to get the same result.
+
+folks who research python re will normally produce the latter version first.
+
 
 timeCopy (default: on)
 ----------------------

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1683,6 +1683,31 @@ On peut désactiver la liaison de fil d’attente comme cela::
 
 (False, ou off marchera aussi.)
 
+sundew_compat_regex_first_match_is_zero (default: Faux)
+------------------------------------------------------
+
+
+Lors de la numérotation des groupes dans les modèles de correspondance, les groupes Sundew commencent à 0.
+Les expressions régulières Python utilisent le groupe zéro pour représenter la chaîne entière et chaque correspondance
+le groupe commence à 1. Il est considéré comme moins surprenant de se conformer aux conventions Python,
+mais le faire unilatéralement romprait la compatibilité. Voici donc un switch à utiliser
+lors du pontage entre Sundew, sarra v2 et sr3. Finalement, cela devrait toujours être désactivé.
+Exemples:
+
+* sundew_compat_regex_first_match_is_zero: True
+* url du message:  https://hpfx.collab.science.gc.ca/20231127/WXO-DD/meteocode/que/cmml/TRANSMIT.FPCN71.11.27.1000Z.xml
+* argument *accept*: .*/WXO-DD/meteocode/(atl|ont|pnr|pyr|que)/.*/TRANSMIT\.FP([A-Z][A-Z]).*([0-2][0-9][0-6][0-9]Z).*
+* *directory* corréspondant: /tmp/meteocode/${2}/${0}/${1}
+* répertoire évalué:  /tmp/meteocode/1000Z/que/CN
+
+Pour obtenir le même résultat lorsque le option est faux:
+
+* sundew_compat_regex_first_match_is_zero: False
+* *directory* corréspondant: /tmp/meteocode/${3}/${1}/${2}
+
+Le monde qui fouille sur les ressources sur les expressions régulière de python
+seront moins surpris par cette dernière convention.
+
 
 timeCopy (défaut: on)
 ---------------------

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -2250,8 +2250,8 @@ class Config:
 
             new_dir=''.join(fragment_list)
 
-            del message['_matches']
-            message['_deleteOnPost'] -= set(['_matches'])
+            #del message['_matches']
+            #message['_deleteOnPost'] -= set(['_matches'])
         return new_dir
 
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -977,7 +977,11 @@ class Flow:
                 oldname_matched = False
                 for mask in self.o.masks:
                     pattern, maskDir, maskFileOption, mask_regexp, accepting, mirror, strip, pstrip, flatten = mask
-                    if (pattern == '.*') or mask_regexp.match(urlToMatch):
+                    matches = mask_regexp.match(urlToMatch)
+                    if (pattern == '.*') or matches:
+                        if matches:
+                            m[ '_matches'] = matches
+                            m['_deleteOnPost'] |= set(['_matches'])
                         oldname_matched = accepting
                         break
 
@@ -1000,8 +1004,12 @@ class Flow:
             matched = False
             for mask in self.o.masks:
                 pattern, maskDir, maskFileOption, mask_regexp, accepting, mirror, strip, pstrip, flatten = mask
+                matches = mask_regexp.match(urlToMatch)
+                if (pattern == '.*') or matches:
+                    if matches:
+                        m[ '_matches'] = matches
+                        m['_deleteOnPost'] |= set(['_matches'])
 
-                if (pattern == '.*') or mask_regexp.match(urlToMatch):
                     matched = True
                     if not accepting:
                         if 'fileOp' in m and 'rename' in m['fileOp'] and oldname_matched:

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -278,7 +278,8 @@ class AMQP(Moth):
                         auto_delete=self.o['auto_delete'],
                         nowait=False,
                         arguments=args)
-                    logger.info( f"queue declared {self.o['queueName']} (as: {broker_str}), (messages waiting: {msg_count})" )
+                    if not passive:
+                        logger.info( f"queue declared {self.o['queueName']} (as: {broker_str}), (messages waiting: {msg_count})" )
 
                 if hasattr(self,'metrics'):
                    self.metrics['brokerQueuedMessageCount'] = msg_count

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -52,11 +52,32 @@ def test_variableExpansion():
      assert try_pattern(  options, message, "${PBD}/${%Y}/${SOURCE}/AIRNOW/CSV/BCMOE/${%H}/",  \
              options.post_baseDir + '/[0-9]{4}/'+ message['source'] +'/AIRNOW/CSV/BCMOE/[0-9]{2}/' )
 
+     options.sundew_compat_regex_first_match_is_zero = True
      options.post_baseDir = '/apps/sarra/public_data'
      input_path='sftp://sarra@server//var/opt/CampbellSci/LoggerNet/data/WQL/WQL_final_storage_1.dat'
-     message['_matches'] = re.match( r'.*.data.(.*)/.*', input_path )
+     accept_regex= r'.*.data.(.*)/.*'
+     logger.info( f"path matched: {input_path} against: {accept_regex}" )
+     message['_matches'] = re.match( accept_regex, input_path )
      assert( try_pattern( options, message, "${PBD}/${YYYYMMDD}/${SOURCE}/loggernet/${0}/", 
          "/apps/sarra/public_data/[0-9]{8}/WhereDataComesFrom/loggernet/WQL" ) )
+
+     logger.info( "Next is an error message generated because the fourth group does not exist. Expected result is that the ${4} is not replaced." )
+     options.sundew_compat_regex_first_match_is_zero = False
+     message['_matches'] = re.match( r'.*.data.(.*)/.*_([0-9])\.', input_path )
+     assert( try_pattern( options, message, "${PBD}/${YYYYMMDD}/${SOURCE}/loggernet/${1}${4}",
+         r"/apps/sarra/public_data/[0-9]{8}/WhereDataComesFrom/loggernet/WQL\$\{4\}" ) )
+
+     
+     options.sundew_compat_regex_first_match_is_zero = True
+     input_path= r'https://hpfx.collab.science.gc.ca/20231127/WXO-DD/meteocode/que/cmml/TRANSMIT.FPCN71.11.27.1000Z.xml'
+     accept_regex= r'.*/WXO-DD/meteocode/(atl|ont|pnr|pyr|que)/.*/TRANSMIT\.FP([A-Z][A-Z]).*([0-2][0-9][0-6][0-9]Z).*'
+     logger.info( f"path matched: {input_path} against: {accept_regex}" )
+     message['_matches'] = re.match( accept_regex, input_path )
+     print( f" matched: {message['_matches']} ")
+
+     assert( try_pattern( options, message, '/tmp/meteocode/${2}/${0}/${1}' , r'/tmp/meteocode/1000Z/que/CN' ))
+
+
 
      # to get stuff to print out, make it fail.
      #assert False 

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -77,6 +77,9 @@ def test_variableExpansion():
 
      assert( try_pattern( options, message, '/tmp/meteocode/${2}/${0}/${1}' , r'/tmp/meteocode/1000Z/que/CN' ))
 
+     options.sundew_compat_regex_first_match_is_zero = False
+     assert( try_pattern( options, message, '/tmp/meteocode/${3}/${1}/${2}' , r'/tmp/meteocode/1000Z/que/CN' ))
+
 
 
      # to get stuff to print out, make it fail.

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -48,10 +48,15 @@ def test_variableExpansion():
      assert try_pattern(  options, message, "${PBD}/${%Y%m%d}/${SOURCE}/AIRNOW/CSV/BCMOE/${%H}/",  \
              options.post_baseDir + '/[0-9]{8}/'+ message['source'] +'/AIRNOW/CSV/BCMOE/[0-9]{2}/' )
      assert try_pattern(  options, message, "/pub/DATASETS/NOAA/G02158/unmasked/${%Y}/${%m}_${%b}", \
-            "/pub/DATASETS/NOAA/G02158/unmasked/" + '/[0-9]{4}/[0-9]{2}_[A-Z]{1}[a-z]{2}' )
-     assert try_pattern(  options, message, "${PBD}/${%Y}/${SOURCE}/AIRNOW/CSV/BCMOE//",  \
-             options.post_baseDir + '/[0-9]{8}/'+ message['source'] +'/AIRNOW/CSV/BCMOE/[0-9]{2}/' )
+            "/pub/DATASETS/NOAA/G02158/unmasked" + '/[0-9]{4}/[0-9]{2}_[A-Z]{1}[a-z]{2}' )
+     assert try_pattern(  options, message, "${PBD}/${%Y}/${SOURCE}/AIRNOW/CSV/BCMOE/${%H}/",  \
+             options.post_baseDir + '/[0-9]{4}/'+ message['source'] +'/AIRNOW/CSV/BCMOE/[0-9]{2}/' )
 
+     options.post_baseDir = '/apps/sarra/public_data'
+     input_path='sftp://sarra@server//var/opt/CampbellSci/LoggerNet/data/WQL/WQL_final_storage_1.dat'
+     message['_matches'] = re.match( r'.*.data.(.*)/.*', input_path )
+     assert( try_pattern( options, message, "${PBD}/${YYYYMMDD}/${SOURCE}/loggernet/${0}/", 
+         "/apps/sarra/public_data/[0-9]{8}/WhereDataComesFrom/loggernet/WQL" ) )
 
      # to get stuff to print out, make it fail.
      #assert False 


### PR DESCRIPTION
This branch fixes an incompatibility with v2, where position parameter matching using regexes works.
 
* added some unit tests to config_test.py with single and multiple positional parameters.
* capture the match resturned by re.match when processing an accept line.  store it in a message field.
* add a loop to variableExpansion() to to substitutions using the matching field.
* implement a new setting: *self.sundew_compat_regex_first_match_is_zero*
  setting is needed, because the natural thing, is to have regexes work like python match & groups.
 
unrelated fix also in the same branch:
* stop printing queue declare if passive==True, as it's spamming the logs.
