### PR TITLE
Add missing `tokIsYear` method from Sundew. Prevents some erronous bulletins not being filtered.

### DIFF
--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -266,8 +266,10 @@ class Bulletin:
 
         ltime = time.localtime()
         current_year  = time.strftime("%Y",ltime )
+        previous_year = str(int(current_year) - 1)
 
-        if bulletin_year == current_year    : return True
+        # Prevent all bulletins being rejected on a new year for a couple of minutes. Check for previous year as well
+        if bulletin_year == current_year or bulletin_year == previous_year    : return True
         if len(bulletin_year) !=    4       : return False
         if bulletin_year[:1]  !=  '2'       : return False
 


### PR DESCRIPTION
Before this fix, the try/except inside `getTime` would just fail whenever the julian date couldn't get extracted.

It was discovered through the audit script that there are edge cases where the wrong date won't fail the try/except, so won't be marked as a problem.

Sundew has https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L183 which basically checks if the year is correct or not inside the bulletin data. I added the same thing under the bulletin class so this same problem shouldn't happen again.