### PR TITLE
Issue912 retry refilter flag

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1528,6 +1528,19 @@ retryEmptyBeforeExit: <boolean> (default: False)
 Used for sr_insects flow tests. Prevents Sarracenia from exiting while there are messages remaining in the retry queue(s). By default, a post will cleanly exit once it has created and attempted to publish messages for all files in the specified directory. If any messages are not successfully published, they will be saved to disk to retry later. If a post is only run once, as in the flow tests, these messages will never be retried unless retryEmptyBeforeExit is set to True.
 
 
+retry_refilter <boolean> (default: False)
+-----------------------------------------
+
+The **retry_refilter** option alters how messages are reloaded when they are retrieved from
+a retry queue. The default way (value: False) is to repeat the transfer using exactly
+the same message as before. If **retry_refilter** is set (value: True) then all the
+message's calculated fields will be discarded, and the processing re-started from the gather
+phase (accept/reject processing will be repeated, destinations re-calculated.)
+
+The normal retry behaviour is use when the remote has had a failure, and need to 
+re-send later, while the retry_refilter option is used when recovering from configuration 
+file errors, and some messages had incorrect selection or destination criteria.
+
 retry_ttl <duration> (default: same as expire)
 ----------------------------------------------
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1503,6 +1503,21 @@ publiés avec succès, ils seront enregistrés sur le disque pour réessayer ult
 exécutée qu’une seule fois, comme dans les tests de flux, ces messages d'annonce ne seront jamais réessayés, sauf si
 retryEmptyBeforeExit est défini à True.
 
+retry_refilter <boolean> (par défaut : False)
+---------------------------------------------
+
+L'option **retry_refilter** modifie la façon dont les messages sont rechargés lorsqu'ils sont récupérés à partir 
+d'une file d'attente pour une nouvelle tentive de transfer (retry). La méthode par défaut (valeur : False) 
+consiste à répéter le transfert en utilisant exactement le même message que précédemment. Si **retry_refilter** 
+est défini (valeur : True), alors tous les Les champs calculés du message + seront supprimés et le 
+traitement redémarrera à partir de la phase *gather*  (le traitement d'acceptation/rejet sera 
+répété, les destinations recalculées.)
+
+Le comportement normal de nouvelle tentative (retry) est utilisé lorsque la destination a subit une 
+panne et doit renvoyer plus tard, tandis que l'option **retry_refilter** est utilisée lors de la récupération 
+de la configuration
+
+
 retry_ttl <duration> (défaut: identique à expire)
 -------------------------------------------------
 

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -113,6 +113,7 @@ default_options = {
     'recursive' : True,
     'report': False,
     'retryEmptyBeforeExit': False,
+    'retry_refilter': False,
     'sanity_log_dead': 9999,
     'sourceFromExchange': False,
     'sundew_compat_regex_first_match_is_zero': False,
@@ -134,7 +135,7 @@ flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl
     'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logMetrics', 'logStdout', 'logReject', 'restore', \
     'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \
     'permCopy', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', \
-    'reconnect', 'report', 'reset', 'retryEmptyBeforeExit', 'save', 'sundew_compat_regex_first_match_is_zero', \
+    'reconnect', 'report', 'reset', 'retry_refilter', 'retryEmptyBeforeExit', 'save', 'sundew_compat_regex_first_match_is_zero', \
     'sourceFromExchange', 'statehost', 'users', 'v2compatRenameDoublePost'
                 ]
 
@@ -2511,6 +2512,10 @@ class Config:
             help=
             'allows simultaneous use of multiple versions and types of messages'
         )
+        parser.add_argument('--retry_refilter',
+                            action='store_true',
+                            default=self.retry_refilter,
+                            help='repeat message processing when retrying transfers (default just resends as previous attempt.)')
         #FIXME: select/accept/reject in parser not implemented.
         parser.add_argument(
             '--select',

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1070,9 +1070,10 @@ class Flow:
             (len(self.worklist.incoming), len(self.worklist.rejected)))
 
     def gather(self) -> None:
+        so_far=0
         for p in self.plugins["gather"]:
             try:
-                new_incoming = p()
+                new_incoming = p(self.o.batch-so_far)
             except Exception as ex:
                 logger.error( f'flowCallback plugin {p} crashed: {ex}' )
                 logger.debug( "details:", exc_info=True )
@@ -1080,6 +1081,12 @@ class Flow:
 
             if len(new_incoming) > 0:
                 self.worklist.incoming.extend(new_incoming)
+                so_far += len(new_incoming) 
+
+            # if we gathered enough with a subset of plugins then return.
+            if so_far >= self.o.batch:
+                return
+
 
     def do(self) -> None:
 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -80,9 +80,9 @@ class FlowCB:
 
         Task: acknowledge messages from a gather source.
 
-    def gather(self) -> list::
+    def gather(self, messageCountMax) -> list::
 
-        Task: gather messages from a source... return a list of messages.
+        Task: gather messages from a source... return a list of messages 
 
               in a poll, gather is always called, regardless of vip posession.
               in all other components, gather is only called when in posession

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -680,7 +680,7 @@ class File(FlowCB):
         self.queued_messages = []
         self.primed = False
 
