### PR TITLE
Add plugins and examples for retrieving data from Copernicus

### DIFF
--- a/sarracenia/examples/poll/copernicus_odata.conf
+++ b/sarracenia/examples/poll/copernicus_odata.conf
@@ -1,0 +1,22 @@
+post_broker   amqp://COPERNICUS@localhost/
+post_exchange xs_COPERNICUS
+exchange      xs_COPERNICUS
+
+callback poll.odata
+
+post_baseUrl     https://zipper.dataspace.copernicus.eu/odata/v1/
+post_urlTemplate Products(--PRODUCT_ID--)/$value
+
+pollUrl https://catalogue.dataspace.copernicus.eu/odata/v1/Products?$filter=
+dataCollection SENTINEL-5P
+timeNowMinus 1d
+
+sleep 10m
+
+acceptUnmatched False
+accept .*L2__O3.*
+reject .*
+
+#logReject True
+#set poll.odata.logLevel debug
+

--- a/sarracenia/examples/subscribe/get_copernicus.conf
+++ b/sarracenia/examples/subscribe/get_copernicus.conf
@@ -1,0 +1,9 @@
+broker amqp://COPERNICUS@localhost/
+exchange xs_COPERNICUS
+
+callback accept.auth_copernicus
+
+directory /tmp/copernicus
+accept .*L2__O3.*
+reject .*
+

--- a/sarracenia/flowcb/accept/auth_copernicus.py
+++ b/sarracenia/flowcb/accept/auth_copernicus.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python3
+
+"""
+Plugin to download from the Copernicus Data Space Ecosystem
+============================================================
+
+This plugin enables authentication for URLs posted by the ``odata.py`` plugin, and other Copernicus data
+sources that use bearer tokens. It may also work with other OpenID Connect-based systems.
+
+For every message processed by this plugin, it will add a credential with a valid bearer token matching the message's
+baseUrl to Sarracenia's in-memory credential database.
+
+Register for an account here: https://documentation.dataspace.copernicus.eu/Registration.html
+
+This code is based on https://documentation.dataspace.copernicus.eu/APIs/Token.html#by-python-script.
+
+  
+Configurable Options:
+----------------------
+
+``openidConnectUrl``:
+^^^^^^^^^^^^^^^^^^^^
+
+    Default is ``https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/token``. If you
+    want to override it, you can specify the ``openidConnectUrl https://your-endpoint.example.com`` option.
+
+``clientId``:
+^^^^^^^^^^^^^
+
+    Passed to the API. Default is ``cdse-public``.
+
+``grantType``:
+^^^^^^^^^^^^^^
+
+    Passed to the API. Default is ``password``.
+
+How to set up your download config:
+------------------------------------
+ 
+    Add ``callback accept.auth_copernicus``, in your subscribe, sarra or other download config.  
+
+    Add ``https://username:password@identity.dataspace.copernicus.eu/`` to your ``credentials.conf`` file (or whatever
+    URL matches your ``openidConnectUrl``). Most usernames are email addresses - you will need to use ``%40`` instead
+    of the ``@`` symbol in the username.
+
+Change log:
+-----------
+
+    - 2023-12-27: first attempt at this plugin.
+"""
+
+import sarracenia
+import datetime
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+class Auth_copernicus(sarracenia.flowcb.FlowCB):
+    def __init__(self, options):
+        super().__init__(options, logger)
+        
+        # Allow setting a logLevel *only* for this plugin in the config file:
+        # set accept.auth_copernicus.logLevel debug
+        if hasattr(self.o, 'logLevel'):
+            logger.setLevel(self.o.logLevel.upper())
+
+        self.o.add_option('openidConnectUrl', kind='str', 
+            default_value='https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/token')
+        self.o.add_option('clientId', kind='str', default_value='cdse-public')
+        self.o.add_option('grantType', kind='str', default_value='password')
+
+        self._token = None
+        self._token_expires = None # format MM/DD/YYYY, e.g. 12/25/2023
+
+        # end __init__
+
+    def after_accept(self, worklist):
+        """ Doesn't actually do any downloading. Get/create a bearer token by logging in with the username and 
+            password from credentials.conf. Then adds the bearer token to Sarracenia's credentials DB for the 
+            message's baseUrl. This will allow the file to be downloaded from msg['baseUrl']+msg['relPath'] 
+            using the bearer token.
+        """
+        for msg in worklist.incoming:
+            token = self.get_token()
+            
+            # If the credential already exists and the bearer_token matches, don't need to do anything
+            ok, details = self.o.credentials.get(msg['baseUrl'])
+            token_already_in_creds = False
+            try: 
+                token_already_in_creds = (ok and details.bearer_token == token)
+                if token_already_in_creds:
+                    logger.debug(f"Token for {msg['baseUrl']} already in credentials database")
+            except:
+                token_already_in_creds = False
+
+            if not token_already_in_creds:
+                logger.info(f"Token for {msg['baseUrl']} not in credentials database. Adding it!")
+                # Add the new bearer token to the internal credentials db. If the credential is already in the db, it will
+                # be replaced which is desirable.
+                cred = sarracenia.credentials.Credential(urlstr=msg['baseUrl'])
+                cred.bearer_token = token
+                self.o.credentials.add(msg['baseUrl'], details=cred)
+
+    def get_token(self):
+        """ Returns a token, or None
+        """
+        if not self._token:
+            logger.debug("Requesting a token")
+
+            # Credentials - from Earthdata endpoint URL
+            ok, details = self.o.credentials.get(self.o.openidConnectUrl)
+            creds = details.url
+            username = creds.username
+            password = creds.password
+            if not ok or not username or not password:
+                # logger.debug(f"{ok}, {username}, {password}")
+                logger.error(f"credential lookup failed for {self.o.openidConnectUrl}. Check credentials.conf!")
+                return None
+
+            data = {
+                "client_id": self.o.clientId,
+                "username": username,
+                "password": password,
+                "grant_type": self.o.grantType,
+            }
+            try:
+                r = requests.post(self.o.openidConnectUrl, data=data)
+                r.raise_for_status()
+                j = r.json()
+                self._token = j["access_token"]
+                logger.info("Success! Access token created.")
+                logger.debug(j)
+            except Exception as e:
+                logger.error(f"Access token creation failed. Reponse from the server was: {r.json()}")
+                return None
+        
+        return self._token

