### PR TITLE
reverting quoting in one place, to see if it helps

### DIFF
--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -161,8 +161,7 @@ class Https(Transfer):
             url = self.sendTo + '/' + msg['retrievePath']
         else:
             u = urllib.parse.urlparse( self.sendTo )
-            url = u.scheme + '://' + u.netloc + '/' + urllib.parse.quote(self.path + '/' +
-                                                              remote_file)
+            url = u.scheme + '://' + u.netloc + '/' + self.path + '/' + remote_file
 
         ok = self.__open__(url, remote_offset, length)
 
@@ -219,7 +218,7 @@ class Https(Transfer):
 
         self.entries = {}
 
-        url = self.sendTo + '/' + urllib.parse.quote(self.path)
+        url = self.sendTo + '/' + self.path
 
         ok = self.__open__(url)
 


### PR DESCRIPTION
close #884  ... 

Looking at why the quoting was added in the first place, not sure there was a good reason.  All the flow tests pass without it.  The description of the original change does not make sense either: It refers to utf8 support, but actual change is about url encoding... I'm not confident this @petersilva guy knew what he was on about in 2021.

Might be worth trying this branch out (issue882) if this solves the problem Also, I gave the branch the wrong name... 


