### PR TITLE
Reject float types for Julian day value in getTime

### DIFF
--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -224,11 +224,10 @@ class Bulletin:
 
             if len(parts) < 4: return None
 
-            # passe-passe pour le jour julien en float parfois ?
-            f = float(jul)
-            i = int(f)
-            jul = '%s' % i
-            # fin de la passe-passe
+            # Julian days shouldn't be float type. Reject them when found. They should only be integers.
+            if '.' in jul:
+                logger.error("Julian days can't be of float type.")
+                return None
 
             # strange 0 filler
 


### PR DESCRIPTION
When Sundew code was ported to sarracenia V2, some analysts added some logic to enable float values for Julian days.

Sundew doesn't allow float values for its Julian days and simply rejects the wrong bulletins.

This will mimic what Sundew already does.
