### PR TITLE
removing xattr as hard dependency (already registered as a feature)

### DIFF
--- a/docs/source/Tutorials/Install.rst
+++ b/docs/source/Tutorials/Install.rst
@@ -89,6 +89,7 @@ On Ubuntu 22.04 and derivatives::
   sudo apt update
   sudo apt install metpx-sr3  # main python package.
   sudo apt install python3-magic # optional support putting file type content-type message headers.
+  sudo apt install python3-xattr # optional support putting checksums in extended attributes (on linux)
   sudo apt install metpx-sr3c # optional C client.
   sudo apt install python3-paramiko  # support SFTP (polls and transfers.)
   sudo apt install python3-amqp  # optionally support rabbitmq brokers
@@ -101,6 +102,12 @@ Currently, only the debian packages include man pages. The guides are only
 available in the source repository. For earlier ubuntu versions, install 
 via pip is required because of missing dependencies in the python environment 
 shipped with earlier operating systems.
+
+.. note::
+   if handling data from sources that use the *arbitrary* checksum algorithm for duplicate suppression
+   they define a token that cannot be derived from the content.  The ECCC DMS application is one that 
+   does that. To correctly forward such messages, the python3-xattr library is very helpful.
+
 
 One can create a bulletin ingest configuration::
 
@@ -174,11 +181,12 @@ For example, on fedora 28 mandatories::
   $ sudo dnf install python3-psutil
   $ sudo dnf install python3-watchdog
   $ sudo dnf install python3-paramiko  
+  $ sudo dnf install python3-xattr  
 
 Optional ones::
 
   $ sudo dnf install python3-amqp      # optionally support rabbitmq brokers
-  $ sudo dnf install python3-magic      # optionally support content-type header in messages.
+  $ sudo dnf install python3-file-magic      # optionally support content-type header in messages.
   $ sudo dnf install python3-netifaces # optionally support vip directive for HA.
   $ sudo dnf install python3-paho-mqtt # optionally support mqtt brokers
 

--- a/docs/source/fr/Tutoriel/Installer.rst
+++ b/docs/source/fr/Tutoriel/Installer.rst
@@ -90,6 +90,7 @@ Sur Ubuntu 22.04 et dérivés du même::
   sudo apt install python3-amqp  # support optionnel pour les courtiers AMWP (rabbitmq)
   sudo apt install python3-paramiko  # support optionnel pour SFTP/SSH 
   sudo apt install python3-magic  # support optionnel pour les entêtes "content-type" dans les messages
+  sudo apt install python3-xattr  # support optionnel pour stocker les checksum des fichiers dans les attributs étendus.
   sudo apt install python3-paho-mqtt  # support optionnel pour les courtiers MQTT 
   sudo apt install python3-netifaces # support optionnel pour les vip (haut-disponibilité)
   sudo apt install python3-dateparser python3-pytz # support optionnel pour les sondages ftp. 
@@ -99,6 +100,12 @@ Actuellement, seuls les paquets Debian incluent des pages de manuel. Les guides 
 disponible dans le référentiel de source. Pour les versions antérieures d’Ubuntu, installez
 via pip est requis en raison de dépendances manquantes dans l’environnement python
 livré avec des systèmes d’exploitation antérieurs.
+
+.. note::
+
+   pour bien juger si in fichier est un duplicat, dans le cas d'un application ou le checksum ne peut 
+   être dérivé du contenu (méthode: *abritrary* ( arbitraire ) ) le module python3-xattr est nécessaire.
+   Un example d'un source affecté sera les données DMS.
 
 Si une option n’est pas installée, mais est nécessaire pour une configuration donnée, alors sr3 le
 détectera et se plaindra, et il faut installer le support manquant::
@@ -166,7 +173,8 @@ Facultatifs::
 
   $ sudo dnf install python3-paramiko  # support pour SFTP/SSH
   $ sudo dnf install python3-amqp   # support pour les messages AMQP (couriers rabbitmq)
-  $ sudo dnf install python3-magic   # support optionnel pour le champs ¨content-type¨  
+  $ sudo dnf install python3-file-magic   # support optionnel pour le champs ¨content-type¨  
+  $ sudo dnf install python3-xattr   # support optionnel stocké certains métadonnées dans les attributs étendus.
   $ sudo dnf install python3-netifaces # support optionnel pour l´optio vip
   $ sudo dnf install python3-paho-mqtt # support optionnel pour les courtiers MQTT 
 

--- a/metpx-sr3.spec
+++ b/metpx-sr3.spec
@@ -14,7 +14,7 @@ BuildRequires:  python3-devel
 BuildRequires: systemd-rpm-macros
 
 
-Requires: python3-appdirs, python3-humanfriendly, python3-humanize, python3-jsonpickle, python3-paramiko, python3-psutil, python3-xattr
+Requires: python3-appdirs, python3-humanfriendly, python3-humanize, python3-jsonpickle, python3-paramiko, python3-psutil
 
 %global _description %{expand:
 MetPX-sr3 (Sarracenia v3) is a data duplication or distribution pump that leverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 dependencies =[
         "appdirs", "humanfriendly", "humanize", "jsonpickle", "paramiko",
         "psutil >= 5.3.0", "watchdog",
-        'xattr ; sys_platform != "win32"', 
 ]
 
 # NOTE:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ features = {
        'ftppoll' : ['dateparser' ],
        'mqtt': [ 'paho.mqtt>=1.5.1' ],
        'vip': [ 'netifaces' ],
-       'redis': [ 'redis' ]
+       'redis': [ 'redis' ],
     } 
 
 
@@ -106,7 +106,6 @@ setup(
     install_requires=[
         "appdirs", "humanfriendly", "humanize", "jsonpickle", "psutil>=5.3.0", 
         "paramiko", "watchdog",
-        'xattr ; sys_platform!="win32"', 
     ],
     # when building on HPC redhat, python OS packages don't exist. 
     # remove the last three lines of install_requires above, aka: 


### PR DESCRIPTION
sr3 features...
 
python3-xattr is sometimes not a hard dependency (because of different implementations on different linux distributions, as well as non-portability to windows.)

when installing v3.00.51rc6~ubuntu20.04.1 the analyst got:

```

Traceback (most recent call last):
  File "/usr/bin/sr3", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3254, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3237, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3266, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'xattr' distribution was not found and is required by metpx-sr3

```

so I just removed it entirely from setup.py
