### PR TITLE
fix #866

### DIFF
--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -77,7 +77,6 @@ class Poll(Flow):
         if not features['ftppoll']['present']:
             if hasattr( self.o, 'pollUrl' ) and ( self.o.pollUrl.startswith('ftp') ):
                 logger.critical( f"attempting to configure an FTP poll pollUrl={self.o.pollUrl}, but missing python modules: {' '.join(features['ftppoll']['modules_needed'])}" )
-                sys.exit(1)
 
     def do(self):
         """

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -44,7 +44,6 @@ def ProtocolPresent(p) -> bool:
     else:
         logger.critical( f"Protocol scheme {p} unsupported for communications with message brokers" )
 
-    sys.exit(1)
     return False
 
 


### PR DESCRIPTION
pretty obvious. UPDATE:   these sys.exit() calls were put in place because it was fairly hard to see what was going on in the error log when many of them flew by, and it seemed like a good idea at the time to exit when encountering a logger.critical message. but it turns out that in most cases, people would rather want *sr3 features* to complete, instead of stopping at the first problem encountered.