-    def gather(self):
+    def gather(self, messageCountMax):
         """
            from sr_post.py/run 
 

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -28,7 +28,7 @@ class Message(FlowCB):
         else:
             logger.critical('missing required broker specification')
 
-    def gather(self) -> list:
+    def gather(self, messageCountMax) -> list:
         """
            return a current list of messages.
         """

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -60,9 +60,9 @@ class Log(FlowCB):
     def metricsReport(self):
         return { 'lagMax': self.lagMax, 'lagTotal':self.lagTotal, 'lagMessageCount':self.msgCount, 'rejectCount':self.rejectCount }
 
-    def gather(self):
+    def gather(self, messageCountMax):
         if set(['gather']) & self.o.logEvents:
-            logger.info('')
+            logger.info( f' messageCountMax: {messageCountMax} ')
 
         return []
 

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -54,6 +54,11 @@ class Retry(FlowCB):
             return
 
         self.o.add_option( 'retry_driver', 'str', 'disk')
+
+        # retry_refilter False -- rety to send with existing processing.
+        # retry_refilter True -- re-ingest and re-apply processing (if it has changed.)
+        self.o.add_option( 'retry_refilter', 'flag', False)
+
         #queuedriver = os.getenv('SR3_QUEUEDRIVER', 'disk')
 
         if self.o.retry_driver == 'redis':
@@ -69,17 +74,53 @@ class Retry(FlowCB):
 
         logger.debug('logLevel=%s' % self.o.logLevel)
 
+
     def gather(self, qty) -> None:
         """
         If there are only a few new messages, get some from the download retry queue and put them into
         `worklist.incoming`.
+
+        Do this in the gather() entry point if retry_refilter is True.
+
         """
-        if not features['retry']['present'] :
+        if not features['retry']['present'] or not self.o.retry_refilter:
             return []
 
         if qty <= 0: return []
 
-        return self.download_retry.get(qty)
+        message_list = self.download_retry.get(qty)
+
+        # eliminate calculated values so it is refiltered from scratch.
+        for m in message_list:
+             for k in m:
+                 if k in m['_deleteOnPost'] or k.startswith('new_'):
+                     del m[k]
+             del m['_deleteOnPost']
+
+        return message_list
+
+
+    def after_accept(self, worklist) -> None:
+        """
+        If there are only a few new messages, get some from the download retry queue and put them into
+        `worklist.incoming`.
+
+        Do this in the after_accept() entry point if retry_refilter is False.
+
+        """
+        if not features['retry']['present'] or self.o.retry_refilter:
+            return
+
+        qty = (self.o.batch / 2) - len(worklist.incoming)
+        #logger.info('qty: %d len(worklist.incoming) %d' % ( qty, len(worklist.incoming) ) )
+
+        if qty <= 0: return
+
+        mlist = self.download_retry.get(qty)
+
+        #logger.debug("loading from %s: qty=%d ... got: %d " % (self.download_retry_name, qty, len(mlist)))
+        if len(mlist) > 0:
+            worklist.incoming.extend(mlist)
 
     def after_work(self, worklist) -> None:
         """

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -69,24 +69,17 @@ class Retry(FlowCB):
 
         logger.debug('logLevel=%s' % self.o.logLevel)
 
-    def after_accept(self, worklist) -> None:
+    def gather(self, qty) -> None:
         """
         If there are only a few new messages, get some from the download retry queue and put them into
         `worklist.incoming`.
         """
         if not features['retry']['present'] :
-            return
+            return []
 
-        qty = (self.o.batch / 2) - len(worklist.incoming)
-        #logger.info('qty: %d len(worklist.incoming) %d' % ( qty, len(worklist.incoming) ) )
+        if qty <= 0: return []
 
-        if qty <= 0: return
-
-        mlist = self.download_retry.get(qty)
-
-        #logger.debug("loading from %s: qty=%d ... got: %d " % (self.download_retry_name, qty, len(mlist)))
-        if len(mlist) > 0:
-            worklist.incoming.extend(mlist)
+        return self.download_retry.get(qty)
 
     def after_work(self, worklist) -> None:
         """

--- a/sarracenia/flowcb/run.py
+++ b/sarracenia/flowcb/run.py
@@ -68,7 +68,7 @@ class Run(FlowCB):
             logger.error("subprocess.run failed err={}".format(err))
             logger.debug("Exception details:", exc_info=True)
 
-    def gather(self):
+    def gather(self, messageCountMax):
         """
            FIXME: this does not make sense. need to figure out how to get the 
            messages back from the script, perhaps using a json file reader?

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -87,7 +87,7 @@ class Scheduled(FlowCB):
         now=datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
         self.update_appointments(now)
 
-    def gather(self):
+    def gather(self,messageCountMax):
 
         # for next expected post
         self.wait_until_next()

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -131,7 +131,7 @@ class Wiski(Scheduled):
         
         return submit_tokenization_request
 
-    def gather(self): # placeholder
+    def gather(self,messageCountMax): # placeholder
         
         messages=[]
 
@@ -216,5 +216,5 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
     me = Wiski(flow.o)
-    me.gather()
+    me.gather(flow.o.batch)
 


### PR DESCRIPTION

closes #912 

builds on the initial issue912 branch by adding a new option:
retry_refilter ... switches between original sr3 processing (just resend using the same message) and v2 method (reprocess the message from scratch.)

I think the vast majority of the time, the client wants the sr3 behaviour... but I'm not sure.  

I have tested this to make sure the flow tests pass, but I don't understand what the interaction with nodupe_ will be.   These retry_refilter messages which were added to a duplicate_suppression cache are likely to be considered duplicates when reprocessed.

I haven't done anything about that yet.  Not sure what should be done (a free pass by defining a "isRetry" field as was done in v2?)

