### PR TITLE
Change raise_signal to os.kill for #948

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -34,6 +34,7 @@ import sarracenia
 from sarracenia.postformat import PostFormat
 from sarracenia.moth import Moth
 import signal
+import os
 
 import time
 from urllib.parse import unquote
@@ -404,7 +405,7 @@ class AMQP(Moth):
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
         if self.please_stop:
-            signal.raise_signal(signal.SIGINT)
+            os.kill(os.getpid(), signal.SIGINT)
 
     def putSetup(self) -> None:
 
@@ -478,7 +479,7 @@ class AMQP(Moth):
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
         if self.please_stop:
-            signal.raise_signal(signal.SIGINT)
+            os.kill(os.getpid(), signal.SIGINT)
 
 
     def putCleanUp(self) -> None:

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -34,6 +34,7 @@ import sarracenia
 from sarracenia.postformat import PostFormat
 from sarracenia.moth import Moth
 import signal
+import os
 import ssl
 import threading
 import time
@@ -417,7 +418,7 @@ class MQTT(Moth):
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
         if self.please_stop:
-            signal.raise_signal(signal.SIGINT)
+            os.kill(os.getpid(), signal.SIGINT)
 
 
 
@@ -498,7 +499,7 @@ class MQTT(Moth):
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
         if self.please_stop:
-            signal.raise_signal(signal.SIGINT)
+            os.kill(os.getpid(), signal.SIGINT)
 
 
     def __sub_on_message(client, userdata, msg):


### PR DESCRIPTION
Fixes #948, `raise_signal` method doesn't exist on older versions of Python that we still support.