### PR TITLE
turn off magic support if redhat library present.

### DIFF
--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -50,7 +50,6 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-
 features = { 
     'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 
             'lament' : 'cannot connect to rabbitmq brokers', 
@@ -115,4 +114,11 @@ for x in features:
        except:
            logger.debug( f"extra feature {x} needs missing module {y}. Disabled" ) 
            features[x]['present']=False
+
+
+if features['filetypes']['present']:
+    import magic
+    if not hasattr(magic,'from_file'):
+        features['filetypes']['present'] = False
+        logger.debug( f'redhat magic bindings not supported.')
 


### PR DESCRIPTION
I tried using the module supplied with redhat, and the API is completely different.  I think you need to load the database of magic file signatures, and when I looked in /etc/magic, it is empty, so must be loading from somewhere else. don't know where, don't know how to do the load if I did, don't know how to use it if I managed to get it initialized properly.  gave up.

This code just recognizes that the entry point were are expecting is missing, and disables the relevant feature.
