### PR TITLE
Am final touches before first release

### DIFF
--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -1,0 +1,244 @@
+import logging
+import time 
+from base64 import b64decode
+
+logger = logging.getLogger(__name__)
+
+
+class Bulletin:
+    """
+        Parent class to be callable by all bulletin handling processes.
+
+        Holds general methods that are applicable to either
+            Modifying bulletin file contents
+            Modifying bulletin filenames
+
+        Spawned from analysts realizing that lots of bulletin handlers/plugins use the same methods repeatedly.
+        This is in turn will reduce duplicate code throughout.
+
+        Usage:
+            from sarracenia.bulletin import Bulletin
+    """
+
+    def __init__(self):
+        self.seq = 0
+        self.binary = 0
+
+    def getData(self, msg, path):
+        """Get the bulletin data.
+           We can either get the bulletin data via
+               1. Sarracenia message content
+               2. Locally downloaded file
+        """
+
+        # Read file data from message or from file path directly if message content not found.
+        # For the binary data, only extract first line (header) as that is all we need. The ascii decoding fails with the rest of the bulletin (usually).
+        try:
+
+            self.binary = 0
+            if msg['content']:
+                data = msg['content']['value']
+
+                # Change from b64. We want to get the header from the raw binary data. Not retrievable in b64 format
+                if msg['content']['encoding'] == 'base64':
+                    data = b64decode(data).splitlines()[0].decode('ascii')
+                    self.binary = 1
+
+            else:
+
+                fp = open(path, 'rb')
+                data = fp.read()
+                fp.close()
+
+                # Decode data, only text. The raw binary data contains the header in which we're interested.
+                # Integrate inputCharset
+                if data.splitlines()[1][:4] not in self.o.binaryInitialCharacters:
+                    data = data.decode(self.o.inputCharset)
+                else:
+                    data = data.splitlines()[0].decode('ascii')
+                    self.binary = 1
+
+
+            return data
+
+        except Exception as e:
+            logger.error(f"Could not fetch file data of from either message content or {path}. Error details: {e}")
+            return None
+
+    def getSequence(self):
+        """ sequence number to make the file unique...
+        """
+        self.seq = self.seq + 1
+        if self.seq > 99999:
+            self.seq = 1
+        return str(self.seq).zfill(5)
+
+
+    def getStation(self, data):
+        """Extracted from Sundew code: https://github.com/MetPX/Sundew/blob/main/lib/bulletin.py#L327-L408
+           Get the station ID from the bulletin contents.
+           Examples:
+              CACN00 CWAO -> Station ID located on second line.
+              FTCN32 CWAO -> Station ID located on first line (with header)
+        """
+
+        station = ''
+
+        # There is no station in a binary bulletin
+        if self.binary:
+            return station
+
+        data = data.lstrip('\n')
+        data = data.split('\n')
+
+        try:
+            premiereLignePleine = ""
+            deuxiemeLignePleine = ""
+
+            # special case, need to get the next full line.
+            i = 0
+            for ligne in data[1:]:
+                i += 1
+                premiereLignePleine = ligne
+                if len(premiereLignePleine) > 1:
+                    if len(data) > i+1 : deuxiemeLignePleine = data[i+1]
+                    break
+
+            #print " ********************* header = ", data[0][0:7]
+            # switch depends on bulletin type.
+            if data[0][0:2] == "SA":
+                if data[1].split()[0] in ["METAR","LWIS"]:
+                    station = premiereLignePleine.split()[1]
+                else:
+                    station = premiereLignePleine.split()[0]
+
+            elif data[0][0:2] == "SP":
+                station = premiereLignePleine.split()[1]
+
+            elif data[0][0:2] in ["SI","SM"]:
+                station = premiereLignePleine.split()[0]
+                if station == "AAXX" :
+                    if deuxiemeLignePleine != "" :
+                        station = deuxiemeLignePleine.split()[0]
+                    else :
+                        station = ''
+
+            elif data[0][0:6] in ["SRCN40","SXCN40","SRMT60","SXAK50", "SRND20", "SRND30"]:
+            #elif data[0][0:6] in self.wmo_id:
+                station = premiereLignePleine.split()[0]
+
+            elif data[0][0:2] in ["FC","FT"]:
+                if premiereLignePleine.split()[1] == "AMD":
+                    station = premiereLignePleine.split()[2]
+                else:
+                    station = premiereLignePleine.split()[1]
+
+            elif data[0][0:2] in ["UE","UG","UK","UL","UQ","US"]:
+                parts = premiereLignePleine.split()
+                if parts[0][:2] in ['EE', 'II', 'QQ', 'UU']:
+                    station = parts[1]
+                elif parts[0][:2] in ['PP', 'TT']:
+                    station = parts[2]
+                else:
+                    station = ''
+
+            elif data[0][0:2] in ["RA","MA","CA"]:
+                station = premiereLignePleine.split()[0].split('/')[0]
+            
+        except Exception:
+            station = ''
+        
+        if station != '' :
+            while len(station) > 1 and station[0] == '?' :
+                station = station[1:]
+            if station[0] != '?' :
+                station = station.split('?')[0]
+                if station[-1] == '=' : station = station[:-1]
+            else :
+                station = ''
+
+        return station
+
+
+    def getBBB(self, first_line):
+        """Get the BBB. If none found, return empty string.
+           The BBB is the field of the bulletin header that states if it was amended or not.
+        """
+
+        if len(first_line) != 4: 
+            BBB = ''
+        else:
+            BBB = first_line[3]
+
+        return BBB
+
+    def buildHeader(self, first_line):
+        """ Build header from file contents
+        """
+
+        try:
+            T1T2A1A2ii = first_line[0]
+            CCCC       = first_line[1]
+
+            if len(first_line) >= 3:
+                YYGGgg = first_line[2]
+                header = T1T2A1A2ii + "_" + CCCC + "_" + YYGGgg
+            else:  
+                header = T1T2A1A2ii + "_" + CCCC # + "_" + YYGGgg
+
+        except Exception:
+            header = None
+
+        return header
+
+
+    def getTime(self, data):
+        """ extract time from the data of the ca station
+            the data's first line looks like this : x,yyyy,jul,hhmm,...
+            where x is an integer of no importance, followed by obs'time
+            yyyy = year
+            jul  = julian day
+            hhmm = hour and mins
+        """
+
+        try:
+            parts = data.split(',')
+
+            if len(parts) < 4: return None
+
+            year = parts[1]
+            jul = parts[2]
+            hhmm = parts[3]
+
+            # passe-passe pour le jour julien en float parfois ?
+            f = float(jul)
+            i = int(f)
+            jul = '%s' % i
+            # fin de la passe-passe
+
+            # strange 0 filler
+
+            while len(hhmm) < 4:
+                hhmm = '0' + hhmm
+            while len(jul) < 3:
+                jul = '0' + jul
+
+            # problematic 2400 for 00z
+
+            if hhmm != '2400':
+                emissionStr = year + jul + hhmm
+                timeStruct = time.strptime(emissionStr, '%Y%j%H%M')
+                ddHHMM = time.strftime("%d%H%M", timeStruct)
+                return ddHHMM
+
+            # sometime hhmm is 2400, to avoid exception
+            # set time to 00, increase by 24 hr
+
+            jul00 = year + jul + '0000'
+            timeStruct = time.strptime(jul00, '%Y%j%H%M')
+            ep_emission = time.mktime(timeStruct) + 24 * 60 * 60
+            timeStruct = time.localtime(self.ep_emission)
+            ddHHMM = time.strftime('%d%H%M', timeStruct)
+            return ddHHMM
+        except Exception as e:
+            return None

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -278,6 +278,7 @@ class Am(FlowCB):
         """ Correct the bulletin contents, either of two ways
             1. Add missing AHL headers for CA,MA,RA bulletins
             2. Add missing AHL headers by mapping station codes
+            3. Add an extra line for SM/SI bulletins
         """
 
         # We need to get the BBB from the header, to properly rewrite it.
