### PR TITLE
Issue860 3 fix sourceFromExchange

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1791,12 +1791,6 @@ class Config:
                 if (not hasattr(self,'broker') or not self.broker):
                     self.broker = self.post_broker
 
-
-        if self.sourceFromExchange and self.exchange:
-           self.source = self.get_source_from_exchange(self.exchange)
-           if not self.source and hasattr(self,'post_exchange'):
-               self.source = self.get_source_from_exchange(self.post_exchange)
-
         if not hasattr(self,'source') and hasattr(self, 'post_broker') and \
            hasattr(self.post_broker,'url') and self.post_broker.url.username:
            self.source = self.post_broker.url.username

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -790,21 +790,6 @@ class Flow:
 
         """
 
-        # resolve source.
-        if not 'source' in msg:
-            source=None
-            if self.o.sourceFromExchange:
-                if 'exchange' in msg:
-                    source = self.o.get_source_from_exchange( msg['exchange'] )
-                if not source and hasattr(self,'exchange'):
-                    source = self.o.get_source_from_exchange( self.o.exchange )
-            if not source and hasattr(self.o,'source'):
-                source = self.o.source
-
-            if source:
-                msg['source'] = source
-                msg['_deleteOnPost'] |= set(['source'])
-
         # relative path by default mirror
 
         relPath = '%s' % msg['relPath']

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -134,7 +134,10 @@ class AMQP(Moth):
             topic = raw_msg.delivery_info['routing_key'].replace(
                 '%23', '#').replace('%22', '*')
             msg['exchange'] = raw_msg.delivery_info['exchange']
-            if self.o['sourceFromExchange']:
+            source=None
+            if 'source' in self.o:
+                source = self.o['source']
+            elif self.o['sourceFromExchange']:
                 itisthere = re.match( "xs_([^_]+)_.*", msg['exchange'] )
                 if itisthere:
                     source = itisthere[1]
@@ -142,9 +145,6 @@ class AMQP(Moth):
                     itisthere = re.match( "xs_([^_]+)", msg['exchange'] )
                     if itisthere:
                         source = itisthere[1]
-            else:
-                if 'source' in self.o:
-                    source = self.o['source']
 
             if source:
                 msg['source'] = source

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1604,7 +1604,7 @@ class sr_GlobalState:
         if len(self.filtered_configurations) > 1 :
             if len(self.filtered_configurations) != self.options.dangerWillRobinson:
                 logging.error(
-                "specify --dangerWillRobinson=<number> of configs to cleanup  when cleaning more than one")
+                        f"specify --dangerWillRobinson=<number> of configs to cleanup (actual: {len(self.filtered_configurations)}, given: {self.options.dangerWillRobinson} ) when cleaning more than one")
                 return
 
         queues_to_delete = []
@@ -1854,8 +1854,9 @@ class sr_GlobalState:
 
         if len(self.filtered_configurations) > 1 :
             if len(self.filtered_configurations) != self.options.dangerWillRobinson:
-                logging.error(
-                    "specify --dangerWillRobinson=<n> of configs to remove when > 1 involved.")
+                logging.error( f"specify --dangerWillRobinson=<n> of configs to remove "
+                   f"when > 1 involved. (actual: {len(self.filtered_configurations)}, "
+                   f"given: {self.options.dangerWillRobinson}")
                 return
 
         for f in self.filtered_configurations:


### PR DESCRIPTION

close #860 

finally fixes sourceFromExchange properly.

It is tested using the no_mirror test in sr_insects.   

3 patches:
* unrelated: have sr3 say how many when --dangerWillRobinson is needed.
* correct implementation of sourceFromExchange in moth/amqp.py (modelled on how v2 does it.)
* remove unnecessary implementations of sourceFromExchange (from previous fix attempts.) in other modules.

Merge this before the PR in sr_insects:

( https://github.com/MetPX/sr_insects/pull/32 ) 

because that test has sourceFromExchange in it.
