### PR TITLE
fix #872 crashing because o.identity is kind of a typo

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -419,7 +419,7 @@ class Message(dict):
                      msg['identity'] = fxainteg
                      return
                 logger.debug("xattr different method than on disk")
-                calc_method = o.identity
+                calc_method = o.identity_method
             else:
                 logger.debug("xattr sum too old")
                 calc_method = o.identity_method


### PR DESCRIPTION
why did this only happen on redhat 8 ... no clue... but it crashes watch entirely there...
