### PR TITLE
Issue953 PRECONDITION_FAILED unknown delivery tag

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -119,6 +119,7 @@ class AMQP(Moth):
                     logger.error(
                         'ignoring message. UTF8 encoding expected. raw message received: %s' % ex)
                     logger.debug('Exception details: ', exc_info=True)
+                    self.channel.basic_ack( raw_msg.delivery_info['delivery_tag'])
                     return None
 
             if 'content_type' in raw_msg.properties:
@@ -129,6 +130,7 @@ class AMQP(Moth):
             msg = PostFormat.importAny( body, raw_msg.headers, content_type, self.o )
             if not msg:
                 logger.error('Decode failed, discarding message')
+                self.channel.basic_ack( raw_msg.delivery_info['delivery_tag'])
                 return None
 
             topic = raw_msg.delivery_info['routing_key'].replace(

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -237,8 +237,8 @@ class AMQP(Moth):
             # check for amqp 1.3.3 and 1.4.9 because connect doesn't exist in those older versions
             self.connection.connect()
 
-        self.channel = self.connection.channel()
-        self.management_channel = self.connection.channel()
+        self.management_channel = self.connection.channel(1)
+        self.channel = self.connection.channel(2)
         return True
 
     def _amqp_setup_signal_handler(self, signum, stack):

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -252,7 +252,7 @@ class AMQP(Moth):
             next_time = self.last_qDeclare + 30
             now=time.time()
             if next_time <= now:
-                self._queueDeclare(passive=True)
+                #self._queueDeclare(passive=True)
                 self.last_qDeclare=now
 
         super().metricsReport()

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1353,7 +1353,7 @@ class sr_GlobalState:
                                     u_url.username, u_url.password, self.options.dry_run )
 
         # declare admin exchanges.
-        if hasattr(self,'default_cfg'):
+        if hasattr(self,'default_cfg') and self.default_cfg.admin:
             logger.info( f"Declaring exchnges for admin.conf using {self.default_cfg.admin} ")
             if hasattr(self.default_cfg, 'declared_exchanges'):
                 xdc = sarracenia.moth.Moth.pubFactory(


### PR DESCRIPTION

The main patch is to comment out the queue declare invocation that implemented the fix for #649.  I do not undestand why declaring a queue on one channel confuses message identifiers on another channel, but so I do not know how to address it.  So I re-opened the old issue.

related stuff I found:

* when some corrupt messages are received, they were being dropped without being acknowledged, added acknowledgement.

* as one attempt to address it, tried specifying channel numbers when they are created.  Made no perceptible difference.

unrelated stuff I found:

* if you do *sr3 declare componenet/config* and there is no admin.conf it bombs with an error about admin.conf url existing.  patch for that.

