### PR TITLE
Branch396 v3 51 re-enabling partitioned transfers on an experimental basis.

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -459,7 +459,7 @@ transfer protocols, not HTTP ones at the moment.
 blocksize <size> default: 0 (auto)
 -----------------------------------
 
-NOTE: **NOT IMPLEMENTEDin sr3, expected to return in future version**
+NOTE: **EXPERIMENTAL** sr3, expected to return in future version**
 This **blocksize** option controls the partitioning strategy used to post files.
 The value should be one of::
 

--- a/docs/source/Reference/sr_post.7.rst
+++ b/docs/source/Reference/sr_post.7.rst
@@ -103,10 +103,18 @@ The headers are an array of name:value pairs::
           "blocks"        - if the file being advertised is partitioned, then:
           {
               "method"    : "inplace" | "partitioned" , - is the file already in parts?
-              "size"      : "9999", - size of the blocks.
-              "count"     : "9999", - number of blocks in the file.
-              "remainder" : "9999", - the size of the last block.
+              "size"      : "9999", - nominal number of bytes in each block.
               "number"    : "9999", - which block is this.
+              "manifest"   - metadata for each block in the file.
+              {
+                  0: {                 - size and checksum of each block in the file.
+                      "size": 9999,    - may not match blocksize (e.g. last block of file.)
+                      "identity": encoded checksum of block (same format as identity value)
+                  },
+                  .
+                  . 
+                  . 
+              }
           }
           "atime" : date string - last access time of a file (optional)
           "mtime" : date string - last modification time of a file (optional)

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -451,7 +451,7 @@ protocoles de transfert de fichiers, et non HTTP pour le moment.
 blocksize <size> défaut: 0 (auto)
 -----------------------------------
 
-REMARQUE: **NON IMPLEMENTÉ pour sr3, devrait revenir dans la version future**
+REMARQUE: **EXPERIMENTAL pour sr3, devrait revenir dans la version future**
 Cette option **blocksize** contrôle la stratégie de partitionnement utilisée pour publier des fichiers.
 La valeur doit être l’une des suivantes ::
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 Sphinx
 python-magic
+rangehttpserver
 paramiko
 nbsphinx
 jupyter

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -601,7 +601,8 @@ class Message(dict):
         elif hasattr(o, 'exchange'):
             msg['exchange'] = o.exchange
 
-        if hasattr(o, 'blocksize') and lstat and (lstat.st_size > o.blocksize) :
+        if hasattr(o, 'blocksize') and (os_stat.S_IFMT(lstat.st_mode) == os_stat.S_IFREG) and \
+           lstat and (lstat.st_size > o.blocksize):
            if o.blocksize > 1:
                msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blocksize, 'manifest': {}  }
 

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -432,7 +432,8 @@ class Message(dict):
         if calc_method == None:
             return
 
-        xattr.set('mtime', msg['mtime'])
+        if 'mtime' in msg:
+            xattr.set('mtime', msg['mtime'])
 
         logger.debug("mtime persisted, calc_method: {calc_method}")
 
@@ -457,7 +458,7 @@ class Message(dict):
                 fp = open(path, 'rb')
                 i = 0
 
-                logger.critical( f"offset: {offset}  size: {msg['size']} max: {offset+msg['size']} " )
+                #logger.info( f"offset: {offset}  size: {msg['size']} max: {offset+msg['size']} " )
                 if offset:
                     fp.seek( offset )
 
@@ -600,9 +601,9 @@ class Message(dict):
         elif hasattr(o, 'exchange'):
             msg['exchange'] = o.exchange
 
-        if hasattr(o, 'blocksize' ):
+        if hasattr(o, 'blocksize') and lstat and (lstat.st_size > o.blocksize) :
            if o.blocksize > 1:
-               msg['blocks'] = { 'method': 'inplace', 'size': o.blocksize, 'manifest': {}  }
+               msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blocksize, 'manifest': {}  }
 
         msg['local_offset'] = 0
         msg['_deleteOnPost'] = set(['exchange', 'local_offset', 'subtopic', '_format'])

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -404,7 +404,6 @@ class Message(dict):
            
            sets the message 'identity' field if appropriate.
         """
-        logger.critical( f"hello ")
         xattr = sarracenia.filemetadata.FileMetadata(path)
 
         if not 'blocks' in msg:
@@ -447,7 +446,7 @@ class Message(dict):
                 'method': 'arbitrary',
                 'value': o.identity_arbitrary_value
             }
-        else:
+        else: # a "normal" calculation method, liks sha512, or md5
             sumalgo = sarracenia.identity.Identity.factory(calc_method)
             sumalgo.set_path(path)
 
@@ -600,6 +599,10 @@ class Message(dict):
             msg['exchange'] = o.post_exchange
         elif hasattr(o, 'exchange'):
             msg['exchange'] = o.exchange
+
+        if hasattr(o, 'blocksize' ):
+           if o.blocksize > 1:
+               msg['blocks'] = { 'method': 'inplace', 'size': o.blocksize, 'manifest': {}  }
 
         msg['local_offset'] = 0
         msg['_deleteOnPost'] = set(['exchange', 'local_offset', 'subtopic', '_format'])

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -601,10 +601,10 @@ class Message(dict):
         elif hasattr(o, 'exchange'):
             msg['exchange'] = o.exchange
 
-        if hasattr(o, 'blocksize') and (os_stat.S_IFMT(lstat.st_mode) == os_stat.S_IFREG) and \
-           lstat and (lstat.st_size > o.blocksize):
-           if o.blocksize > 1:
-               msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blocksize, 'manifest': {}  }
+        if hasattr(o, 'blocksize') and (o.blocksize > 1) and lstat and \
+                (os_stat.S_IFMT(lstat.st_mode) == os_stat.S_IFREG) and \
+                (lstat.st_size > o.blocksize):
+           msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blocksize, 'manifest': {}  }
 
         msg['local_offset'] = 0
         msg['_deleteOnPost'] = set(['exchange', 'local_offset', 'subtopic', '_format'])

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -178,7 +178,7 @@ class Sarracenia:
         call. However the notification message returned will lack an identity checksum field.
         once you get the file, you can add the Identity field with:
     
-        m.__computeIdentity(path, o):
+        m.computeIdentity(path, o):
     
         In terms of consuming notification messages, the fields in the dictionary provide metadata
         for the announced resource. The anounced data could be embedded in the notification message itself,
@@ -390,7 +390,7 @@ class Message(dict):
         self['_deleteOnPost'] = set(['_format'])
 
 
-    def __computeIdentity(msg, path, o):
+    def computeIdentity(msg, path, o, offset=0):
         """
            check extended attributes for a cached identity sum calculation.
            if extended attributes are present, and 
@@ -453,7 +453,11 @@ class Message(dict):
 
                 fp = open(path, 'rb')
                 i = 0
-                while i < msg['size']:
+
+                if offset:
+                    fp.lseek( offset )
+
+                while i < offset+msg['size']:
                     buf = fp.read(o.bufsize)
                     if not buf: break
                     sumalgo.update(buf)
@@ -543,7 +547,7 @@ class Message(dict):
         m = sarracenia.Message.fromFileInfo(path, o, lstat)
         if lstat :
             if os_stat.S_ISREG(lstat.st_mode):
-                m.__computeIdentity(path, o)
+                m.computeIdentity(path, o)
                 if features['filetypes']['present']:
                     try:
                         t = magic.from_file(path,mime=True)

--- a/sarracenia/blockmanifest.py
+++ b/sarracenia/blockmanifest.py
@@ -44,7 +44,7 @@ class BlockManifest:
        TODO:
 
        * uses flufl.lock with feature guards.
