### PR TITLE
Issue942 - sarra consumer writing wrong files because 'rename' field should have been deleted.

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -805,10 +805,16 @@ class Flow:
             u = sarracenia.baseUrlParse(msg['baseUrl'])
             relPath = u.path[1:] + '/' + relPath
 
-        # FIXME... why the % ? why not just assign it to copy the value?
         if self.o.download and 'rename' in msg: 
+            # FIXME... why the % ? why not just assign it to copy the value?
             relPath = '%s' % msg['rename']
+
+            # after download we dont propagate renaming... once used, get rid of it
             del msg['rename']
+            # FIXME: worry about publishing after a rename.
+            # the relpath should be replaced by rename value for downstream
+            # because the file was written to rename.
+            # not sure if this happens or not.
 
 
         token = relPath.split('/')

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -554,6 +554,11 @@ class Flow:
                         # restore adjustment to fileOp
                         if 'post_fileOp' in m:
                             m['fileOp'] = m['post_fileOp']
+
+                        if self.o.download and 'retrievePath' in m:
+                            # retrieve paths do not propagate after download.
+                            del m['retrievePath'] 
+
                         
                     self._runCallbacksWorklist('after_work')
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -808,6 +808,8 @@ class Flow:
         # FIXME... why the % ? why not just assign it to copy the value?
         if self.o.download and 'rename' in msg: 
             relPath = '%s' % msg['rename']
+            del msg['rename']
+
 
         token = relPath.split('/')
         filename = token[-1]

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -96,6 +96,8 @@ class Log(FlowCB):
             s+= f"relPath: {msg['relPath']} "
         if 'retrievePath' in msg:
             s+= f"retrievePath: {msg['retrievePath']} "
+        if 'rename' in msg:
+            s+= f"rename: {msg['rename']} "
         return s
         
     def _messagePostStr(self,msg):
@@ -124,6 +126,8 @@ class Log(FlowCB):
             s+= f"relPath: {msg['relPath']} "
         if 'retrievePath' in msg:
             s+= f"retrievePath: {msg['retrievePath']} "
+        if 'rename' in msg:
+            s+= f"rename: {msg['rename']} "
         return s
 
     def after_accept(self, worklist):

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2806,7 +2806,7 @@ class sr_GlobalState:
             elif len(status['running']) == (len(self.configs[c]) -
                                             len(status['disabled'])):
                 print('%-10s %-10s %-6s %-3d %s' % (c, 'most', 'OKd', \
-                    (len(self.configs[c]) - len(status['disabled']),  ', '.join(status['running'] ))) )
+                    len(self.configs[c]) - len(status['disabled']),  ', '.join(status['running'] )))
             else:
                 print('%-10s %-10s %-6s %3d' %
                       (c, 'mixed', 'mult', len(self.configs[c])))


### PR DESCRIPTION
closes #942 
closes #943 

This adds deletion of the 'rename' message field after it is applied.
For similar reasons, retrievePath needs to be deleted once the download is done.