--- a/sarracenia/flowcb/poll/odata.py
+++ b/sarracenia/flowcb/poll/odata.py
@@ -1,0 +1,277 @@
+#!/usr/bin/python3
+
+"""
+Plugin to poll an OData REST API
+=====================================================================================
+
+This plugin is for polling an OData REST API (https://www.odata.org/). It was written
+for, and only tested with Copernicus' OData Catalogue API: 
+https://dataspace.copernicus.eu/analyse/apis/catalogue-apis
+
+This code is based on https://dataspace.copernicus.eu/news/2023-9-28-accessing-sentinel-mission-data-new-copernicus-data-space-ecosystem-apis
+
+Filtering can be done using the default accept/reject options in Sarracenia.
+
+URLs posted by this plugin may need authentication (e.g. with a bearer token).
+
+  
+Configurable Options:
+----------------------
+
+``pollUrl`` (required):
+^^^^^^^^^^^^^^^^^^^^^^^^
+    
+    The ``pollUrl`` option should be set to the base URL for the API you want to query. For Copernicus, it is:
+    ``pollUrl https://catalogue.dataspace.copernicus.eu/odata/v1/Products?$filter=``
+
+``post_baseUrl`` (required):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    The ``post_baseUrl`` should be set to the base URL for the file download. For Copernicus, it is:
+    ``post_baseUrl https://zipper.dataspace.copernicus.eu/odata/v1/``
+
+``post_urlTemplate``:
+^^^^^^^^^^^^^^^^^^^^^^
+
+    The URL used to download the file (retrievePath) will be ``post_baseUrl`` + 
+    ``post_urlTemplate.replace("--PRODUCT_ID--", "$the_product_id_from_the_API")``.
+
+    For Copernicus, use ``post_urlTemplate Products(--PRODUCT_ID--)/$value``
+    
+``dataCollection``:
+^^^^^^^^^^^^^^^^^^^^
+
+    Which data collection you want to poll. 
+
+    For Copernicus, the available options at the time of writing are: ``SENTINEL-1``, ``SENTINEL-2``, ``SENTINEL-3``,
+    and ``SENTINEL-5P``.
+
+        https://documentation.dataspace.copernicus.eu/Data.html
+
+    You can define multiple ``dataCollections`` s in your config file.
+
+    The ``dataCollection`` option is added to the URL as ``Collection/Name eq 'YOUR_DATA_COLLECTION_HERE'``.
+
+    This is optional. If ``dataCollection`` is not used by the OData endpoint you are polling, leave it blank. 
+    ``queryString`` can be used to manually define the query.
+
+``timeNowMinus`` Time Range (required):
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Provides a time range to poll. The plugin will always use the current 
+    date/time as the "end time" and the "start time" is determined by the ``timeNowMinus`` duration option.
+
+    The default value is 1 hour.
+
+    This is a duration option. It will accept a floating point number, or a floating point number suffixed with
+    a unit. Examples:
+        - Bare number: ``timeNowMinus 3600`` --> 3600 seconds
+        - ``s`` Seconds: ``timeNowMinus 3600`` --> 3600 seconds
+        - ``m`` Minutes: ``timeNowMinus 120m`` --> 120 minutes
+        - ``h`` Hours: ``timeNowMinus 24h`` --> 24 hours
+        - ``d`` Days: ``timeNowMinus 5d`` --> 5 days
+        - ``w`` Weeks: ``timeNowMinus 1w`` --> 1 week
+
+    For example, if the poll is running at 2023-04-26 12:35:00Z and ``timeNowMinus`` is ``1d``, 
+    the time range to poll would be: ::
+
+        ContentDate/Start gt 2023-04-25T12:35:00.000Z and ContentDate/Start lt 2023-04-26T12:35:00.000Z
+
+``queryString``:
+^^^^^^^^^^^^^^^^^
+
+    You can use this list option to add anything to the URL. Multiple ``queryString`` s can be defined.
+
+    For example, the URL to be polled could be: 
+    ``.../odata/v1/Products?$filter=Collection/Name eq 'SENTINEL-1' and ContentDate/Start gt 2023-01-01T00:00:00.000Z and ContentDate/Start lt 2023-01-02T00:00:00.000Z``
+
+    If you set ``queryString and OData.CSC.Intersects(area=geography'SRID=4326;POLYGON((4.220581 50.958859,4.521264 50.953236,4.545977 50.906064,4.541858 50.802029,4.489685 50.763825,4.23843 50.767734,4.192435 50.806369,4.189689 50.907363,4.220581 50.958859))')``
+    the ``and OData.CSC....`` string will be appended to the URL to be polled.
+
+    When multiple ``queryStrings`` are set, they will all be appended to the URL.
+    
+
+*Potential Room For Improvement*: 
+----------------------------------
+
+    - Let ``timeNowMinus`` be disabled to build a query without a start and end time?
+    - Support checksums other than MD5
+
+How to set up your poll config:
+--------------------------------
+ 
+    Use ``callback poll.odata``, and read about the config options above.
+    
+    For examples, see https://github.com/MetPX/sarracenia/tree/main/sarracenia/examples/poll files named ``*odata*.conf``. 
+
+Change log:
+-----------
+
+    - 2023-12: first attempt
+"""
+
+import sarracenia
+import datetime
+import logging
+import requests
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Can use ContentLength, Checksum, ID is for Downloading, need to set name somehow. If online is not true log a warning?. S3Path would be interesting.l
+
+class Odata(sarracenia.flowcb.FlowCB):
+    def __init__(self, options):
+        super().__init__(options, logger)
+        
+        # Allow setting a logLevel *only* for this plugin in the config file:
+        # set poll.odata.logLevel debug
+        if hasattr(self.o, 'logLevel'):
+            logger.setLevel(self.o.logLevel.upper())
+
+        logger.debug("plugin: odata __init__")
+
+        self.o.add_option('dataCollection', kind='list', default_value=None)
+        self.o.add_option('timeNowMinus', kind='duration', default_value=3600.0) # 3600 sec = 1 hour
+        self.o.add_option('queryString',  kind='list', default_value=None)
+        self.o.add_option('post_urlTemplate', kind='str', default_value="--PRODUCT_ID--")
+        
+        # end __init__
+
+    def poll(self) -> list:
+        """Poll odata
+        polling doesn't require authentication, only downloading does
+        """
+        logger.debug("starting poll")
+
+        gathered_messages = []
+
+        ### SETUP 
+
+        # Figure out the date range
+        # Format: ContentDate/Start gt 2023-04-25T12:35:00.000Z and ContentDate/Start lt 2023-04-26T12:35:00.000Z
+        t_now = datetime.datetime.utcnow()
+        t_range_end = t_now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+        try:
+            n_seconds = float(self.o.timeNowMinus)
+        except:
+            logger.error("invalid timeNowMinus option")
+            n_seconds = 0
+
+        t_now_minus = t_now - datetime.timedelta(seconds=n_seconds)
+        t_range_start = t_now_minus.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        
+        time_range = f"ContentDate/Start gt {t_range_start} and ContentDate/Start lt {t_range_end}"
+        logger.debug(f"Time range: {time_range} (timeNowMinus={self.o.timeNowMinus})")
+
+        # Build the query
+        query = f"{time_range}"
+
+        # dataCollection can be empty, one thing or multiple things
+        if self.o.dataCollection:
+            if len(self.o.dataCollection) > 1:
+                query += ' and ('
+                for dc in self.o.dataCollection:
+                    query += f"Collection/Name eq '{dc}' or "
+                query = query[:-3] + ')' # remove the trailing or
+            else:
+                query += f" and Collection/Name eq '{self.o.dataCollection[0]}' "
+        
+        # add any query strings
+        if self.o.queryString:
+            for qs in self.o.queryString:
+                query += f" {qs}"
+        
+        logger.debug(f"Full Query: {query}")
+        
+        ### DO THE POLL
+        url = self.o.pollUrl + requests.utils.quote(query.strip())
+        while url:
+            logger.info(f"Polling URL: {url}")
+            try:
+                r = requests.get(url)
+                data = r.json()
+
+                # https://documentation.dataspace.copernicus.eu/APIs/ReleaseNotes.html#odata-catalog-api-updates
+                # Sometimes the response will have a value key with list of things
+                if 'value' in data:
+                    for val in data['value']:
+                        result = self.parse_json_to_msg(val)
+                        if result:
+                            gathered_messages.append(result)
+                # When there's only one result, the data will be directly in the json
+                elif 'Id' in data:
+                    result = self.parse_json_to_msg(data)
+                    if result:
+                        gathered_messages.append(result)
+                else:
+                    logger.warning(f"Found nothing in: {data}")
+
+                # the API only gives ~20 responses at a time. If there's more, there will be @odata.nextLink
+                if '@odata.nextLink' in data:
+                    url = data['@odata.nextLink']
+                else:
+                    url = None # stop the loop
+
+            except Exception as e:
+                logger.error(f"Error while polling URL: {url}")
+                logger.debug("Exception details:", exc_info=True)
+                url = None
+        
+        return gathered_messages
+
+    def parse_json_to_msg(self, jdata):
+        """ Build a Sarracenia message using the json data returned by the API and configured options in self.o.
+        """
+        msg = None
+
+        # {'@odata.mediaContentType': 'application/octet-stream', 
+        #  'Id': 'd86d00a2-58bc-4603-9e6a-28bc571d79a6', 
+        # 'Name': 'S1A_IW_GRDH_1SDV_20230425T123926_20230425T123951_048253_05CD62_EA4E_COG.SAFE', 
+        #  'ContentType': 'application/octet-stream', 
+        #  'ContentLength': 1229909379, 
+        #  'OriginDate': '2023-05-06T12:36:57.469Z', 
+        #  'PublicationDate': '2023-05-06T12:42:38.119Z', 
+        #  'ModificationDate': '2023-05-06T12:42:38.119Z', 
+        #  'Online': True, 
+        #  'EvictionDate': '', 
+        #  'S3Path': '/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2023/04/25/S1A_IW_GRDH_1SDV_20230425T123926_20230425T123951_048253_05CD62_EA4E_COG.SAFE', 
+        #  'Checksum': [{}], 
+        #  'ContentDate': {'Start': '2023-04-25T12:39:26.902Z', 'End': '2023-04-25T12:39:51.900Z'}, 
+        #  'Footprint': "geography'SRID=4326;POLYGON ((79.757111 29.038794, 82.362259 29.452579, 82.123009 30.965038, 79.47876 30.555256, 79.757111 29.038794))'", 
+        #  'GeoFootprint': {'type': 'Polygon', 'coordinates': [[[79.757111, 29.038794], [82.362259, 29.452579], [82.123009, 30.965038], [79.47876, 30.555256], [79.757111, 29.038794]]]}
+        # }
+
+        data_path = self.o.post_urlTemplate.replace('--PRODUCT_ID--', jdata['Id'])
+        msg = sarracenia.Message.fromFileInfo(data_path, self.o)
+
+        # Set optional fields in the message
+
+        # Give the file a nice name, if possible
+        if 'Name' in jdata and len(jdata['Name']) > 0:
+            msg['retrievePath'] = msg['relPath']
+            msg['relPath'] = jdata['Name']
+            logger.debug(f"baseUrl: {msg['baseUrl']}, relPath: {msg['relPath']}, retrievePath: {msg['retrievePath']}")
+        
+        if 'ContentLength' in jdata:
+            msg['size'] = jdata['ContentLength']
+
+        # TODO: support checksums other than MD5. Copernicus also provides BLAKE3, which sr3 doesn't support.
+        if 'Checksum' in jdata:
+            for c in jdata['Checksum']:
+                if 'Algorithm' in c and c['Algorithm'].upper() == "MD5":
+                    msg['identity'] = {'method':'md5', 'value':c['Value']}
+                    break
+            
+        if 'ContentType' in jdata:
+            msg['contentType'] = jdata['ContentType']
+
+        if 'ModificationDate' in jdata:
+            msg['mtime'] = jdata['ModificationDate'].replace('Z', '').replace(':', '').replace('-', '')
+
+        if 'GeoFootprint' in jdata:
+            msg['type'] = 'Feature'
+            msg['geometry'] = jdata['GeoFootprint']
+        
+        return msg

