### PR TITLE
Fix character encoding for AM and move code to gather

### DIFF
--- a/sarracenia/examples/flow/amserver.conf
+++ b/sarracenia/examples/flow/amserver.conf
@@ -1,8 +1,12 @@
+
+callback gather.am
 callback post.message
-flowcb amserver
+
 post_broker amqp://tsource@localhost
 post_exchange xs_tsource_am
 post_baseUrl file://
+
+download on
 directory /tmp/andre_am_receiver
 accept .*
 sum sha512

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -62,7 +62,7 @@ from random import randint
 
 logger = logging.getLogger(__name__)
 
-class Amserver(FlowCB):
+class Am(FlowCB):
 
     def __init__(self, options):
         
@@ -352,7 +352,7 @@ class Amserver(FlowCB):
                         decoded_bulletin = bulletin.decode(charset)
 
                         msg['content'] = {
-                        "encoding":f"charset", 
+                        "encoding":f"{charset}", 
                         "value":decoded_bulletin 
                         }
 

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -24,7 +24,7 @@ Description:
             Filters outbound connections with provided IPs. All other IPs won't be accepted. 
             If unselected, accept all IPs. 
 
-        outputCharset (string):
+        inputCharset (string):
             Option to personalize the character set encoding advertised to consumers. 
             Default value is utf-8
 
@@ -76,7 +76,7 @@ class Am(FlowCB):
         self.sizeAM = struct.calcsize(self.patternAM)
 
         self.o.add_option('AllowIPs', 'list', [])
-        self.o.add_option('outputCharset', 'str', 'utf-8')
+        self.o.add_option('inputCharset', 'str', 'utf-8')
         self.o.add_option('MissingAMHeaders', 'str', 'CN00 CWAO')
         self.o.add_option('binaryInitialCharacters', 'list', [b'BUFR' , b'GRIB', b'\211PNG'])
 
@@ -279,7 +279,7 @@ class Am(FlowCB):
 
             if status == 'OK':
                 (bulletin, longlen) = self.unwrapmsg()
-                charset = self.o.outputCharset
+                charset = self.o.inputCharset
 
                 # Set buffer for next bulletin ingestion
                 self.inBuffer = self.inBuffer[longlen:]


### PR DESCRIPTION
Changes:
* Add an option to specify character encoding of bulletin contents.
* Default this encoding to `utf-8`

* Move amserver.py to gather/am.py