### PR TITLE
Rename tests to have consistent naming

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -1,4 +1,4 @@
-name: sr_insects Flow Tests.
+name: Flow Tests / AMQP
 
 on:
   pull_request:
@@ -36,7 +36,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    name: ${{ matrix.which_test }} on ${{ matrix.osver }}
     timeout-minutes: 40
     
     steps:

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -1,4 +1,4 @@
-name: sr_insects Flow Tests using AMQP Consumer.
+name: Flow Tests / AMQP Consumer
 
 on:
   pull_request:
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - development
-      - stable
 
     paths-ignore:
       - '.github/**'
@@ -34,7 +33,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    name: ${{ matrix.which_test }} on ${{ matrix.osver }}
     timeout-minutes: 40
     
     steps:

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -1,4 +1,4 @@
-name: Sr3 sr_insects Flow Tests using MQTT.
+name: Flow Tests / MQTT
 
 on:
   pull_request:
@@ -33,7 +33,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    name: ${{ matrix.which_test }} on ${{ matrix.osver }}
     timeout-minutes: 45
     
     steps:

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -1,4 +1,4 @@
-name: Flow Tests (with Redis).
+name: Flow Tests / Redis
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - v03_disabled
+    
     paths-ignore:
       - '.github/**'
       - 'debian/changelog'


### PR DESCRIPTION
| Old | New |
|-----|-------|
| sr_insects Flow Tests | Flow Tests / AMQP |
| sr_insects Flow Tests using AMQP Consumer | Flow Tests / AMQP Consumer |
| Sr3 sr_insects Flow Tests using MQTT | Flow Tests / MQTT |
| Flow Tests (with Redis). | Flow Tests / Redis |

I also removed `test` from the name of each job (e.g. "static_flow on ubuntu-22.04" instead of "static_flow test on ubuntu-22.04") to save a bit more space. (Now that I look at the list, maybe `on` should be changed to `/` too?)

I used `/` as the separator, because that's what GitHub uses to separate in the list (shown below). The list of checks isn't sorted in any obvious way but I think this change still helps organize the tests.