--- a/sarracenia/flowcb/poll/odata.py
+++ b/sarracenia/flowcb/poll/odata.py
@@ -226,23 +226,6 @@ class Odata(sarracenia.flowcb.FlowCB):
         """
         msg = None
 
-        # {'@odata.mediaContentType': 'application/octet-stream', 
-        #  'Id': 'd86d00a2-58bc-4603-9e6a-28bc571d79a6', 
-        # 'Name': 'S1A_IW_GRDH_1SDV_20230425T123926_20230425T123951_048253_05CD62_EA4E_COG.SAFE', 
-        #  'ContentType': 'application/octet-stream', 
-        #  'ContentLength': 1229909379, 
-        #  'OriginDate': '2023-05-06T12:36:57.469Z', 
-        #  'PublicationDate': '2023-05-06T12:42:38.119Z', 
-        #  'ModificationDate': '2023-05-06T12:42:38.119Z', 
-        #  'Online': True, 
-        #  'EvictionDate': '', 
-        #  'S3Path': '/eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2023/04/25/S1A_IW_GRDH_1SDV_20230425T123926_20230425T123951_048253_05CD62_EA4E_COG.SAFE', 
-        #  'Checksum': [{}], 
-        #  'ContentDate': {'Start': '2023-04-25T12:39:26.902Z', 'End': '2023-04-25T12:39:51.900Z'}, 
-        #  'Footprint': "geography'SRID=4326;POLYGON ((79.757111 29.038794, 82.362259 29.452579, 82.123009 30.965038, 79.47876 30.555256, 79.757111 29.038794))'", 
-        #  'GeoFootprint': {'type': 'Polygon', 'coordinates': [[[79.757111, 29.038794], [82.362259, 29.452579], [82.123009, 30.965038], [79.47876, 30.555256], [79.757111, 29.038794]]]}
-        # }
-
         data_path = self.o.post_urlTemplate.replace('--PRODUCT_ID--', jdata['Id'])
         msg = sarracenia.Message.fromFileInfo(data_path, self.o)
 


### PR DESCRIPTION
Adds a plugin that polls Copernicus' OData API. 

https://dataspace.copernicus.eu/news/2023-9-28-accessing-sentinel-mission-data-new-copernicus-data-space-ecosystem-apis

This replaces an old v2 plugin (not published on GitHub) that stopped working when this other API was shut down: https://scihub.copernicus.eu/

OData is not Copernicus-specific, it's a standard for building REST APIs: https://www.odata.org/. The poll plugin will hopefully work with other OData APIs, but I don't know of any others to test with.