### PR TITLE
Close gzip target file before renaming it (to ensure it's flushed)

### DIFF
--- a/sarracenia/flowcb/rxqueue_gzip.py
+++ b/sarracenia/flowcb/rxqueue_gzip.py
@@ -37,7 +37,9 @@ class RxQueue_gzip(FlowCB):
             tname = f'{gzname}.tmp'
             if os.path.exists(fname):
                 # Only try this if the uncompressed file actually exists
-                gzip.open(tname, 'wb').write(open(fname,'rb').read())
+                gzf = gzip.open(tname, 'wb')
+                gzf.write(open(fname,'rb').read())
+                gzf.close()
                 os.rename(tname, gzname)
                 os.unlink(fname)
                 self.rxq.put( gzname )


### PR DESCRIPTION
After years of chasing this, I found that my previous plugin was causing subtle bugs.

The existing code would let the python garbage collection destroy (and thus flush/close) the gzip file.  This would happen *after* the file was renamed, sometimes many seconds after it was renamed.  This created a race condition in any application that was trying to access these files.

By explicitly closing the file, it causes the contents to be flushed BEFORE the rename.  Closing the race condition window.