### PR TITLE
fix #910 add a further heuristic for detecting v02 messages

### DIFF
--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -31,7 +31,7 @@ class V02(PostFormat):
             return True
 
         # all the other formats are JSON based. only v02 has plain-text body.
-        if not b'{' in payload[0:5]:
+        if not '{' in payload[0:5]:
             return True
 
         # in the v02, we used topic to identify message format. (not reliable for other formats.)

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -29,6 +29,11 @@ class V02(PostFormat):
        """
         if content_type == V02.content_type() :
             return True
+
+        # all the other formats are JSON based. only v02 has plain-text body.
+        if not '{' in payload[0:5]:
+            return True
+
         return False
 
     @staticmethod

--- a/sarracenia/postformat/v02.py
+++ b/sarracenia/postformat/v02.py
@@ -31,9 +31,13 @@ class V02(PostFormat):
             return True
 
         # all the other formats are JSON based. only v02 has plain-text body.
-        if not '{' in payload[0:5]:
+        if not b'{' in payload[0:5]:
             return True
 
+        # in the v02, we used topic to identify message format. (not reliable for other formats.)
+        if headers['topic'].startswith('v02.'):
+            return True
+        
         return False
 
     @staticmethod


### PR DESCRIPTION
fix for #910.

I think this is similar to the logic in v2... but I worry that other future message formats might be caught by this.  

v2 sr_message.py :

```
          if msg.body[0] == '[' :
               self.logger.debug("from_amqplib transitional v03" )
               self.pubtime, self.baseurl, self.relpath, self.headers = json.loads(msg.body)
               self.notice = "%s %s %s" % ( self.pubtime, self.baseurl, self.relpath )
          elif msg.body[0] == '{' :
               self.logger.debug("from_amqplib v03 body: %s" % msg.body)
           ...
          else: # v2.
```

* can't use the methods from v2  in sr3 because there is *wis* format which geo+json and *v03* which is a simpler json, so json is not enough to identify the format.  so the decision is... if it ISN't JSON, then it's v02.

* a future format (for aviation/AMHS/SWIM) will likely be XML based, and thus some adjustments to the detection might be necessary if that post format is added.

I think the check for the brace is helpful, and the body of v02 messages is very simple so it should work for all known current cases.  but it feels like a heuristic.

