### PR TITLE
promote do() entry point from subscribe to parent flow

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1082,16 +1082,15 @@ class Flow:
                 self.worklist.incoming.extend(new_incoming)
 
     def do(self) -> None:
-        """
-            stub to do the work: does nothing, marking everything done.
-            to be replaced in child classes that do transforms or transfers.
-        """
 
-        # mark all remaining messages as done.
-        self.worklist.ok = self.worklist.incoming
-        self.worklist.incoming = []
-        logger.debug('processing %d messages worked! (stop requested: %s)' %
-                     (len(self.worklist.ok), self._stop_requested))
+        if self.o.download:
+            self.do_download()
+        else:
+            # mark all remaining messages as done.
+            self.worklist.ok = self.worklist.incoming
+            self.worklist.incoming = []
+
+        logger.debug('processing %d messages worked!' % len(self.worklist.ok))
 
     def post(self) -> None:
 

--- a/sarracenia/flow/sarra.py
+++ b/sarracenia/flow/sarra.py
@@ -21,14 +21,3 @@ class Sarra(Flow):
         if hasattr(self.o, 'post_exchange'):
             self.plugins['load'].insert(
                 0, 'sarracenia.flowcb.post.message.Message')
-
-    def do(self):
-
-        if self.o.download:
-            self.do_download()
-        else:
-            # mark all remaining messages as done.
-            self.worklist.ok = self.worklist.incoming
-            self.worklist.incoming = []
-
-        logger.debug('processing %d messages worked!' % len(self.worklist.ok))

--- a/sarracenia/flow/subscribe.py
+++ b/sarracenia/flow/subscribe.py
@@ -20,14 +20,3 @@ class Subscribe(Flow):
         if hasattr(self.o, 'post_exchange'):
             self.plugins['load'].insert(
                 0, 'sarracenia.flowcb.post.message.Message')
-
-    def do(self):
-
-        if self.o.download:
-            self.do_download()
-        else:
-            # mark all remaining messages as done.
-            self.worklist.ok = self.worklist.incoming
-            self.worklist.incoming = []
-
-        logger.debug('processing %d messages worked!' % len(self.worklist.ok))


### PR DESCRIPTION
as discussed for #900.  by 

* promoting the do() entry point  from sarra/subscribe to the parent flow class.
* This makes the default do() routine capable of downloading data, and that is available to flow subclasses.  
* this do() routine, has a gate on "self.o.download" 
   * the download option defaults to false (overriden in sarra and subscribe.)  
   * when download is false, the do routine does nothing except move the incoming worklist to ok, which is what the old do() in parent used to do.
* The only flow subclass that needs something different is sender(), which already has an overridding do() entry point.

so the promotion of do to the parent class, when combined with the default download settings, actually has no effect on function.  The code should do exactly the same thing.  

So made the change on an experimental basis, ran it throught the flow tests, and they all passed as expected.  Any existing flows should inherit the  default download false setting... so it has no effect on them either.

In @andreleblanc11's work the amserver can now  have:
```

download on

```

to get the files created with the proper names based on the inlined content.
