### PR TITLE
fix #922 avoid mixing up post_exchange with exchange in display

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -749,6 +749,37 @@ class sr_GlobalState:
             exl.append(x)
             return exl
 
+    def __resolved_post_exchanges(self, c, cfg, o):
+        """
+          Guess the name of an exchange. looking at either a direct setting,
+          or an existing queue state file, or lastly just guess based on conventions.
+        """
+        exl = []
+        #if hasattr(o,'declared_exchanges'):
+        #    exl.extend(o.declared_exchanges)
+
+        if hasattr(o, 'post_exchange'):
+            if type(o.post_exchange) == list:
+                exl.extend(o.post_exchange)
+            else:
+                exl.append(o.post_exchange)
+            return exl
+
+        x = 'xs_%s' % o.post_broker.url.username
+
+        if hasattr(o, 'post_exchangeSuffix'):
+            x += '_%s' % o.post_exchangeSuffix
+
+        if hasattr(o, 'post_exchangeSplit'):
+            l = []
+            for i in range(0, o.instances):
+                y = x + '%02d' % i
+                l.append(y)
+            return l
+        else:
+            exl.append(x)
+            return exl
+
     def __guess_queueName(self, c, cfg, o):
         """
           Guess the name of a queue. looking at either a direct setting,
@@ -832,17 +863,8 @@ class sr_GlobalState:
                 if hasattr(o, 'post_broker') and o.post_broker is not None and o.post_broker.url is not None:
                     host = self._init_broker_host(o.post_broker.url.netloc)
 
-                    #o.broker = o.post_broker
-                    if hasattr(o, 'post_exchange'):
-                        o.exchange = o.post_exchange
-                    if hasattr(o, 'post_exchangeSplit'):
-                        o.exchangeSplit = o.post_exchangeSplit
-                    if hasattr(o, 'post_exchangeSuffix'):
-                        o.exchangeSuffix = o.post_exchangeSuffix
-
-                    xl = self.__resolved_exchanges(c, cfg, o)
-
-                    self.configs[c][cfg]['options'].resolved_exchanges = xl
+                    self.configs[c][cfg]['options'].resolved_exchanges = \
+                            self.__resolved_post_exchanges(c, cfg, o)
 
                     if hasattr(o, 'post_exchange'):
                         self.brokers[host]['exchange'] = o.post_exchange


### PR DESCRIPTION
closes #922 

There was a weird chunk of code where it set exchange = post_exchange (and some other related settings, and then called _resolved_exchange() to apply things like post_exchange_split and such... 

I created a separate routine, _resolved_post_exchange() that is a copy of the above one, but operating on the post_ settings rather than reusing the routine.

This fixes the display problem, passes all tests, and I ran a test on a system that reproduced the problem, and it was fixed with this branch.
