### PR TITLE
Add AM AHL headers and put bulletin contents in message

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1133,7 +1133,7 @@ class Flow:
         if msg['content']['encoding'] == 'base64':
             data = b64decode(msg['content']['value'])
         else:
-            data = msg['content']['value'].encode('utf-8')
+            data = msg['content']['value'].encode(msg['content']['encoding'])
 
         if self.o.identity_method.startswith('cod,'):
             algo_method = self.o.identity_method[4:]

--- a/sarracenia/flowcb/amserver.py
+++ b/sarracenia/flowcb/amserver.py
@@ -60,7 +60,10 @@ class Amserver(FlowCB):
         self.limit = 32678
         self.patternAM = '80sII4siIII20s'
         self.sizeAM = struct.calcsize(self.patternAM)
+
         self.o.add_option('AllowIPs', 'list', [])
+        self.o.add_option('MissingAMHeaders', 'str', 'CN00 CWAO')
+
         self.host = self.url.netloc.split(':')[0]
         self.port = int(self.url.netloc.split(':')[1])
         self.minnum = 00000
@@ -267,7 +270,10 @@ class Amserver(FlowCB):
                 logger.debug(f"Bulletin contents: {bulletin}")
 
                 parse = self.header.split(b'\0',1)
+                
+                # We only want the first two letters of the bulletin.
                 bulletinHeader = parse[0].decode('iso-8859-1').replace(' ', '_')
+                firstchars = bulletinHeader[0:2]
 
                 # Insert AHL headers in bulletin contents
                 try:
@@ -285,13 +291,13 @@ class Amserver(FlowCB):
                     ##                                   Station
                     ##                                       Random Integer
 
-                    missing_ahl = b'CN00 CWAO'
+                    missing_ahl = self.o.MissingAMHeaders
 
 
                     filename = bulletinHeader + '__' +  f"{randint(self.minnum, self.maxnum)}".zfill(len(str(self.maxnum)))
                     filepath = self.o.directory + os.sep + filename
 
-                    if bulletinHeader in [ "CA", "RA", "MA" ]:
+                    if firstchars in [ "CA", "RA", "MA" ]:
 
                         logger.debug("Adding missing headers in file contents")
 

--- a/sarracenia/flowcb/amserver.py
+++ b/sarracenia/flowcb/amserver.py
@@ -321,7 +321,7 @@ class Amserver(FlowCB):
 
                         logger.debug("Adding missing headers in file contents")
 
-                        lines[0] += missing_ahl
+                        lines[0] += missing_ahl.encode('iso-8859-1')
                         
                         # Reconstruct the bulletin
                         new_bulletin = b''
@@ -340,19 +340,19 @@ class Amserver(FlowCB):
                     msg = sarracenia.Message.fromFileInfo(filepath, self.o)
 
                     # Store the bulletin contents inside of the message.
-                    # Contents can be binary or ASCII text
                     if not binary:
                         
+                        # Data can't be binary. Post method fails with binary data, with JSON parser.
                         decoded_bulletin = bulletin.decode('iso-8859-1')
 
                         msg['content'] = {
-                        "encoding":"utf-8", 
+                        "encoding":"iso-8859-1", 
                         "value":decoded_bulletin 
                         }
 
                     else:
 
-                        decoded_bulletin = b64encode(bulletin).decode('iso-8859-1')
+                        decoded_bulletin = b64encode(bulletin).decode('ascii')
 
                         msg['content'] = {
                         "encoding":"base64", 
@@ -370,7 +370,7 @@ class Amserver(FlowCB):
                     # There is always a default value given
                     ident = sarracenia.identity.Identity.factory(method=self.o.identity_method)
                     ident.set_path("") # the argument isn't used
-                    ident.update(decoded_bulletin)
+                    ident.update(bulletin)
                     msg['identity'] = {'method':self.o.identity_method, 'value':ident.value}
 
                     logger.debug(f"New sarracenia message: {msg}")

--- a/sarracenia/flowcb/amserver.py
+++ b/sarracenia/flowcb/amserver.py
@@ -271,11 +271,19 @@ class Amserver(FlowCB):
                 # Create a file for new messages and let sarracenia format the data
                 try:
                     ## Filenames have the following naming scheme:
-                    ##   1. Bulletin header
-                    ##   2. Counter (makes filename unique for each bulletin)
-                    ##   IF A* or R* present in header, include in filename
+                    ##   1. Bulletin header (composed of bulletin type, Issuing office, timestamp)
+					##   2. BBB, for amendments
+					##   3. Station (sometimes omitted, depending on the bulletin)
+                    ##   4. Counter (makes filename unique for each bulletin)
                     ##
-                    ##   Example: SXVX65_KWNB_181800_RRB__99705
+                    ##   Example: SXVX65_KWNB_181800_RRB_WVR_99705
+					##            Type   |    |      |   |   |
+					##					 Issuing office  |   |
+					##						  Timestamps |   |
+					##						         Amendment
+					##									 Station
+					##										  Random Integer
+
                     filepath = self.o.directory + os.sep + bulletinHeader + '__' +  f"{randint(self.minnum, self.maxnum)}".zfill(len(str(self.maxnum)))
 
                     file = open(filepath, 'wb')
@@ -288,5 +296,6 @@ class Amserver(FlowCB):
 
                 except:
                     logger.error("Unable to generate bulletin file.")
+					logger.debug(f"Bulletin file contents: {bulletin}")
 
         return newmsg 


### PR DESCRIPTION
The changes include:

- Add bulletin contents to the sarracenia message (v03 only) via the contents field.
- Add logic for the built-in AHL header auto-corrections