@@ -323,6 +324,19 @@ class Am(FlowCB):
                     # We found the station. We can leave the loop now.
                     reconstruct = 1
                     break
+
+        # From Sundew ->  https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L114-L115
+        # AddSMHeader is set to True on all operational Sundew configs so no need to add an option
+        if bulletin_firstchars in ["SM", "SI"]:
+
+            logger.debug("Adding missing line in SI/SM bulletin")
+
+            ddhh = lines[0].split(b' ')[2][0:4]
+            line2add = b"AAXX " + ddhh + b"4"
+            lines.insert(1, line2add)
+
+            reconstruct = 1
+
 
         if reconstruct == 1:
             # Reconstruct the bulletin

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -58,9 +58,9 @@ Improvements:
 """
 
 from sarracenia.flowcb import FlowCB
+from sarracenia.bulletin import Bulletin
 import logging
-from base64 import b64decode
-import time, datetime
+import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +70,7 @@ class Raw2bulletin(FlowCB):
         super().__init__(options,logger)
         self.seq = 0
         self.binary = 0
+        self.bulletinHandler = Bulletin()
         # Need to redeclare these options to have their default values be initialized.
         self.o.add_option('inputCharset', 'str', 'utf-8')
         self.o.add_option('binaryInitialCharacters', 'list', [b'BUFR' , b'GRIB', b'\211PNG'])
@@ -83,7 +84,7 @@ class Raw2bulletin(FlowCB):
 
             path = msg['new_dir'] + '/' + msg['new_file']
 
-            data = self.getData(msg, path)
+            data = self.bulletinHandler.getData(msg, path)
 
             # AM bulletins that need their filename rewritten with data should only have two chars before the first underscore
             # This is in concordance with Sundew logic -> https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L70-L71
@@ -103,7 +104,7 @@ class Raw2bulletin(FlowCB):
             first_line  = lines[0].split(' ')
 
             # Build header from bulletin
-            header = self.buildHeader(first_line)
+            header = self.bulletinHandler.buildHeader(first_line)
             if header == None:
                 logger.error("Unable to fetch header contents. Skipping message")
                 worklist.rejected.append(msg)
@@ -111,20 +112,20 @@ class Raw2bulletin(FlowCB):
             
             # Get the station timestamp from bulletin
             if len(header.split('_')) == 2:
-                ddhhmm = self.getTime(data)
+                ddhhmm = self.bulletinHandler.getTime(data)
                 if ddhhmm == None:
                     logger.error("Unable to get julian time.")
             else:
                 ddhhmm = ''
             
             # Get the BBB from bulletin
-            BBB = self.getBBB(first_line)
+            BBB = self.bulletinHandler.getBBB(first_line)
 
             # Get the station ID from bulletin
-            stn_id = self.getStation(data)
+            stn_id = self.bulletinHandler.getStation(data)
 
             # Generate a sequence (random ints)
-            seq = self.getSequence()
+            seq = self.bulletinHandler.getSequence()
 
             # Rename file with data fetched
             try:
@@ -163,224 +164,3 @@ class Raw2bulletin(FlowCB):
                 continue
 
         worklist.incoming = good_msgs
-
-
-    def getData(self, msg, path):
-        """Get the bulletin data.
-           We can either get the bulletin data via
-               1. Sarracenia message content
-               2. Locally downloaded file
-        """
-
-        # Read file data from message or from file path directly if message content not found.
-        # For the binary data, only extract first line (header) as that is all we need. The ascii decoding fails with the rest of the bulletin (usually).
-        try:
-
-            self.binary = 0
-            if msg['content']:
-                data = msg['content']['value']
-
-                # Change from b64. We want to get the header from the raw binary data. Not retrievable in b64 format
-                if msg['content']['encoding'] == 'base64':
-                    data = b64decode(data).splitlines()[0].decode('ascii')
-                    self.binary = 1
-
-            else:
-
-                fp = open(path, 'rb')
-                data = fp.read()
-                fp.close()
-
-                # Decode data, only text. The raw binary data contains the header in which we're interested.
-                # Integrate inputCharset
-                if data.splitlines()[1][:4] not in self.o.binaryInitialCharacters:
-                    data = data.decode(self.o.inputCharset)
-                else:
-                    data = data.splitlines()[0].decode('ascii')
-                    self.binary = 1
-
-
-            return data
-
-        except Exception as e:
-            logger.error(f"Could not fetch file data of from either message content or {path}. Error details: {e}")
-            return None
-
-
-    def getSequence(self):
-        """ sequence number to make the file unique...
-        """
-        self.seq = self.seq + 1
-        if self.seq > 99999:
-            self.seq = 1
-        return str(self.seq).zfill(5)
-
-
-    def getStation(self, data):
-        """Extracted from Sundew code: https://github.com/MetPX/Sundew/blob/main/lib/bulletin.py#L327-L408
-           Get the station ID from the bulletin contents.
-           Examples:
-              CACN00 CWAO -> Station ID located on second line.
-              FTCN32 CWAO -> Station ID located on first line (with header)
-        """
-
-        station = ''
-
-        # There is no station in a binary bulletin
-        if self.binary:
-            return station
-
-        data = data.lstrip('\n')
-        data = data.split('\n')
-
-        try:
-            premiereLignePleine = ""
-            deuxiemeLignePleine = ""
-
-            # special case, need to get the next full line.
-            i = 0
-            for ligne in data[1:]:
-                i += 1
-                premiereLignePleine = ligne
-                if len(premiereLignePleine) > 1:
-                    if len(data) > i+1 : deuxiemeLignePleine = data[i+1]
-                    break
-
-            #print " ********************* header = ", data[0][0:7]
-            # switch depends on bulletin type.
-            if data[0][0:2] == "SA":
-                if data[1].split()[0] in ["METAR","LWIS"]:
-                    station = premiereLignePleine.split()[1]
-                else:
-                    station = premiereLignePleine.split()[0]
-
-            elif data[0][0:2] == "SP":
-                station = premiereLignePleine.split()[1]
-
-            elif data[0][0:2] in ["SI","SM"]:
-                station = premiereLignePleine.split()[0]
-                if station == "AAXX" :
-                    if deuxiemeLignePleine != "" :
-                        station = deuxiemeLignePleine.split()[0]
-                    else :
-                        station = ''
-
-            elif data[0][0:6] in ["SRCN40","SXCN40","SRMT60","SXAK50", "SRND20", "SRND30"]:
-            #elif data[0][0:6] in self.wmo_id:
-                station = premiereLignePleine.split()[0]
-
-            elif data[0][0:2] in ["FC","FT"]:
-                if premiereLignePleine.split()[1] == "AMD":
-                    station = premiereLignePleine.split()[2]
-                else:
-                    station = premiereLignePleine.split()[1]
-
-            elif data[0][0:2] in ["UE","UG","UK","UL","UQ","US"]:
-                parts = premiereLignePleine.split()
-                if parts[0][:2] in ['EE', 'II', 'QQ', 'UU']:
-                    station = parts[1]
-                elif parts[0][:2] in ['PP', 'TT']:
-                    station = parts[2]
-                else:
-                    station = ''
-
-            elif data[0][0:2] in ["RA","MA","CA"]:
-                station = premiereLignePleine.split()[0].split('/')[0]
-            
-        except Exception:
-            station = ''
-        
-        if station != '' :
-            while len(station) > 1 and station[0] == '?' :
-                station = station[1:]
-            if station[0] != '?' :
-                station = station.split('?')[0]
-                if station[-1] == '=' : station = station[:-1]
-            else :
-                station = ''
-
-        return station
-
-
-    def getBBB(self, first_line):
-        """Get the BBB. If none found, return empty string.
-           The BBB is the field of the bulletin header that states if it was amended or not.
-        """
-
-        if len(first_line) != 4: 
-            BBB = ''
-        else:
-            BBB = first_line[3]
-
-        return BBB
-
-    def buildHeader(self, first_line):
-        """ Build header from file contents
-        """
-
-        try:
-            T1T2A1A2ii = first_line[0]
-            CCCC       = first_line[1]
-
-            if len(first_line) >= 3:
-                YYGGgg = first_line[2]
-                header = T1T2A1A2ii + "_" + CCCC + "_" + YYGGgg
-            else:  
-                header = T1T2A1A2ii + "_" + CCCC # + "_" + YYGGgg
-
-        except Exception:
-            header = None
-
-        return header
-
-
-    def getTime(self, data):
-        """ extract time from the data of the ca station
-            the data's first line looks like this : x,yyyy,jul,hhmm,...
-            where x is an integer of no importance, followed by obs'time
-            yyyy = year
-            jul  = julian day
-            hhmm = hour and mins
-        """
-
-        try:
-            parts = data.split(',')
-
-            if len(parts) < 4: return None
-
-            year = parts[1]
-            jul = parts[2]
-            hhmm = parts[3]
-
-            # passe-passe pour le jour julien en float parfois ?
-            f = float(jul)
-            i = int(f)
-            jul = '%s' % i
-            # fin de la passe-passe
-
-            # strange 0 filler
-
-            while len(hhmm) < 4:
-                hhmm = '0' + hhmm
-            while len(jul) < 3:
-                jul = '0' + jul
-
-            # problematic 2400 for 00z
-
-            if hhmm != '2400':
-                emissionStr = year + jul + hhmm
-                timeStruct = time.strptime(emissionStr, '%Y%j%H%M')
-                ddHHMM = time.strftime("%d%H%M", timeStruct)
-                return ddHHMM
-
-            # sometime hhmm is 2400, to avoid exception
-            # set time to 00, increase by 24 hr
-
-            jul00 = year + jul + '0000'
-            timeStruct = time.strptime(jul00, '%Y%j%H%M')
-            ep_emission = time.mktime(timeStruct) + 24 * 60 * 60
-            timeStruct = time.localtime(self.ep_emission)
-            ddHHMM = time.strftime('%d%H%M', timeStruct)
-            return ddHHMM
-        except Exception as e:
-            return None


### PR DESCRIPTION
This PR adds the following.

- Add the missing extra line for SM/SI bulletins (inspired from Sundew source code -> https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L114-L115
- Delegate bulletin parent class to all generalized bulletin methods.
- Use bulletin parent class in AM renamer to get the julian date inside the file contents.

I've been testing on dev and the filenames/file checksums are matching what is already on ncp3/4 for an hours worth of data.