### PR TITLE
Housekeeping logging changes

### DIFF
--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -440,7 +440,7 @@ class DiskQueue():
 
         self.msg_count = N
         if N == 0:
-            logger.info("%s No retry in list" % self.name)
+            logger.debug("%s No retry in list" % self.name)
             try:
                 os.unlink(self.housekeeping_path)
             except:

--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -359,7 +359,7 @@ class DiskQueue():
            remove .new
            rename housekeeping to queue for next period.
         """
-        logger.info("%s on_housekeeping" % self.name)
+        logger.debug("%s on_housekeeping" % self.name)
 
         # finish retry before reshuffling all retries entries
 
@@ -440,7 +440,7 @@ class DiskQueue():
 
         self.msg_count = N
         if N == 0:
-            logger.info("No retry in list")
+            logger.info("%s No retry in list" % self.name)
             try:
                 os.unlink(self.housekeeping_path)
             except:
@@ -449,7 +449,7 @@ class DiskQueue():
         # housekeeping file becomes new retry
 
         else:
-            logger.info("Number of messages in retry list %d" % N)
+            logger.info("%s Number of messages in retry list %d" % (self.name, N))
             try:
                 os.rename(self.housekeeping_path, self.queue_file)
             except:
@@ -463,4 +463,4 @@ class DiskQueue():
             pass
 
         elapse = sarracenia.nowflt() - self.now
-        logger.info("on_housekeeping elapse %f" % elapse)
+        logger.debug("on_housekeeping elapse %f" % elapse)

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -329,7 +329,7 @@ class Flow:
         """ Run housekeeping callbacks
             Return the time when housekeeping should be run next
         """
-        logger.info(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
+        logger.debug(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
         self.runCallbacksTime('on_housekeeping')
         self.metricsFlowReset()
         self.metrics['flow']['last_housekeeping'] = now

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -329,7 +329,7 @@ class Flow:
         """ Run housekeeping callbacks
             Return the time when housekeeping should be run next
         """
-        logger.debug(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
+        logger.info(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
         self.runCallbacksTime('on_housekeeping')
         self.metricsFlowReset()
         self.metrics['flow']['last_housekeeping'] = now

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -40,16 +40,14 @@ from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
 from sarracenia.featuredetection import features
 
+logger = logging.getLogger(__name__)
+
 if features['process']['present']:
     import psutil
 else:
     logger.error("missing psutil class cannot monitor process memory usage")
 
-
 import sys
-
-logger = logging.getLogger(__name__)
-
 
 class Resources(FlowCB):
     def __init__(self, options):
@@ -71,8 +69,7 @@ class Resources(FlowCB):
             mem = 0
 
         ost = os.times()
-        logger.info(
-            f"Current Memory cpu_times: user={ost.user} system={ost.system}")
+        logger.info(f"Current cpu_times: user={ost.user} system={ost.system}")
 
         # We must set a threshold **after** the config file has been parsed.
         if self.threshold is None:
@@ -94,9 +91,7 @@ class Resources(FlowCB):
 
                 self.threshold = int(self.o.MemoryMultiplier * mem)
 
-            logger.info(
-                f"Memory threshold set to: {naturalSize(self.threshold)}"
-            )
+            logger.info(f"Memory threshold set to: {naturalSize(self.threshold)}")
 
         logger.info(
             f"Current Memory usage: {naturalSize(mem)} / "

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -35,19 +35,16 @@ Returns:
 import logging
 
 import os
-import psutil
 from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
 from sarracenia.featuredetection import features
 
-logger = logging.getLogger(__name__)
-
 if features['process']['present']:
     import psutil
-else:
-    logger.error("missing psutil class cannot monitor process memory usage")
 
 import sys
+
+logger = logging.getLogger(__name__)
 
 class Resources(FlowCB):
     def __init__(self, options):

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -244,5 +244,5 @@ class Log(FlowCB):
     def on_housekeeping(self):
         if set(['on_housekeeping']) & self.o.logEvents:
             self.stats()
-            logger.info("housekeeping")
+            logger.debug("housekeeping")
         self.__reset()

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -53,12 +53,12 @@ class Message(FlowCB):
     def on_housekeeping(self):
         if hasattr(self,'poster') and self.poster:
             m = self.poster.metricsReport()
-            logger.info(
+            logger.debug(
                 f"messages: good: {m['txGoodCount']} bad: {m['txBadCount']} bytes: {m['txByteCount']}"
             )
             self.poster.metricsReset()
         else:
-            logger.info( "no metrics available" )
+            logger.debug( "no metrics available" )
 
     def on_start(self):
         if hasattr(self,'poster') and self.poster:

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -171,7 +171,7 @@ class Retry(FlowCB):
         self.post_retry.cleanup()
 
     def on_housekeeping(self) -> None:
-        logger.info("on_housekeeping")
+        logger.debug("on_housekeeping")
 
         self.download_retry.on_housekeeping()
         self.post_retry.on_housekeeping()


### PR DESCRIPTION
I'm proposing these changes to reduce the housekeeping logging a bit.

Currently there are ~16 lines logged when housekeeping runs. This is a lot, especially since it runs every 5 minutes for most configs.

v2 logs ~7 lines. 

This change downgrades some INFO messages to DEBUG, reducing sr3 to ~10 lines.

Before: 288 housekeeping runs per day × 16 lines = 4608 housekeeping log lines  
After:  288 housekeeping runs per day × 10 lines = 2880 housekeeping log lines, a 37.% reduction

```
2024-03-15 18:20:20,014 [INFO] sarracenia.flow _runHousekeeping on_housekeeping pid: 32205 sarra/cvt_rawca_to_bulletin instance: 1
2024-03-15 18:20:20,014 [INFO] sarracenia.flowcb.post.message on_housekeeping messages: good: 0 bad: 0 bytes: 0
2024-03-15 18:20:20,015 [INFO] sarracenia.flowcb.gather.message on_housekeeping messages: good: 0 bad: 0 bytes: 0 Bytes average: 0 Bytes
2024-03-15 18:20:20,015 [INFO] sarracenia.flowcb.retry on_housekeeping on_housekeeping              # downgraded to debug
2024-03-15 18:20:20,015 [INFO] sarracenia.diskqueue on_housekeeping work_retry_01 on_housekeeping   # downgraded to debug
2024-03-15 18:20:20,015 [INFO] sarracenia.diskqueue on_housekeeping No retry in list                # added the retry queue name (work_retry_01)
2024-03-15 18:20:20,015 [INFO] sarracenia.diskqueue on_housekeeping on_housekeeping elapse 0.000461 # downgraded to debug
2024-03-15 18:20:20,015 [INFO] sarracenia.diskqueue on_housekeeping post_retry_001 on_housekeeping  # downgraded to debug
2024-03-15 18:20:20,016 [INFO] sarracenia.diskqueue on_housekeeping No retry in list                # added the retry queue name (post_retry_001)
2024-03-15 18:20:20,016 [INFO] sarracenia.diskqueue on_housekeeping on_housekeeping elapse 0.000458 # downgraded to debug
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.housekeeping.resources on_housekeeping Current Memory cpu_times: user=8.73 system=1.8
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.housekeeping.resources on_housekeeping Current Memory usage: 131.0 MiB / 389.4 MiB = 33.63%
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log stats version: 3.00.52rc4, started: 4 hours ago, last_housekeeping: 301.0 seconds ago
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log stats messages received: 0, accepted: 0, rejected: 0   rate accepted: 0.0% or 0.0 m/s
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log stats files transferred: 0 bytes: 0 Bytes rate: 0 Bytes/sec
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log on_housekeeping housekeeping                   # downgraded to debug



2024-03-15 18:20:20,014 [INFO] sarracenia.flow _runHousekeeping on_housekeeping pid: 32205 sarra/cvt_rawca_to_bulletin instance: 1
2024-03-15 18:20:20,014 [INFO] sarracenia.flowcb.post.message on_housekeeping messages: good: 0 bad: 0 bytes: 0
2024-03-15 18:20:20,015 [INFO] sarracenia.flowcb.gather.message on_housekeeping messages: good: 0 bad: 0 bytes: 0 Bytes average: 0 Bytes
2024-03-15 18:20:20,015 [INFO] sarracenia.diskqueue on_housekeeping work_retry_01 No retry in list
2024-03-15 18:20:20,016 [INFO] sarracenia.diskqueue on_housekeeping post_retry_001 No retry in list
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.housekeeping.resources on_housekeeping Current Memory cpu_times: user=8.73 system=1.8
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.housekeeping.resources on_housekeeping Current Memory usage: 131.0 MiB / 389.4 MiB = 33.63%
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log stats version: 3.00.52rc4, started: 4 hours ago, last_housekeeping: 301.0 seconds ago
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log stats messages received: 0, accepted: 0, rejected: 0   rate accepted: 0.0% or 0.0 m/s
2024-03-15 18:20:20,016 [INFO] sarracenia.flowcb.log stats files transferred: 0 bytes: 0 Bytes rate: 0 Bytes/sec
```


.