### PR TITLE
Move AM renamer to gather. Allows us to properly use sundew variable expansions.

### DIFF
--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -65,6 +65,7 @@ from base64 import b64encode
 import urllib.parse
 import sarracenia
 from sarracenia.bulletin import Bulletin
+from sarracenia.flowcb.rename.raw2bulletin import Raw2bulletin
 import sarracenia.config
 from sarracenia.flowcb import FlowCB
 from random import randint
@@ -77,6 +78,7 @@ class Am(FlowCB):
         
         super().__init__(options,logger)
         self.bulletinHandler = Bulletin()
+        self.renamer = Raw2bulletin(self.o)
 
         self.url = urllib.parse.urlparse(self.o.sendTo)
 
@@ -464,6 +466,10 @@ class Am(FlowCB):
                     ident.update(bulletin)
                     msg['identity'] = {'method':self.o.identity_method, 'value':ident.value}
 
+                    # Call renamer
+                    msg = self.renamer.rename(msg)
+                    if msg == None:
+                        continue
                     logger.debug(f"New sarracenia message: {msg}")
 
                     newmsg.append(msg)


### PR DESCRIPTION
This should've probably been tested before v3.00.52rc2 but oh well.

I started toying around with [Sundew compatible substitutions](https://metpx.github.io/sarracenia/Reference/sr3_options.7.html#sundew-compatible-substituions) and ran into some problems.

The renamer was getting called via `after_accept` which is wrong since we're doing Sundew substitutions BEFORE calling `after_accept`. With this PR, by moving the renamer before the filtering, we essentially avoid all of the limbo that is required to call the sundew substitutions after the filtering. It makes the whole process easier and makes more sens.