### PR TITLE
adding mention of scheduled flows as an option when migrating v2 polls

### DIFF
--- a/docs/source/Contribution/Development.rst
+++ b/docs/source/Contribution/Development.rst
@@ -123,6 +123,11 @@ Planned by 2022/04/11:
 
  * launchpad has recipes to produce metpx-sr3 packages from the stable branch. 
 
+ * The *MetPX Daily* repository is a snapshot of the development branch. 
+
+ * The *MetPX Pre-Release* repository should receive versions ending in rcX (release candidate) 
+
+ * The *MetPX* repository should only contain stable releases that have graduated from the rcX series.
 
 
 sr_insects
@@ -1467,6 +1472,14 @@ occurs that is identified as the released version.
 PyPi
 ~~~~
 
+Pypi does not distinguish between older and newer python releases. There is only one package
+version for all supported versions. When uploading from a new OS, the versions in use on the 
+OS are inferred to be the minimum, and so installation on older operating systems may be blocked
+by generated dependencies on overly modern versions.
+
+So when uploading to pypi, always do so from the oldest operating system where it needs to work.
+upward compatibility is more likely than downward.
+
 Pypi Credentials go in ~/.pypirc.  Sample Content::
 
   [pypi]
@@ -1477,7 +1490,7 @@ Assuming pypi upload credentials are in place, uploading a new release used to b
 
     python3 setup.py bdist_wheel upload
 
-on older systems, or on newer ones::
+on older systems, or on (python >= 3.7) newer ones::
 
    python3 -m build --no-isolation
    twine upload dist/metpx_sarracenia-2.22.6-py3-none-any.whl dist/metpx_sarracenia-2.22.6.tar.gz

--- a/docs/source/How2Guides/v2ToSr3.rst
+++ b/docs/source/How2Guides/v2ToSr3.rst
@@ -426,7 +426,7 @@ In general, v3 plugins:
   The checksum is already performed when the new notification message is being generated so most likely
   any message fields such as **sumalgo** and other **algo** fields can be discarded.
 
-  For an example of using the message builder, look at  `do_poll -> poll`_
+  For an example of using the message builder, look at  `do_poll -> poll or gather`_
 
 
 * v3 plugins **rarely, involve subclassing of moth or transfer classes.**
@@ -603,8 +603,8 @@ examples:
 
 
 
-do_poll -> poll
-~~~~~~~~~~~~~~~
+do_poll -> poll or gather
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 v2: call do_poll from plugin.
 
@@ -620,6 +620,9 @@ v2: call do_poll from plugin.
  * often paired with download\_something plugins where a partial message is built with the poll
    and the download one is specialized to to the actual download.
 
+There is a common pattern in v2 polls where, rather than querying a remote server to find out what new products
+are available, in sr3 we have the concept of a scheduled flow, where there is a fixed list of requests done
+periodically. See `Scheduled Flow` for more on that. For typical polls, the migration to sr3 follows:
 
 v3: define poll in a flowcb class.
 
@@ -682,7 +685,6 @@ and at the end::
 
      return gathered_messages
 
- 
 
 Virtual IP processing in poll
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -699,6 +701,20 @@ to update their recent_files cache.
 
 examples:
  * flowcb/poll/airnow.py
+
+Scheduled Flow
+~~~~~~~~~~~~~~
+
+If there is a WISKIS ( https://www.kisters.net/wiski ) server, one needs to issue
+time centric queries are regular intervals. so a gather() entry point is implmented
+which returns a list of messages that a downloader will use to obtain the data.
+
+* https://github.com/MetPX/sarracenia/blob/development/sarracenia/examples/flow/opg.conf an example flow configuration for polling Ontario Power Generation sensors.
+
+* https://github.com/MetPX/sarracenia/blob/development/sarracenia/flowcb/scheduled/wiski.py  The plugin used by the OPG configuration using the gather() entry point.
+
+
+
 
 on_html_page -> subclass flowcb/poll
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
this week ported some v2 polls and ended up with scheduled flows... that's missing from v2to sr3 porting document because the document was written before scheduled flows existed.
