### PR TITLE
Add fix to handle improperly parsed station names from getStation

### DIFF
--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -1,5 +1,6 @@
 import logging
 import time 
+import re
 from base64 import b64decode
 
 logger = logging.getLogger(__name__)
@@ -155,6 +156,11 @@ class Bulletin:
                 station = station.split('?')[0]
                 if station[-1] == '=' : station = station[:-1]
             else :
+                station = ''
+
+            # Added to SR3
+            # The station needs to be alphanumeric, between 3 and 5 characters. If not, don't assign a station
+            if re.search('^[a-zA-Z0-9]{3,5}$', station) == None:
                 station = ''
 
         return station


### PR DESCRIPTION
Spawned from my audit script.

It saw a bulletin , a `UECN99`, crashing sr3 on the new NCP servers. Turns out the `getStation` method inside `sarracenia/bulletin.py` is technically wrong and Sundew has a way of handling these errors better than sr3.

I added a fix where we only want alphanumeric data to pass through for the station (3 to 5 characters). This fixes this issue but its possible that other non-valid alphanumeric stations pass through. Only time will tell.

FYI : The Sundew way of handling the error could not be found.