### PR TITLE
Issue884  second fix for #884, this time with safe=

### DIFF
--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -161,7 +161,8 @@ class Https(Transfer):
             url = self.sendTo + '/' + msg['retrievePath']
         else:
             u = urllib.parse.urlparse( self.sendTo )
-            url = u.scheme + '://' + u.netloc + '/' + self.path + '/' + remote_file
+            url = u.scheme + '://' + u.netloc + '/' + urllib.parse.quote(self.path + '/' +
+                                                              remote_file)
 
         ok = self.__open__(url, remote_offset, length)
 
@@ -218,7 +219,7 @@ class Https(Transfer):
 
         self.entries = {}
 
-        url = self.sendTo + '/' + self.path
+        url = self.sendTo + '/' + urllib.parse.quote(self.path)
 
         ok = self.__open__(url)
 

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -162,7 +162,7 @@ class Https(Transfer):
         else:
             u = urllib.parse.urlparse( self.sendTo )
             url = u.scheme + '://' + u.netloc + '/' + urllib.parse.quote(self.path + '/' +
-                                                              remote_file)
+                                                              remote_file, safe='/+')
 
         ok = self.__open__(url, remote_offset, length)
 
@@ -219,7 +219,7 @@ class Https(Transfer):
 
         self.entries = {}
 
-        url = self.sendTo + '/' + urllib.parse.quote(self.path)
+        url = self.sendTo + '/' + urllib.parse.quote(self.path, safe='/+')
 
         ok = self.__open__(url)
 


### PR DESCRIPTION
closes #884 

different method from #885, this time, just adding '+' to the list of *safe* characters not to encode.
 