### PR TITLE
Lots of AM corrections (Renamer + AHL corrections in gather)

### DIFF
--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -265,7 +265,7 @@ class Am(FlowCB):
             return '', 0
 
 
-    def gather(self):
+    def gather(self, messageCountMax):
 
         self.AddBuffer()
 

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -38,6 +38,15 @@ Examples:
 
        Output filename: CACN00_CWAO_141600_PQU__00003
 
+    A ISA binary bulletin
+       Input filename: ISAA41_CYZX_162000__00035 
+
+       Contents:
+        ISAA41_CYZX_162000
+        BUFR
+
+       Output filename: ISAA41_CYZX_162000___00035  
+
 Usage:
    callback rename.raw2bulletin
 
@@ -46,7 +55,6 @@ Contributions:
 
 Improvements:
     Delegate some of the generalized methods to a parent class. To be callable by other plugins.
-    Add more Sundew logic if ever some bulletins end up failing when implemented
 """
 
 from sarracenia.flowcb import FlowCB


### PR DESCRIPTION
Here is a summary of what was done for this PR.

For the AM renamer:
   - Handle binary data better. I thought that the binary data wouldn't want to be ingested by the renamer, but I was wrong. I removed the guard that discouraged handling binary data.
   - Append "PROBLEM" at the bulletins suffix if it cannot be renamed.
  
For the AM gather:
   - Add missing gather correction from https://github.com/MetPX/sarracenia/pull/928
   - Add the bulletin mapping option to map bulletins to their relative stations.

I opted to add the bulletin station mapping stuff in the gather as it tampers with the file contents, and not the filename. I moved all of the bulletin AHL adding logic inside of its own method.

Things left to complete AM after this:
   - The SM/SI bulletins still need some headers? to be added on their second line. When comparing dev to ops, they're missing. Here is the sundew logic for it : https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L114-L115
   - Have the Julian date appended to the CA,RA,MA headers inside the bulletin. I'm not adding this right away as I want to have it all added via a parent bulletin class.