-
+       * look at flowcb/block_reassembly.py
 
 
     """

--- a/sarracenia/blockmanifest.py
+++ b/sarracenia/blockmanifest.py
@@ -1,0 +1,110 @@
+
+
+import logging
+import json
+import flufl.lock
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class BlockManifest:
+
+    """
+
+      json i/o to a file, of a given dict, using locking to serialize updates.
+      
+      there might be an API to reconcile...
+         -- compare what is on disk to what is in memory.
+
+    """
+
+
+    def __init__(self,path):
+        """
+            lock the path, read the data, leave it ready to be re-written. 
+            still locked.
+        """
+
+        if '§block_' in path: # replace block suffix with manifest suffice if needbe.
+            pp=path.split('§')
+            self.path= '§'.join(pp[0:-2]) + '§block_manifest§'
+        else:
+            self.path=path + '§block_manifest§'
+
+        self.lock_file = self.path + '.flufl_lock'
+
+        logger.info( f"FIXME! locking with: {self.lock_file}" )
+        self.lock = flufl.lock.Lock(self.lock_file)
+
+        self.lock.lock()
+        logger.info( "FIXME! locked." )
+
+        self.x = None
+        self.new_x = None
+
+        if os.path.exists(self.path):
+            self.fd = open(self.path,"r+")
+            logger.info( f" self.fd: {self.fd} " )
+            s=self.fd.read()
+            logger.info( f" manifest content: {s} " )
+            self.x = json.loads(s)
+            logger.info( f" read self.x: {self.x} " )
+
+            for k in ['manifest', 'waiting' ]:
+                if k in self.x:
+                    m={}
+                    for db in self.x[k]: # when json'd for writing, numeric indices are stringified.
+                        m[db if type(db) is int else int(db)] = self.x[k][db]
+                    self.x[k] = m
+        else:
+            self.fd = open(self.path,"w+")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.persist()
+
+    def __del__(self):
+        self.persist()
+
+    def get(self):
+        """
+            return the value of the block manifest.
+        """
+        if self.new_x:
+            return self.new_x
+        elif self.x:
+            return self.x
+        return None
+
+
+    def set(self,bm):
+        """
+
+        """
+        self.new_x=bm.copy()
+        if "number" in self.new_x:
+            del self.new_x['number']
+
+    def persist(self):
+       """
+          write the new data, release the lock.
+       """
+       if not self.fd:
+           return
+
+       if self.new_x and (self.new_x != self.x):
+           logger.info( f"FIXME! overwriting" )
+           self.fd.seek(0)
+           self.fd.write(json.dumps(self.new_x,sort_keys=True,indent=4))
+           self.fd.truncate()
+       else:
+           logger.info( f"FIXME! closing unchanged" )
+
+       self.fd.close()
+       logger.info( f"FIXME! unlocking " )
+       self.lock.unlock()
+       self.fd=None
+

--- a/sarracenia/blockmanifest.py
+++ b/sarracenia/blockmanifest.py
@@ -1,4 +1,10 @@
 
+"""
+ DEPENDENCY:
+  should not be imported unless sarracenia.features['reassembly']['present'] is True
+  (indicating that flufl.lock is installed.)
+
+"""
 
 import logging
 import json

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -89,6 +89,7 @@ default_options = {
     'batch' : 100,
     'baseDir': None,
     'baseUrl_relPath': False,
+    'block_reassemble': True,
     'delete': False,
     'documentRoot': None,
     'download': False,
@@ -113,7 +114,6 @@ default_options = {
     'post_baseUrl': None,
     'post_format': 'v03',
     'realpathPost': False,
-    'reassemble': True,
     'recursive' : True,
     'report': False,
     'retryEmptyBeforeExit': False,
@@ -133,11 +133,11 @@ count_options = [
 
 
 # all the boolean settings.
-flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl_relPath', 'debug', \
+flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl_relPath', 'block_reassemble', 'debug', \
     'delete', 'discard', 'download', 'dry_run', 'durable', 'exchangeDeclare', 'exchangeSplit', 'logReject', 'realpathFilter', \
     'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logMetrics', 'logStdout', 'logReject', 'restore', \
     'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \
-    'permCopy', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', 'reassemble', \
+    'permCopy', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', \
     'reconnect', 'report', 'reset', 'retryEmptyBeforeExit', 'save', 'sundew_compat_regex_first_match_is_zero', \
     'sourceFromExchange', 'statehost', 'users', 'v2compatRenameDoublePost'
                 ]

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -113,6 +113,7 @@ default_options = {
     'post_baseUrl': None,
     'post_format': 'v03',
     'realpathPost': False,
+    'reassemble': True,
     'recursive' : True,
     'report': False,
     'retryEmptyBeforeExit': False,
@@ -136,8 +137,8 @@ flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl
     'delete', 'discard', 'download', 'dry_run', 'durable', 'exchangeDeclare', 'exchangeSplit', 'logReject', 'realpathFilter', \
     'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logMetrics', 'logStdout', 'logReject', 'restore', \
     'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \
-    'permCopy', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', 'reconnect', \
-    'report', 'reset', 'retryEmptyBeforeExit', 'save', 'sundew_compat_regex_first_match_is_zero', \
+    'permCopy', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', 'reassemble', \
+    'reconnect', 'report', 'reset', 'retryEmptyBeforeExit', 'save', 'sundew_compat_regex_first_match_is_zero', \
     'sourceFromExchange', 'statehost', 'users', 'v2compatRenameDoublePost'
                 ]
 

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -184,7 +184,6 @@ str_options = [
    accelerators and rate limiting are now built-in, no plugin required.
 """
 convert_to_v3 = {
-    'blocksize' : ['continue'],
     'cache_stat' : ['continue'],
     'cluster_aliases' : [ 'continue' ],
     'discard' : [ 'delete_destination', 'on' ], 

--- a/sarracenia/examples/block_reassembly.inc
+++ b/sarracenia/examples/block_reassembly.inc
@@ -1,0 +1,6 @@
+
+
+reject .*flufl_lock.*
+reject .*§block_manifest§.*
+
+callback_prepend block_reassembly

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -72,7 +72,7 @@ features = {
    'process' : { 'modules_needed': ['psutil'], 'present': False,
         'lament': 'cannot monitor running processes, sr3 CLI basically does not work.',
         'rejoice': 'can monitor, start, stop processes:  Sr3 CLI should basically work' },
-   'reassemble' :  { 'modules_needed': [ 'flufl.lock' ], 'Needed': True,
+   'reassembly' :  { 'modules_needed': [ 'flufl.lock' ], 'Needed': True,
         'lament' : 'need to lock block segmented files to put them back together',
         'rejoice' : 'can reassemble block segmented files transferred' },
    'redis' : { 'modules_needed': [ 'redis', 'redis_lock' ],

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -72,6 +72,9 @@ features = {
    'process' : { 'modules_needed': ['psutil'], 'present': False,
         'lament': 'cannot monitor running processes, sr3 CLI basically does not work.',
         'rejoice': 'can monitor, start, stop processes:  Sr3 CLI should basically work' },
+   'reassemble' :  { 'modules_needed': [ 'flufl.lock' ], 'Needed': True,
+        'lament' : 'need to lock block segmented files to put them back together',
+        'rejoice' : 'can reassemble block segmented files transferred' },
    'redis' : { 'modules_needed': [ 'redis', 'redis_lock' ],
         'lament': 'cannot use redis implementations of retry and nodupe',
         'rejoice': 'can use redis implementations of retry and nodupe'

--- a/sarracenia/filemetadata.py
+++ b/sarracenia/filemetadata.py
@@ -154,7 +154,12 @@ class FileMetadata:
             self.x['identity'] = self.x['integrity']
             del self.x['integrity']
 
-         
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.persist()
+
     def __del__(self):
         self.persist()
 
@@ -174,6 +179,16 @@ class FileMetadata:
            return the value of the named extended attribute.
         """
         if name in self.x.keys():
+            if name == 'blocks':
+                m={}
+                for k in ['manifest', 'wanted' ]:
+                    if k in self.x['blocks']:
+                        for db in self.x['blocks'][k]: # when json'd for writing, numeric indices are stringified.
+                            if type(db) is str:
+                                m[int(db)] = self.x['blocks'][k][db]
+                            else:
+                                m[db] = b[db]
+                        self.x['blocks'][k] = m
             return self.x[name]
         return None
 

--- a/sarracenia/filemetadata.py
+++ b/sarracenia/filemetadata.py
@@ -180,14 +180,11 @@ class FileMetadata:
         """
         if name in self.x.keys():
             if name == 'blocks':
-                m={}
-                for k in ['manifest', 'wanted' ]:
+                for k in ['manifest', 'waiting' ]:
+                    m={}
                     if k in self.x['blocks']:
                         for db in self.x['blocks'][k]: # when json'd for writing, numeric indices are stringified.
-                            if type(db) is str:
-                                m[int(db)] = self.x['blocks'][k][db]
-                            else:
-                                m[db] = b[db]
+                            m[db if type(db) is int else int(db)] = self.x['blocks'][k][db]
                         self.x['blocks'][k] = m
             return self.x[name]
         return None

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1764,9 +1764,11 @@ class Flow:
         if 'blocks' in msg: 
             logger.error( f" blocks active, manifest is: {msg['blocks']} " )
             if msg['blocks']['method'] in [ 'inplace' ]: # download only a specific block from a file, not the whole thing.
-                logger.info( f"splitting into individual block downloads" )
+                logger.info( f"splitting into individual block downloads blocks: {msg['blocks']}" )
+
                 blkno = msg['blocks']['number']
-                blksz_l = sarracenia.naturalSize(msg['blocks']['manifest'][blkno]['size']).split()
+                
+                blksz_l = sarracenia.naturalSize(msg['blocks']['size']).split()
                 blksz = blksz_l[0]+blksz_l[1][0].lower()
                 new_file += f"§block_{blkno:04d},{blksz}_§"
                 msg['new_file'] = new_file

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1762,12 +1762,9 @@ class Flow:
         new_inflight_path = None
 
         if 'blocks' in msg: 
-            logger.error( f" blocks active, manifest is: {msg['blocks']} " )
             if msg['blocks']['method'] in [ 'inplace' ]: # download only a specific block from a file, not the whole thing.
-                logger.info( f"splitting into individual block downloads blocks: {msg['blocks']}" )
-
+                logger.debug( f"splitting 1 file into {len(msg['blocks']['manifest'])} block messages." )
                 blkno = msg['blocks']['number']
-                
                 blksz_l = sarracenia.naturalSize(msg['blocks']['size']).split()
                 blksz = blksz_l[0]+blksz_l[1][0].lower()
                 new_file += f"§block_{blkno:04d},{blksz}_§"

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1223,6 +1223,10 @@ class Flow:
                             # cache good.
                             msg['local_identity'] = s
                             msg['_deleteOnPost'] |= set(['local_identity'])
+                            b = x.get('blocks')
+                            if b:
+                                msg['local_blocks'] = b
+                                msg['_deleteOnPost'] |= set(['local_blocks'])
                             return
             except:
                 pass
@@ -2389,24 +2393,28 @@ class Flow:
         """
            after a file has been written, restore permissions and ownership if necessary.
         """
-        #logger.debug("sr_transport set_local_file_attributes %s" % local_file)
+        logger.debug("%s" % local_file)
 
         # if the file is not partitioned, the the onfly_checksum is for the whole file.
         # cache it here, along with the mtime.
-        if (not 'blocks' in msg):
-            x = sarracenia.filemetadata.FileMetadata(local_file)
+        x = sarracenia.filemetadata.FileMetadata(local_file)
 
-            # FIXME ... what to do when checksums don't match?
-            if 'onfly_checksum' in msg: 
-                x.set( 'identity', msg['onfly_checksum'] )
-            elif 'identity' in msg:
-                x.set('identity', msg['identity'] )
+        logger.error("hoho!")
+        if 'blocks' in msg:
+            x.set('blocks', msg['blocks'] )
 
-            if self.o.timeCopy and 'mtime' in msg and msg['mtime']:
-                x.set('mtime', msg['mtime'])
-            else:
-                x.set('mtime', sarracenia.timeflt2str(os.path.getmtime(local_file)))
-            x.persist()
+        # FIXME ... what to do when checksums don't match?
+        if 'onfly_checksum' in msg: 
+            x.set( 'identity', msg['onfly_checksum'] )
+        elif 'identity' in msg:
+            x.set('identity', msg['identity'] )
+
+        if self.o.timeCopy and 'mtime' in msg and msg['mtime']:
+            x.set('mtime', msg['mtime'])
+        else:
+            x.set('mtime', sarracenia.timeflt2str(os.path.getmtime(local_file)))
+
+        x.persist()
 
         mode = 0
         if self.o.permCopy and 'mode' in msg:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2414,7 +2414,6 @@ class Flow:
         # cache it here, along with the mtime.
         x = sarracenia.filemetadata.FileMetadata(local_file)
 
-        logger.error("hoho!")
         if 'blocks' in msg:
             x.set('blocks', msg['blocks'] )
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1856,7 +1856,7 @@ class Flow:
 
             remote_offset = 0
             if ('blocks' in msg) and (msg['blocks']['method'] == 'inplace'):
-                remote_offset = msg['offset']
+                remote_offset = msg['blocks']['size']*msg['blocks']['number']
 
             if 'size' in msg:
                 block_length = msg['size']

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1224,17 +1224,8 @@ class Flow:
                             msg['local_identity'] = s
                             msg['_deleteOnPost'] |= set(['local_identity'])
                             b = x.get('blocks')
-                            if b:
-                                if 'manifest' in b:
-                                    m={}
-                                    for db in b['manifest']:
-                                        if type(db) is str:
-                                            m[int(db)] = b[db]
-                                        else:
-                                            m[db] = b[db]
-                                    b['manifest'] = m
-                                msg['local_blocks'] = b
-                                msg['_deleteOnPost'] |= set(['local_blocks'])
+                            msg['local_blocks'] = b
+                            msg['_deleteOnPost'] |= set(['local_blocks'])
                             return
             except:
                 pass
@@ -1775,8 +1766,9 @@ class Flow:
             if msg['blocks']['method'] in [ 'inplace' ]: # download only a specific block from a file, not the whole thing.
                 logger.info( f"splitting into individual block downloads" )
                 blkno = msg['blocks']['number']
-                blksz = sarracenia.naturalSize(msg['blocks']['manifest'][blkno]['size']).replace(' ','_')
-                new_file += f"§block_{blkno:04d}_{blksz}_§"
+                blksz_l = sarracenia.naturalSize(msg['blocks']['manifest'][blkno]['size']).split()
+                blksz = blksz_l[0]+blksz_l[1][0].lower()
+                new_file += f"§block_{blkno:04d},{blksz}_§"
                 msg['new_file'] = new_file
 
         if options.inflight == None:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -18,7 +18,7 @@ import urllib.parse
 import sarracenia
 
 import sarracenia.filemetadata
-import sarracenia.blockmanifest
+
 
 # for v2 subscriber routines...
 import json, os, sys, time
@@ -31,6 +31,9 @@ from mimetypes import guess_type
 # end v2 subscriber
 
 from sarracenia.featuredetection import features
+
+if features['reassembly']['present']:
+    import sarracenia.blockmanifest
 
 from sarracenia import nowflt
 
@@ -2412,7 +2415,7 @@ class Flow:
         # if the file is not partitioned, the the onfly_checksum is for the whole file.
         # cache it here, along with the mtime.
 
-        if 'blocks' in msg:
+        if ('blocks' in msg) and sarracenia.features['reassembly']['present']:
             with sarracenia.blockmanifest.BlockManifest(local_file) as y:
                 y.set( msg['blocks'] )
 

--- a/sarracenia/flowcb/block_reassembly.py
+++ b/sarracenia/flowcb/block_reassembly.py
@@ -67,6 +67,16 @@ class Block_reassembly(FlowCB):
        * if all blocks of the file have been delivered
           * then make the message reflect the whole file.
           
+    TODO:
+       - support more inflight options.
+       - if the manifest isn't present for the file on disk. create it.
+       - look at ../blockmanifest.
+       - think about file overwrite clashes...
+         - use a different name? 
+         - close, then re-open & re-write?
+       - recover from corrupted manifest by re-building.
+
+
     """
     def __init__(self, options) -> None:
 

--- a/sarracenia/flowcb/block_reassembly.py
+++ b/sarracenia/flowcb/block_reassembly.py
@@ -23,7 +23,6 @@ from sarracenia.featuredetection import features
 
 logger = logging.getLogger(__name__)
 
-
 class Block_reassembly(FlowCB):
     """
      if you see receive partitioned files (with §block_... _§ at the end of the file name)    

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -279,8 +279,9 @@ class File(FlowCB):
             msg['blocks']['manifest'][current_block] = { 'size':length, 'identity': msg['identity']['value'] }
 
         
-        with sarracenia.blockmanifest.BlockManifest( path ) as x:
-            x.set(msg['blocks'])
+        if not hasattr(self.o, 'block_manifest_delete') or not self.o.block_manifest_delete:
+            with sarracenia.blockmanifest.BlockManifest( path ) as x:
+                x.set(msg['blocks'])
 
         messages = []
         for current_block in blocks:

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -19,6 +19,7 @@ from random import choice
 
 import sarracenia
 from sarracenia import *
+import sarracenia.blockmanifest
 from sarracenia.featuredetection import features
 from sarracenia.flowcb import FlowCB
 import sarracenia.identity
@@ -278,9 +279,8 @@ class File(FlowCB):
             msg['blocks']['manifest'][current_block] = { 'size':length, 'identity': msg['identity']['value'] }
 
         
-        x = sarracenia.filemetadata.FileMetadata( path )
-        x.set('blocks', msg['blocks'])
-        x.persist()
+        with sarracenia.blockmanifest.BlockManifest( path ) as x:
+            x.set(msg['blocks'])
 
         messages = []
         for current_block in blocks:

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -19,8 +19,12 @@ from random import choice
 
 import sarracenia
 from sarracenia import *
-import sarracenia.blockmanifest
+
 from sarracenia.featuredetection import features
+
+if features['reassembly']['present']:
+    import sarracenia.blockmanifest
+
 from sarracenia.flowcb import FlowCB
 import sarracenia.identity
 
@@ -279,7 +283,8 @@ class File(FlowCB):
             msg['blocks']['manifest'][current_block] = { 'size':length, 'identity': msg['identity']['value'] }
 
         
-        if not hasattr(self.o, 'block_manifest_delete') or not self.o.block_manifest_delete:
+        if features['reassembly']['present'] and \
+           (not hasattr(self.o, 'block_manifest_delete') or not self.o.block_manifest_delete):
             with sarracenia.blockmanifest.BlockManifest( path ) as x:
                 x.set(msg['blocks'])
 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -264,6 +264,7 @@ class File(FlowCB):
         msg['blocks'] = {
             'method': 'inplace',
             'size': chunksize,
+            'number': -1,
             'manifest': {}
         }
         logger.debug( f" blocks:{blocks} " )

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -162,7 +162,7 @@ class File(FlowCB):
         return [msg]
 
     def post_file(self, path, lstat, key=None, value=None):
-        logger.debug("start  %s" % path)
+        #logger.debug("start  %s" % path)
 
         # check if it is a part file
         if path.endswith('.' + self.o.part_ext):
@@ -180,7 +180,7 @@ class File(FlowCB):
 
         # if we should send the file in parts
 
-        if blksz > 0 and blksz < fsiz:
+        if (blksz > 0 and blksz < fsiz) and os.path.isfile(path):
             return self.post_file_in_parts(path, lstat)
 
         msg = sarracenia.Message.fromFileData(path, self.o, lstat)
@@ -234,7 +234,7 @@ class File(FlowCB):
         return [msg]
 
     def post_file_in_parts(self, path, lstat):
-        #logger.debug("post_file_in_parts %s" % path )
+        #logger.info("start %s" % path )
 
         msg = sarracenia.Message.fromFileInfo(path, self.o, lstat)
 
@@ -250,7 +250,7 @@ class File(FlowCB):
         remainder = fsiz % chunksize
         if remainder > 0: block_count = block_count + 1
 
-        logger.debug( f" fiz:{fsiz}, chunksize:{chunksize}, block_count:{block_count}, remainder:{remainder}" )
+        #logger.debug( f" fiz:{fsiz}, chunksize:{chunksize}, block_count:{block_count}, remainder:{remainder}" )
 
         # loop on blocks
 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -164,15 +164,6 @@ class File(FlowCB):
     def post_file(self, path, lstat, key=None, value=None):
         #logger.debug("start  %s" % path)
 
-        # check if it is a part file
-        if path.endswith('.' + self.o.part_ext):
-            return self.post_file_part(path, lstat)
-
-        # This variable means that part_file_assemble plugin is loaded and will handle posting the original file (being assembled)
-
-        elif hasattr(self, 'suppress_posting_partial_assembled_file'):
-            return []
-
         # check the value of blocksize
 
         fsiz = lstat.st_size
@@ -303,34 +294,6 @@ class File(FlowCB):
             messages.append(copy.deepcopy(msg))
 
         return messages
-
-    def post_file_part(self, path, lstat):
-
-        msg = sarracenia.Message.fromFileInfo(path, self.o, lstat)
-
-        # verify suffix
-
-        ok, log_msg, suffix, partstr, sumstr = self.msg.verify_part_suffix(
-            path)
-
-        # something went wrong
-
-        if not ok:
-            logger.debug("file part extension but %s for file %s" %
-                         (log_msg, path))
-            return False
-
-        # check rename see if it has the right part suffix (if present)
-        if 'rename' in self.msg.headers and not suffix in self.msg.headers[
-                'rename']:
-            msg['rename'] += suffix
-
-        # complete  message
-
-        msg['parts'] = partstr
-        msg['identity'] = sumstr
-
-        return [msg]
 
     def post_link(self, path, key='link', value=None):
         #logger.debug("post_link %s" % path )

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -285,7 +285,10 @@ class File(FlowCB):
             msg.computeIdentity(path, self.o, offset=offset )
             msg['blocks']['manifest'][current_block] = { 'size':length, 'identity': msg['identity']['value'] }
 
-
+        
+        x = sarracenia.filemetadata.FileMetadata( path )
+        x.set('blocks', msg['blocks'])
+        x.persist()
 
         messages = []
         for current_block in blocks:
@@ -294,7 +297,7 @@ class File(FlowCB):
             msg['size'] = msg['blocks']['manifest'][current_block]['size']
             msg['identity']['value'] = msg['blocks']['manifest'][current_block]['identity']
 
-            logger.info( f" size: {msg['size']} blocks: {msg['blocks']}, offset: {offset} identity: {msg['identity']} " )
+            #logger.info( f" size: {msg['size']} blocks: {msg['blocks']}, offset: {offset} identity: {msg['identity']} " )
 
             messages.append(copy.deepcopy(msg))
 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -262,17 +262,15 @@ class File(FlowCB):
                         str(blocks))
 
         messages = []
-        logger.debug( "f blocks:{blocks} " )
-        for i in blocks:
+        logger.debug( f" blocks:{blocks} " )
+        for current_block in blocks:
 
             # compute block stuff
-
-            current_block = i
-
             offset = current_block * chunksize
             length = chunksize
 
             last = current_block == block_count - 1
+
             if last and remainder > 0:
                 length = remainder
 
@@ -288,7 +286,9 @@ class File(FlowCB):
                 'number': current_block
             }
 
-            msg.computeIdentity(path, self.o, offset=chunksize*block_count )
+            msg.computeIdentity(path, self.o, offset=offset )
+
+            logger.info( f" size: {msg['size']} blocks: {msg['blocks']}, offset: {offset} identity: {msg['identity']} " )
 
             messages.append(copy.deepcopy(msg))
 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -564,7 +564,13 @@ class File(FlowCB):
             try:
                 messages.extend(self.process_event(event, src, dst))
             except OSError as err:
-                logger.error("skipping event that could not be processed: ({}): {}".format(
+                """
+                  This message is reduced to debug priority because it often happens when files
+                  are too transitory (they disappear before we have a chance to post them)
+                  not sure if it should be an error message or not.
+                  
+                """
+                logger.debug("skipping event that could not be processed: ({}): {}".format(
                     event, err))
                 logger.debug("Exception details:", exc_info=True)
             self.left_events.pop(key)

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -261,8 +261,13 @@ class File(FlowCB):
             logger.info('Sending partitions in the following order: ' +
                         str(blocks))
 
-        messages = []
+        msg['blocks'] = {
+            'method': 'inplace',
+            'size': chunksize,
+            'manifest': {}
+        }
         logger.debug( f" blocks:{blocks} " )
+
         for current_block in blocks:
 
             # compute block stuff
@@ -277,16 +282,17 @@ class File(FlowCB):
             msg['size']=length
 
             # set partstr
-
-            msg['blocks'] = {
-                'method': 'inplace',
-                'size': chunksize,
-                'count': block_count,
-                'remainder': remainder,
-                'number': current_block
-            }
-
             msg.computeIdentity(path, self.o, offset=offset )
+            msg['blocks']['manifest'][current_block] = { 'size':length, 'identity': msg['identity']['value'] }
+
+
+
+        messages = []
+        for current_block in blocks:
+
+            msg['blocks']['number'] = current_block
+            msg['size'] = msg['blocks']['manifest'][current_block]['size']
+            msg['identity']['value'] = msg['blocks']['manifest'][current_block]['identity']
 
             logger.info( f" size: {msg['size']} blocks: {msg['blocks']}, offset: {offset} identity: {msg['identity']} " )
 

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -148,9 +148,7 @@ class Log(FlowCB):
             if lag > self.lagMax:
                 self.lagMax = lag
             if set(['after_accept']) & self.o.logEvents:
-
-                logger.info("accepted: (lag: %.2f ) %s " %
-                            (lag, self._messageAcceptStr(msg)))
+                logger.info( f"accepted: (lag: {lag:.2f} ) {self._messageStr(msg)}" )
 
     def after_post(self, worklist):
         if set(['after_post']) & self.o.logEvents:

--- a/sarracenia/flowcb/reassemble.py
+++ b/sarracenia/flowcb/reassemble.py
@@ -1,0 +1,221 @@
+"""
+ re-assemble files transferred as partitions.
+
+ author: Peter Silva
+"""
+
+import flufl.lock
+import humanfriendly
+import logging
+import os
+import re
+import stat
+import time
+
+from sarracenia import nowflt
+import sarracenia
+import sarracenia.filemetadata
+
+from sarracenia.flowcb import FlowCB
+
+from sarracenia.featuredetection import features
+
+features['reassemble'] = { 'modules_needed': [ 'flufl.lock' ], 'Needed': True,
+        'lament' : 'need to lock block segmented files to put them back together',
+        'rejoice' : 'can reassemble block segmented files transferred' }
+
+try:
+    import flufl.lock
+    features['reassemble']['present'] = True
+except:
+    features['reassemble']['present'] = False
+
+
+logger = logging.getLogger(__name__)
+
+
+class Reassemble(FlowCB):
+    """
+     if you see receive partitioned files (with §block_... _§ at the end of the file name)    
+     then turning on this callback will have them re-assembled.
+
+
+     usage:
+
+        callback_prepend reassemble
+
+        * whan a part is received but we are still waiting for more blocks, do the
+          block file message is put in the rejected worklist.
+        * only when all parts are received will a completed file be forwarded for
+          processing by subsequent plugins, and posting for future consumer.
+
+   limitations:
+
+      inflight None  -- required.. doesn't work with tmp files.
+
+
+    algorithm:
+       given the reassemble setting is on, and have received a block file,
+       then:
+
+       * partition file is whose name ends in §block_<blokno>,<blocksize>_§
+       * determing the inflight_file name for the entire file.
+       * lock the inflight_file.
+       * place the block in the working file.
+       * update the manifest of the inflight_file.
+       * delete the block file.
+       * if the file is not yet complete, remove the message from the posting queue.
+       * if all blocks of the file have been delivered
+          * then make the message reflect the whole file.
+          
+    """
+    def __init__(self, options) -> None:
+
+        super().__init__(options,logger)
+
+        #FIXME: missing metrics for now.
+        self.metric_scanned = 0
+        self.metric_hits = 0
+       
+    def after_work(self, worklist) -> None:
+
+        if self.o.inflight:
+            logger.error( f"partitioned file transfer only work with inflight None" )
+            return
+
+        new_ok=[]
+        for m in worklist.ok:
+
+            # this callback only operates on partition files.
+            if not ('blocks' in m and m['relPath'].endswith('_§') ):
+                continue
+
+            new_sz=0
+            for b in m['blocks']['manifest']:
+                new_sz+= m['blocks']['manifest'][b]['size']
+
+            rp=m['relPath']
+            blk_suffix=re.search( '§block_.*_§', rp ).group().split(',')
+            if not len(blk_suffix) >= 2:
+                logger.error( f"badly name block file, skipping {m['relPath']} " )
+                continue
+
+            # assert: have a properly named block file.
+            blkno=int(blk_suffix[0][7:])
+            blksz=humanfriendly.parse_size(blk_suffix[1],binary=True)
+
+            if blkno != m['blocks']['number']:
+                logger.warning(" mismatch {m['relPath']} name says {blkno} but message says {m['block']['number']}" )
+                blkno = m['blocks']['number']
+
+            #determine root file name.
+            part_file=m['new_dir'] + os.sep + m['new_file']
+            root_file=m['new_dir'] + os.sep + os.path.basename(rp[0:rp.find("§block_")])
+            lock_file=root_file + '.flufl_lock'
+                
+            # FIXME: need to lock the file.
+            flck = flufl.lock.Lock(lock_file)
+
+            flck.lock()
+
+            pf=open(part_file,'rb')
+
+            if os.path.exists(root_file):
+                rf=open(root_file,'r+b')
+            else:
+                rf=open(root_file,'w+b')
+
+            old_stat = os.stat(root_file)
+            logger.info( f" stat of {root_file} is: {old_stat}" )
+
+            with sarracenia.filemetadata.FileMetadata(root_file) as xrfa:
+                old_blocks = xrfa.get( 'blocks' )
+
+            # calculate old file size.
+            if old_blocks and 'manifest' in old_blocks:
+                old_sz=0
+                for b in old_blocks['manifest']:
+                    old_sz += old_blocks['manifest'][b]['size']
+
+                if old_sz != old_stat.st_size :
+                    logger.warning( f"manifest says file is {old_sz}, but file system says: {old_stat.st_size}" )
+            else:
+                old_sz = old_stat.st_size
+
+            # new file is shorter than before.
+            if new_sz < old_sz:  
+                logger.info( f"truncating to {new_sz}" )
+                rf.truncate(new_sz)
+
+            # update old_blocks to reflect receipt of this block.
+            if old_blocks and 'manifest' in old_blocks:
+                logger.info( f" old block manifest: {old_blocks['manifest']}" )
+                found=False
+                sz=0
+                # add
+                old_blocks['manifest'][blkno] = m['blocks']['manifest'][blkno] 
+            else:
+                old_blocks = { 'method': 'separate', 'size': m['blocks']['size'], 'number': blkno }
+                old_blocks['waiting'] = m['blocks']['manifest'].copy()
+                old_blocks['manifest'] = { blkno: m['blocks']['manifest'][blkno] }
+
+            # no longer waiting for the block which has been received.
+
+            if blkno in old_blocks['waiting']:
+                del old_blocks['waiting'][blkno]
+                logger.info( f"deleted block {blkno} from waiting: {old_blocks['waiting']} ") 
+
+            # calculate where to seek to...
+            offset=0
+            i=0
+            while i < blkno:
+                thisblk = m['blocks']['manifest'][i]['size']
+                offset += thisblk
+                i+=1
+            
+            logger.info( f" new block manifest: {m['blocks']['manifest']}" )
+            byteCount = m['blocks']['manifest'][blkno]['size']
+
+            logger.info( f" blocks: adding block {blkno} by seeking to: {offset} to write {byteCount} bytes in {root_file}" )
+            logger.info( f" still waiting for: {len(old_blocks['waiting'])} - {old_blocks['waiting']} " ) 
+
+            # FIXME: can seek ever fail? how do we check?
+            rf.seek(offset)     
+
+            # copy data from block partition file into final destination.
+            sz=self.o.bufsize if self.o.bufsize > byteCount else byteCount
+            bytesTransferred=0
+            while bytesTransferred < byteCount: 
+                b = pf.read(sz)
+                rf.write(b)
+                bytesTransferred += len(b)
+                bytesLeft = byteCount - bytesTransferred
+                sz=self.o.bufsize if self.o.bufsize > bytesLeft else bytesLeft
+
+            rf.close()
+            pf.close()
+            # assert: block data is now in main file, so delete block
+            #os.unlink(part_file)
+
+            with sarracenia.filemetadata.FileMetadata(root_file) as xrfab:
+                xrfab.set('mtime',m['mtime'])
+                xrfab.set('blocks',old_blocks)
+
+            if len( old_blocks['waiting'] ) > 0 :
+                # do not re-post the message if it's only part that has been received.
+                worklist.rejected.append(m)
+            else:
+                m['relPath'] = rp[0:rp.find("§block_")]
+                m['blocks']['method'] = 'inplace'
+                del m['blocks']['number']
+                m['size'] = new_sz
+                new_ok.append(m)
+
+            flck.unlock()
+
+        worklist.ok = new_ok
+
+    def on_housekeeping(self):
+        logger.info( f'files scanned {self.metric_scanned}, hits: {self.metric_hits} ')
+        self.metric_scanned = 0
+        self.metric_hits = 0

--- a/sarracenia/flowcb/reassemble.py
+++ b/sarracenia/flowcb/reassemble.py
@@ -4,6 +4,7 @@
  author: Peter Silva
 """
 
+import flufl.lock
 import humanfriendly
 import logging
 import os
@@ -18,17 +19,6 @@ import sarracenia.filemetadata
 from sarracenia.flowcb import FlowCB
 
 from sarracenia.featuredetection import features
-
-features['reassemble'] = { 'modules_needed': [ 'flufl.lock' ], 'Needed': True,
-        'lament' : 'need to lock block segmented files to put them back together',
-        'rejoice' : 'can reassemble block segmented files transferred' }
-
-try:
-    import flufl.lock
-    features['reassemble']['present'] = True
-except:
-    features['reassemble']['present'] = False
-
 
 logger = logging.getLogger(__name__)
 

--- a/sarracenia/flowcb/reassemble.py
+++ b/sarracenia/flowcb/reassemble.py
@@ -4,7 +4,6 @@
  author: Peter Silva
 """
 
-import flufl.lock
 import humanfriendly
 import logging
 import os

--- a/sarracenia/flowcb/reassemble.py
+++ b/sarracenia/flowcb/reassemble.py
@@ -110,6 +110,8 @@ class Reassemble(FlowCB):
 
             #determine root file name.
             part_file=m['new_dir'] + os.sep + m['new_file']
+
+            # FIXME: could add code here to deal with inflight != none make root_file the inflight file.
             root_file=m['new_dir'] + os.sep + os.path.basename(rp[0:rp.find("§block_")])
             lock_file=root_file + '.flufl_lock'
                 
@@ -206,6 +208,8 @@ class Reassemble(FlowCB):
                 # do not re-post the message if it's only part that has been received.
                 worklist.rejected.append(m)
             else:
+                # FIXME: for inflight.  now rename the file to the real name.
+
                 m['relPath'] = rp[0:rp.find("§block_")]
                 m['new_file'] = m['new_file'][0:m['new_file'].find("§block_")]
                 m['blocks']['method'] = 'inplace'

--- a/sarracenia/flowcb/reassemble.py
+++ b/sarracenia/flowcb/reassemble.py
@@ -208,6 +208,16 @@ class Reassemble(FlowCB):
 
             if len( old_blocks['waiting'] ) > 0 :
                 # do not re-post the message if it's only part that has been received.
+                """
+                206 Partial Content 
+                   The server is delivering only part of the resource (byte 
+                   serving) due to a range header sent by the client. The range
+                   header is used by HTTP clients to enable resuming of 
+                   interrupted downloads, or split a download into multiple 
+                   simultaneous streams.
+                   (from https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
+                """
+                m.setReport( 206, "file block subset received and reassembled ok. Not forwarding." )
                 worklist.rejected.append(m)
             else:
                 # FIXME: for inflight.  now rename the file to the real name.

--- a/sarracenia/flowcb/reassemble.py
+++ b/sarracenia/flowcb/reassemble.py
@@ -88,6 +88,7 @@ class Reassemble(FlowCB):
 
             # this callback only operates on partition files.
             if not ('blocks' in m and m['relPath'].endswith('_§') ):
+                new_ok.append(m)
                 continue
 
             new_sz=0
@@ -98,6 +99,7 @@ class Reassemble(FlowCB):
             blk_suffix=re.search( '§block_.*_§', rp ).group().split(',')
             if not len(blk_suffix) >= 2:
                 logger.error( f"badly name block file, skipping {m['relPath']} " )
+                new_ok.append(m)
                 continue
 
             # assert: have a properly named block file.

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -125,8 +125,17 @@ class Message:
             else:
                 m = 'p'
             p = h['blocks']
-            h['parts'] = '%s,%d,%d,%d,%d' % (m, p['size'], p['count'],
-                                             p['remainder'], p['number'])
+            if 'number' in p:
+                remainder = p['manifest'][p['number']]['size']
+                number = p['number']
+            else:
+                number=0
+                if 'manifest' in p:
+                    remainder = p['manifest'][len(p['manifest'])-1]['size']
+                else:       
+                    remainder = 0
+            h['parts'] = '%s,%d,%d,%d,%d' % (m, p['size'], len(p['manifest']),
+                                             remainder, number)
 
         h['topic'] = [ 'v02', 'post' ] + self.relpath.split('/')[0:-1]
 

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -115,16 +115,14 @@ class V02(PostFormat):
             if 'parts' in msg:
                 (style, chunksz, block_count, remainder,
                  current_block) = msg['parts'].split(',')
-                if style in ['i', 'p']:
-                    msg['blocks'] = {}
-                    msg['blocks']['method'] = {
-                        'i': 'inplace',
-                        'p': 'partitioned'
-                    }[style]
-                    msg['blocks']['size'] = int(chunksz)
-                    msg['blocks']['count'] = int(block_count)
-                    msg['blocks']['remainder'] = int(remainder)
-                    msg['blocks']['number'] = int(current_block)
+                if style in ['i', 'p']: # FIXME: v2 partitioning scheme kind of broken/dead code here.
+                    logger.error( "v2 partitioned transfers not supported in sr3: guaranteed corruption" )
+                    #msg['blocks'] = {}
+                    #msg['blocks']['method'] = { 'i': 'inplace', 'p': 'partitioned' }[style]
+                    #msg['blocks']['size'] = int(chunksz)
+                    #msg['blocks']['count'] = int(block_count)
+                    #msg['blocks']['remainder'] = int(remainder)
+                    #msg['blocks']['number'] = int(current_block)
                 else:
                     msg['size'] = int(chunksz)
                 del msg['parts']

--- a/sarracenia/postformat/v03.py
+++ b/sarracenia/postformat/v03.py
@@ -59,8 +59,7 @@ class V03(PostFormat):
               observed Sarracenia v2.20.08p1 and earlier have 'parts' header in v03 messages.
               bug, or implementation did not keep up. Applying Postel's Robustness principle: normalizing messages.
             """
-        if ('parts' in msg
-            ):  # bug in v2 code makes v03 messages with parts header.
+        if 'parts' in msg :  # bug in v2 code makes v03 messages with parts header.
             (m, s, c, r, n) = msg['parts'].split(',')
             if m == '1':
                 msg['size'] = int(s)
@@ -79,6 +78,18 @@ class V03(PostFormat):
         elif ('size' in msg):
             if (type(msg['size']) is str):
                 msg['size'] = int(msg['size'])
+
+        if 'blocks' in msg :
+            if 'manifest' in msg['blocks']:
+               bToDel=[]
+               new_manifest={}
+               for b in msg['blocks']['manifest']:  # when writing... json conversion numeric keys become strings...
+                   if type(b) is str:
+                      new_manifest[int(b)] = msg['blocks']['manifest'][b]
+                   else:
+                      new_manifest[b] = msg['blocks']['manifest'][b]
+
+               msg['blocks']['manifest'] = new_manifest
         return msg
 
     @staticmethod

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -297,7 +297,7 @@ class Transfer():
                         src,
                         local_file,
                         local_offset=0,
-                        length=0):
+                        length=0, exactLength=False):
         #logger.debug("sr_proto read_writelocal")
 
         # open
@@ -313,7 +313,7 @@ class Transfer():
         # 2022/12/02 - pas - need copies to always work...
         # in HPC mirroring case, a lot of short files, likely length is wrong in announcements.
         # grab the whole file unconditionally for now, detect error using mismatch.
-        rw_length = self.read_write(src, dst, 0)
+        rw_length = self.read_write(src, dst, length if exactLength else 0)
 
         # close
         self.local_write_close(dst)

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -114,7 +114,7 @@ class File(Transfer):
             local_file,
             remote_offset=0,
             local_offset=0,
-            length=0):
+            length=0, exactLength=False):
 
         remote_path = self.cwd + os.sep + remote_file
 
@@ -138,7 +138,7 @@ class File(Transfer):
 
         return rw_length
 
-    def getAccelerated(self, msg, remote_file, local_file, length=0):
+    def getAccelerated(self, msg, remote_file, local_file, length=0, remote_offset=0, exactLength=False):
 
         base_url = msg['baseUrl'].replace('file:', '')
         if base_url[-1] == '/':

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -266,7 +266,7 @@ class Ftp(Transfer):
             local_file,
             remote_offset=0,
             local_offset=0,
-            length=0):
+            length=0, exactLength=False):
         logger.debug("sr_ftp get %s %s %d" %
                      (remote_file, local_file, local_offset))
 
@@ -290,7 +290,7 @@ class Ftp(Transfer):
 
         return rw_length
 
-    def getAccelerated(self, msg, remote_file, local_file, length=0):
+    def getAccelerated(self, msg, remote_file, local_file, length=0, remote_offset=0, exactLength=False):
 
         base_url = msg['baseUrl']
         if base_url[-1] == '/':

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -180,15 +180,15 @@ class Https(Transfer):
         arg1 = arg1.replace(' ', '\\ ')
         arg2 = local_file
 
-        if exactLength:
-            range=f"--header=Range: bytes={remote_offset}-{length-1}"
-        else:
-            range=""
-
         cmd = self.o.accelWgetCommand.replace('%s', arg1)
 
         cmd = cmd.replace('%d', arg2).split()
-        cmd = [cmd[0]] + [range] + cmd[1:]
+
+        if exactLength:
+            cmd = [cmd[0]] + [ f"--header=Range: bytes={remote_offset}-{length-1}" ] + cmd[1:]
+        else:
+            cmd = [cmd[0]] + cmd[1:]
+
         logger.info("accel_wget: %s" % ' '.join(cmd))
         p = subprocess.Popen(cmd)
         p.wait()

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -162,7 +162,7 @@ class Https(Transfer):
         else:
             u = urllib.parse.urlparse( self.sendTo )
             url = u.scheme + '://' + u.netloc + '/' + urllib.parse.quote(self.path + '/' +
-                                                              remote_file)
+                                                              remote_file, safe='/+')
 
         ok = self.__open__(url, remote_offset, length)
 
@@ -226,7 +226,7 @@ class Https(Transfer):
 
         self.entries = {}
 
-        url = self.sendTo + '/' + urllib.parse.quote(self.path)
+        url = self.sendTo + '/' + urllib.parse.quote(self.path, safe='/+')
 
         ok = self.__open__(url)
 

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -161,7 +161,8 @@ class Https(Transfer):
             url = self.sendTo + '/' + msg['retrievePath']
         else:
             u = urllib.parse.urlparse( self.sendTo )
-            url = u.scheme + '://' + u.netloc + '/' + self.path + '/' + remote_file
+            url = u.scheme + '://' + u.netloc + '/' + urllib.parse.quote(self.path + '/' +
+                                                              remote_file)
 
         ok = self.__open__(url, remote_offset, length)
 
@@ -225,7 +226,7 @@ class Https(Transfer):
 
         self.entries = {}
 
-        url = self.sendTo + '/' + self.path
+        url = self.sendTo + '/' + urllib.parse.quote(self.path)
 
         ok = self.__open__(url)
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -333,10 +333,10 @@ class Sftp(Transfer):
             local_file,
             remote_offset=0,
             local_offset=0,
-            length=0):
+            length=0, exactLength=False):
         logger.debug(
-            "sr_sftp get %s %s %d %d %d" %
-            (remote_file, local_file, remote_offset, local_offset, length))
+            "sr_sftp get %s %s %d %d %d %s" %
+            (remote_file, local_file, remote_offset, local_offset, length, exactLength))
 
         alarm_set(2 * self.o.timeout)
         rfp = self.sftp.file(remote_file, 'rb', self.o.bufsize)
@@ -347,7 +347,7 @@ class Sftp(Transfer):
         # read from rfp and write to local_file
 
         rw_length = self.read_writelocal(remote_file, rfp, local_file,
-                                         local_offset, length)
+                                         local_offset, length, exactLength=False)
 
         
         # close

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -358,7 +358,7 @@ class Sftp(Transfer):
 
         return rw_length
 
-    def getAccelerated(self, msg, remote_file, local_file, length=0):
+    def getAccelerated(self, msg, remote_file, local_file, length=0, remote_offset=0, exactLength=False):
 
         base_url = msg['baseUrl'].replace('sftp://', '')
         if base_url[-1] == '/':

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ features = {
        'filetypes-redhat': [ "python-file-magic" ], 
        'ftppoll' : ['dateparser' ],
        'mqtt': [ 'paho.mqtt>=1.5.1' ],
+       'reassemble': [ 'flufl.lock' ],
        'vip': [ 'netifaces' ],
        'redis': [ 'redis' ]
     } 

--- a/tests/sarracenia/__init___test.py
+++ b/tests/sarracenia/__init___test.py
@@ -136,7 +136,7 @@ class Test_Message():
         msg['mtime'] = sarracenia.nowstr()
         msg['size'] = 0
         #msg['mtime'] = sarracenia.timeflt2str(sarracenia.timestr2flt(msg['mtime']) + 1000)
-        msg._Message__computeIdentity(path1, options)
+        msg.computeIdentity(path1, options)
         assert msg['identity']['method'] == options.identity_method
 
         # Set 2
@@ -148,7 +148,7 @@ class Test_Message():
         msg['mtime'] = sarracenia.nowstr()
         msg['size'] = 0
         mocker.patch('random.choice', return_value=None)
-        msg._Message__computeIdentity(path2, options)
+        msg.computeIdentity(path2, options)
         assert 'identity' not in msg
 
         # Set 3 - tests random, and algorithm == None
@@ -160,7 +160,7 @@ class Test_Message():
         msg['mtime'] = sarracenia.nowstr()
         msg['size'] = 0
         mocker.patch('random.choice', return_value=None)
-        msg._Message__computeIdentity(path3, options)
+        msg.computeIdentity(path3, options)
         assert 'identity' not in msg
 
         # Set 4 - abitrary method
@@ -172,21 +172,21 @@ class Test_Message():
         msg = sarracenia.Message()
         msg['mtime'] = sarracenia.nowstr()
         msg['size'] = 0
-        msg._Message__computeIdentity(path4, options)
+        msg.computeIdentity(path4, options)
         assert msg['identity']['value'] == 'identity_arbitrary_value'
 
         # Set 4a - random 
         options.identity = 'random'
         options.identity_method = 'random'
         del(msg['identity'])
-        msg._Message__computeIdentity(path4, options)
+        msg.computeIdentity(path4, options)
         assert msg['identity']['method'] == 'random'
 
         # Set 4b - 'cod,*' method
         options.identity = 'cod,testname'
         options.identity_method = 'cod,testname'
         del(msg['identity'])
-        msg._Message__computeIdentity(path4, options)
+        msg.computeIdentity(path4, options)
         assert msg['identity'] == 'cod,testname'
 
         try:
@@ -202,13 +202,13 @@ class Test_Message():
             msg = sarracenia.Message()
             msg['mtime'] = sarracenia.nowstr()
             msg['size'] = 0
-            msg._Message__computeIdentity(path5, options)
+            msg.computeIdentity(path5, options)
             assert msg['identity']['method'] == options.identity_method
             assert xattr.getxattr(path5, b'user.sr_mtime').decode('utf-8') == msg['mtime']
             # Set 5a - Cover cases where the identity on disk is different than what's configured
             options.identity = 'md5name'
             options.identity_method = 'md5name'
-            msg._Message__computeIdentity(path5, options)
+            msg.computeIdentity(path5, options)
             found_log_set5 = False
             for record in caplog.records:
                 if "xattr different method than on disk" in record.message:
@@ -225,7 +225,7 @@ class Test_Message():
             msg = sarracenia.Message()
             msg['mtime'] = msg_time
             msg['size'] = 0
-            msg._Message__computeIdentity(path6, options)
+            msg.computeIdentity(path6, options)
             assert msg['identity']['value'] == 'xattr_identity_value'
         except:
             pass

--- a/tests/sarracenia/__init___test.py
+++ b/tests/sarracenia/__init___test.py
@@ -127,7 +127,7 @@ def message():
 
 class Test_Message():
 
-    def test___computeIdentity(self, tmp_path, mocker, caplog):
+    def test_computeIdentity(self, tmp_path, mocker, caplog):
         # Set 1
         path1 = str(tmp_path) + os.sep + "file1.txt"
         open(path1, 'a').close()

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -8,8 +8,8 @@
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt update
-sudo apt upgrade
-sudo apt -y install python3-setuptools python3-magic
+sudo apt -y upgrade
+sudo apt -y install python3-setuptools python3-magic python-setuptools
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -32,7 +32,7 @@ done
 # in case it was installed as a dependency.
 sudo apt -y remove metpx-sr3
 
-pip3 install -e .
+pip3 install .
 
 # Setup basic configs
 mkdir -p ~/.config/sarra ~/.config/sr3


### PR DESCRIPTION
I did this work in the early fall and had to set it aside for a while, so it was lingering on a parallel branch for months, and thus gets stale/hard to maintain.  Would prefer to have the working parts in the mainline development, so I cherry picked the stuff is relevant, and now have something mergeable.

It passes all the normal flow tests.  I created a partitioned_flow tests in sr_insects, and that got merged (by mistake) a few months ago.  but this new test isn't completely passing yet.  here it is:

```
test 1 success: Log perms confirmed
                 | content of subdirs of /home/peter/sarra_devdocroot |
test 2 success: compare contents of downloaded_by_sub_amqp and downloaded_by_sub_cp are the same
test 3 success: compare contents of downloaded_by_sub_cp and downloaded_by_sub_rabbitmqtt are the same
test 4 success: compare contents of downloaded_by_sub_rabbitmqtt and downloaded_by_sub_u are the same
test 5 success: compare contents of downloaded_by_sub_u and posted_by_shim are the same
test 6 success: compare contents of downloaded_by_sub_amqp and linked_by_shim are the same
test 7 success: compare contents of posted_by_shim and sent_by_tsource2send are the same
test 8 FAILURE: compare contents of downloaded_by_sub_amqp and cfile differ
test 9 success: compare contents of cfile and cfr are the same
broker state:
 source tree: total:1418 files: 1111 directories:307 rejected:10
                 | dd.weather routing |
test 10 success: post	 (9305) t_dd1 should have the same number of items as t_dd2	 (9305)
test 11 success: sarra	 (18610) should receive the same number of items as both post	 (18610)
test 12 success: sarra	 (9305) should publish the same number of items as one post	 (9305)
test 13 success: sarra	 (9305) should winnow the same number of items as one post	 (9305)
test 14 FAILURE: subscribe	 (628) should rx the same number of items as in static tree	 (1408)
                 | watch      routing |
test 15 FAILURE: watch		 (938) should be the same as subscribe amqp_f30		  (628)
test 16 FAILURE: sender		 (629) should publish the same number of items as watch  (938)
test 17 FAILURE: rabbitmqtt		 (629) should download same number of items as watch  (938)
test 18 success: subscribe u_sftp_f60 (629) should download same number of items as sender (629)
test 19 success: subscribe cp_f61	 (629) should download same number of items as sender (629)
                 | poll       routing |
test 20 FAILURE: poll sftp_f62	 (589) should publish same number of items of sender sent	 (629)
test 21 success: poll sftp_f63	 (589) should see the same number of items as poll sftp_f62 posted	 (629)
test 22 success: subscribe q_f71	 (589) should download same number of items as poll test1_f62 (589)
                 | flow_post  routing |
test 23 FAILURE: post test2_f61	 (320) should have the same number of files of sender 	 (629)
test 24 success: subscribe ftp_f70	 (320) should have the same number of items as post test2_f61 (320)
test 25 success: post test2_f61	 (320) should post about the same number of files as shim_f63	 (320)
test 26 success: post test2_f61	 (320) should post about the same number of links as shim_f63	 (320)
test 27 FAILURE: static tree	 (307) directories should be posted twice: for 1st copy and linked_dir by shim_f63	 (450)
                 | py infos   routing |
test 28 success: 0 messages received that we don't know what happened.
                 | C          routing |
test 29 success: cpost both pelles should post the same number of messages (1420) (1420)
test 30 success: cdnld_f21 subscribe downloaded (1111) the same number of files that was published by both van_14 and van_15 (1111)
test 31 success: veille_f34 should post as many files (1111) as subscribe cdnld_f21 downloaded (1111)
test 32 success: veille_f34 should post as many files (1111) as subscribe cfile_f44 downloaded (1111)
Overall partitioned_flow 24 of 32 passed (sample size: 1418) !
```

it posts files partitioned with a 200 byte block size (so message is produced for every 200 bytes of each file) then each block is separately downloaded via http.  that part seems to work.  instead of 1111 messages, there are 9305 messages to make a tree.
They get downloaded, and the contents seems ok ish... but not perfect.  Still working on it.

The documentation labels it "EXPERIMENTAL"  (where it used to be marked non-existent.  So this is a place holder to capture progress made.  and then permit more progress in the future.

