### PR TITLE
Issue920 cleanup and #912 add _isRetry

### DIFF
--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -74,8 +74,8 @@ class Poll(Flow):
         self.plugins['load'].insert(0,
                                     'sarracenia.flowcb.post.message.Message')
 
-        if self.o.nodupe_ttl < self.o.nodupe_fileAgeMax:
-            logger.warning( f"nodupe_ttl < nodupe_fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904")
+        if self.o.nodupe_ttl < self.o.fileAgeMax:
+            logger.warning( f"nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904")
 
         if not features['ftppoll']['present']:
             if hasattr( self.o, 'pollUrl' ) and ( self.o.pollUrl.startswith('ftp') ):

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -154,8 +154,6 @@ class Disk(NoDupe):
 
         if self.o.fileAgeMin > 0:
             max_mtime = self.now - self.o.fileAgeMin
-        elif type(self.o.inflight) in [ int, float ] and self.o.inflight > 0:
-            max_mtime = self.now - self.o.inflight
         else:
             # FIXME: should we add some time here to allow for different clocks?
             #        100 seconds in the future? hmm...
@@ -177,7 +175,7 @@ class Disk(NoDupe):
                     worklist.rejected.append(m)
                     continue
 
-            if self.check_message(m):
+            if '_isRetry' in m or self.check_message(m):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])

--- a/sarracenia/flowcb/nodupe/redis.py
+++ b/sarracenia/flowcb/nodupe/redis.py
@@ -173,7 +173,7 @@ class Redis(NoDupe):
                     worklist.rejected.append(m)
                     continue
 
-            if self._is_new(m):
+            if '_isRetry' in m or self._is_new(m):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -95,7 +95,9 @@ class Retry(FlowCB):
              for k in m:
                  if k in m['_deleteOnPost'] or k.startswith('new_'):
                      del m[k]
-             del m['_deleteOnPost']
+             m['_isRetry'] = True
+             m['_deleteOnPost'] = set( [ '_isRetry' ] )
+
 
         return message_list
 


### PR DESCRIPTION
close #912 

(branch is labelled with the wrong issue...) anyways....

found a problem with missing thing from #920 (nodupe_fileAge rename missed in flow/poll) 

but also adding _isRetry field to messages when retrieved from retry queue, and having nodupe implementations ignore automatically pass those messages through.

