### PR TITLE
Scheduled poll refactor done.

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -1,4 +1,4 @@
-name: sr_insects Flow Tests.
+name: Flow Tests / AMQP
 
 on:
   pull_request:
@@ -36,7 +36,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    name: ${{ matrix.which_test }} on ${{ matrix.osver }}
     timeout-minutes: 40
     
     steps:

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -1,4 +1,4 @@
-name: sr_insects Flow Tests using AMQP Consumer.
+name: Flow Tests / AMQP Consumer
 
 on:
   pull_request:
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - development
-      - stable
 
     paths-ignore:
       - '.github/**'
@@ -34,7 +33,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    name: ${{ matrix.which_test }} on ${{ matrix.osver }}
     timeout-minutes: 40
     
     steps:

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, edited, reopened]
   push:
     branches:
-      - issue_457_amqp_consumer
+      - development
+      - stable
 
     paths-ignore:
       - '.github/**'
@@ -48,7 +49,7 @@ jobs:
           sudo sh -c 'echo "MaxStartups 750" >> /etc/ssh/sshd_config'
           sudo systemctl restart ssh
           echo "amqp_consumer True" >> ${HOME}/.config/sr3/default.conf
-          echo "set sarracenia.moth.amqpconsumer.AMQPConsumer.logLevel debug" >> ${HOME}/.config/sr3/default.conf
+          #echo "set sarracenia.moth.amqpconsumer.AMQPConsumer.logLevel debug" >> ${HOME}/.config/sr3/default.conf
       
       - name: Setup ${{ matrix.which_test }} test.
         run: |

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - development
+      - stable
 
     paths-ignore:
       - '.github/**'

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - development
-      - stable
 
     paths-ignore:
       - '.github/**'

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -1,4 +1,4 @@
-name: Sr3 sr_insects Flow Tests using MQTT.
+name: Flow Tests / MQTT
 
 on:
   pull_request:
@@ -33,7 +33,7 @@ jobs:
 
     runs-on: ${{ matrix.osver }}
   
-    name: ${{ matrix.which_test }} test on ${{ matrix.osver }}
+    name: ${{ matrix.which_test }} on ${{ matrix.osver }}
     timeout-minutes: 45
     
     steps:

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -1,4 +1,4 @@
-name: Flow Tests (with Redis).
+name: Flow Tests / Redis
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - v03_disabled
+    
     paths-ignore:
       - '.github/**'
       - 'debian/changelog'

--- a/docs/source/Explanation/SarraPluginDev.rst
+++ b/docs/source/Explanation/SarraPluginDev.rst
@@ -585,12 +585,17 @@ for detailed information about call signatures and return values, etc...
 |                     | permanent name.                                    |
 |                     |                                                    |
 |                     | return the new name for the downloaded/sent file.  |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 | download(self,msg)  | replace built-in downloader return true on success |
 |                     | takes message as argument.                         |
 +---------------------+----------------------------------------------------+
 | gather(self)        | gather messages from a source, returns a list of   |
 |                     | messages.                                          |
+|                     | can also return a tuple where the first element    |
+|                     | is a boolean flag keep_going indicating whether    |
+|                     | to stop gather processing.                         |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 |                     | Called every housekeeping interval (minutes)       |
 |                     | used to clean cache, check for occasional issues.  |

--- a/docs/source/How2Guides/FlowCallbacks.rst
+++ b/docs/source/How2Guides/FlowCallbacks.rst
@@ -215,7 +215,11 @@ Other entry_points, extracted from sarracenia/flowcb/__init__.py ::
 
 
     def gather(self):
-        Task: gather notification messages from a source... return a list of notification messages.
+        Task: gather notification messages from a source... return either:
+              * a list of notification messages, or
+              * a tuple, (bool:keep_going, list of messages)
+              * to curtail further gathers in this cycle.
+                
         return []
 
     def metrics_report(self) -> dict:

--- a/docs/source/fr/CommentFaire/FlowCallbacks.rst
+++ b/docs/source/fr/CommentFaire/FlowCallbacks.rst
@@ -182,6 +182,8 @@ Autres entry_points, extraits de sarracenia/flowcb/__init__.py ::
 
     def gather(self):
         Task: gather notification messages from a source... return a list of notification messages.
+              can also return tuple (keep_going, new_messages) where keep_going is a flag 
+              that when False stops processing of further gather routines.
         return []
 
     """

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -554,6 +554,10 @@ pour des informations détaillées sur les signatures d’appel et les valeurs d
 +---------------------+----------------------------------------------------+
 | gather(self)        | Rassembler les messages a la source, retourne une  |
 |                     | une liste de messages.                             |
+|                     | on peut également retourner un tuple dont le       |
+|                     | première élément est une valeur booléen keep_going |
+|                     | qui peut arreter l´execution des gather.           |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 |                     | Appelé à chaque intervalle housekeeping (minutes). |
 |                     | utilisé pour nettoyer le cache, vérifier les       |

--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -224,11 +224,10 @@ class Bulletin:
 
             if len(parts) < 4: return None
 
-            # passe-passe pour le jour julien en float parfois ?
-            f = float(jul)
-            i = int(f)
-            jul = '%s' % i
-            # fin de la passe-passe
+            # Julian days shouldn't be float type. Reject them when found. They should only be integers.
+            if '.' in jul:
+                logger.error("Julian days can't be of float type.")
+                return None
 
             # strange 0 filler
 

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1984,6 +1984,11 @@ class Config:
 
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
+        else:
+            if self.sleep > 1:
+                self.scheduled_interval = self.sleep
+                self.sleep=1
+
 
         if self.vip and not features['vip']['present']:
             logger.critical( f"vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )

--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -440,7 +440,7 @@ class DiskQueue():
 
         self.msg_count = N
         if N == 0:
-            logger.info("%s No retry in list" % self.name)
+            logger.debug("%s No retry in list" % self.name)
             try:
                 os.unlink(self.housekeeping_path)
             except:

--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -359,7 +359,7 @@ class DiskQueue():
            remove .new
            rename housekeeping to queue for next period.
         """
-        logger.info("%s on_housekeeping" % self.name)
+        logger.debug("%s on_housekeeping" % self.name)
 
         # finish retry before reshuffling all retries entries
 
@@ -440,7 +440,7 @@ class DiskQueue():
 
         self.msg_count = N
         if N == 0:
-            logger.info("No retry in list")
+            logger.info("%s No retry in list" % self.name)
             try:
                 os.unlink(self.housekeeping_path)
             except:
@@ -449,7 +449,7 @@ class DiskQueue():
         # housekeeping file becomes new retry
 
         else:
-            logger.info("Number of messages in retry list %d" % N)
+            logger.info("%s Number of messages in retry list %d" % (self.name, N))
             try:
                 os.rename(self.housekeeping_path, self.queue_file)
             except:
@@ -463,4 +463,4 @@ class DiskQueue():
             pass
 
         elapse = sarracenia.nowflt() - self.now
-        logger.info("on_housekeeping elapse %f" % elapse)
+        logger.debug("on_housekeeping elapse %f" % elapse)

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1094,6 +1094,7 @@ class Flow:
     def gather(self) -> None:
         so_far=0
         keep_going=True
+        logger.info( f"FIXME: {self.plugins['gather']=} " )
         for p in self.plugins["gather"]:
             try:
                 retval = p(self.o.batch-so_far)
@@ -1117,6 +1118,32 @@ class Flow:
             # if we gathered enough with a subset of plugins then return.
             if not keep_going or so_far >= self.o.batch:
                 return
+
+        # if the last gather (often scheduled) said we should stop, then return.
+        if not keep_going:
+            return
+
+        logger.info("FIXME, ok! run a poll now") 
+
+        # gather is an extended version of poll.
+        if self.o.component != 'poll':
+            return
+
+
+        if len(self.worklist.incoming) > 0:
+            logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
+            self.worklist.poll_catching_up = True
+            return
+        else:
+            self.worklist.poll_catching_up = False
+
+        if self.have_vip:
+            logger.info( f"yup, have vip... FIXME: {self.plugins['poll']=} " )
+            for plugin in self.plugins['poll']:
+                new_incoming = plugin()
+                if len(new_incoming) > 0:
+                    self.worklist.incoming.extend(new_incoming)
+
 
 
     def do(self) -> None:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -329,7 +329,7 @@ class Flow:
         """ Run housekeeping callbacks
             Return the time when housekeeping should be run next
         """
-        logger.info(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
+        logger.debug(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
         self.runCallbacksTime('on_housekeeping')
         self.metricsFlowReset()
         self.metrics['flow']['last_housekeeping'] = now

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1119,10 +1119,6 @@ class Flow:
             if not keep_going or so_far >= self.o.batch:
                 return
 
-        # if the last gather (often scheduled) said we should stop, then return.
-        if not keep_going:
-            return
-
         logger.info("FIXME, ok! run a poll now") 
 
         # gather is an extended version of poll.

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -475,13 +475,6 @@ class Flow:
 
                 logger.critical( f"FIXME back from gather, {len(self.worklist.incoming)=}  ")
 
-                if len(self.worklist.incoming) > 0:
-                    logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
-                    self.worklist.poll_catching_up = True
-                    return
-                else:
-                    self.worklist.poll_catching_up = False
-
                 last_gather_len = len(self.worklist.incoming)
                 if (last_gather_len == 0):
                     spamming = True
@@ -1141,6 +1134,12 @@ class Flow:
         if self.o.component != 'poll':
             return
 
+        if len(self.worklist.incoming) > 0:
+            logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
+            self.worklist.poll_catching_up = True
+            return
+        else:
+            self.worklist.poll_catching_up = False
 
         if self.have_vip:
             logger.info( f"yup, have vip... ok run poll now FIXME: {self.plugins['poll']=} " )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -329,7 +329,7 @@ class Flow:
         """ Run housekeeping callbacks
             Return the time when housekeeping should be run next
         """
-        logger.debug(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
+        logger.info(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
         self.runCallbacksTime('on_housekeeping')
         self.metricsFlowReset()
         self.metrics['flow']['last_housekeeping'] = now

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -66,13 +66,14 @@ class Poll(Flow):
         if not 'scheduled' in ','.join(self.plugins['load']):
             self.plugins['load'].append('sarracenia.flowcb.scheduled.poll.Poll')
 
-        if not 'poll' in ','.join(self.plugins['load']):
+        if not 'flowcb.poll.Poll' in ','.join(self.plugins['load']):
             logger.info( f"adding poll plugin, because missing from: {self.plugins['load']}" ) 
             self.plugins['load'].append('sarracenia.flowcb.poll.Poll')
 
         if options.vip:
             self.plugins['load'].insert( 0, 'sarracenia.flowcb.gather.message.Message')
 
+        self.plugins['load'].insert( 0, 'sarracenia.flowcb.post.message.Message')
 
         if self.o.nodupe_ttl < self.o.fileAgeMax:
             logger.warning( f"nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904")

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -63,16 +63,16 @@ class Poll(Flow):
             else:
                 logger.info( f"Good! post_exchange: {px} and exchange: {self.o.exchange} match so multiple instances to share a poll." )
 
+        if not 'scheduled' in ','.join(self.plugins['load']):
+            self.plugins['load'].append('sarracenia.flowcb.scheduled.Scheduled')
+
         if not 'poll' in ','.join(self.plugins['load']):
             logger.info( f"adding poll plugin, because missing from: {self.plugins['load']}" ) 
             self.plugins['load'].append('sarracenia.flowcb.poll.Poll')
 
         if options.vip:
-            self.plugins['load'].insert(
-                0, 'sarracenia.flowcb.gather.message.Message')
+            self.plugins['load'].insert( 0, 'sarracenia.flowcb.gather.message.Message')
 
-        self.plugins['load'].insert(0,
-                                    'sarracenia.flowcb.post.message.Message')
 
         if self.o.nodupe_ttl < self.o.fileAgeMax:
             logger.warning( f"nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904")
@@ -97,22 +97,3 @@ class Poll(Flow):
         logger.debug('processing %d messages worked! (stop requested: %s)' %
                      (len(self.worklist.incoming), self._stop_requested))
         self.worklist.incoming = []
-
-
-    def gather(self):
-
-        super().gather()
-
-        if len(self.worklist.incoming) > 0:
-            logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
-            self.worklist.poll_catching_up = True
-            return 
-        else:
-            self.worklist.poll_catching_up = False
-
-        if self.have_vip:
-            for plugin in self.plugins['poll']:
-                new_incoming = plugin()
-                if len(new_incoming) > 0:
-                    self.worklist.incoming.extend(new_incoming)
-

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -64,7 +64,7 @@ class Poll(Flow):
                 logger.info( f"Good! post_exchange: {px} and exchange: {self.o.exchange} match so multiple instances to share a poll." )
 
         if not 'scheduled' in ','.join(self.plugins['load']):
-            self.plugins['load'].append('sarracenia.flowcb.scheduled.Scheduled')
+            self.plugins['load'].append('sarracenia.flowcb.scheduled.poll.Poll')
 
         if not 'poll' in ','.join(self.plugins['load']):
             logger.info( f"adding poll plugin, because missing from: {self.plugins['load']}" ) 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -87,10 +87,16 @@ class FlowCB:
               * gather_more ... bool whether to continue gathering 
               * messages ... list of messages 
 
-              in a poll, gather is always called, regardless of vip posession.
-              in all other components, gather is only called when in posession
+              or just return a list of messages.
+
+              In a poll, gather is always called, regardless of vip posession.
+
+              In all other components, gather is only called when in posession
               of the vip.
-        return (True, [])
+
+        return (True, list)
+         OR
+        return list
 
     def after_accept(self,worklist) -> None::
 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -80,14 +80,17 @@ class FlowCB:
 
         Task: acknowledge messages from a gather source.
 
-    def gather(self, messageCountMax) -> list::
+    def gather(self, messageCountMax) -> (gather_more, messages) ::
 
-        Task: gather messages from a source... return a list of messages 
+        Task: gather messages from a source... return a tuple:
+
+              * gather_more ... bool whether to continue gathering 
+              * messages ... list of messages 
 
               in a poll, gather is always called, regardless of vip posession.
               in all other components, gather is only called when in posession
               of the vip.
-        return []
+        return (True, [])
 
     def after_accept(self,worklist) -> None::
 

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -485,4 +485,4 @@ class Am(FlowCB):
                 except Exception as e:
                     logger.error(f"Unable to generate bulletin file. Error message: {e}")
 
-        return newmsg 
+        return (True, newmsg) 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -692,19 +692,19 @@ class File(FlowCB):
         if len(self.queued_messages) > self.o.batch:
             messages = self.queued_messages[0:self.o.batch]
             self.queued_messages = self.queued_messages[self.o.batch:]
-            return messages
+            return (True, messages)
 
         elif len(self.queued_messages) > 0:
             messages = self.queued_messages
             self.queued_messages = []
 
             if self.o.sleep < 0:
-                return messages
+                return (True, messages)
         else:
             messages = []
 
         if self.primed:
-            return self.wakeup()
+            return (True, self.wakeup())
 
         cwd = os.getcwd()
 
@@ -740,4 +740,4 @@ class File(FlowCB):
             messages = messages[0:self.o.batch]
 
         self.primed = True
-        return messages
+        return (True, messages)

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -30,14 +30,16 @@ class Message(FlowCB):
 
     def gather(self, messageCountMax) -> list:
         """
-           return a current list of messages.
+           return:
+              True ... you can gather from other sources. and:
+              a list of messages obtained from this source.
         """
         if hasattr(self,'consumer') and hasattr(self.consumer,'newMessages'):
-            return self.consumer.newMessages()
+            return (True, self.consumer.newMessages())
         else:
             logger.warning( f'not connected. Trying to connect to {self.o.broker}')
             self.consumer = sarracenia.moth.Moth.subFactory(self.od)
-            return []
+            return (True, [])
 
     def ack(self, mlist) -> None:
 

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -39,8 +39,6 @@ from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
 from sarracenia.featuredetection import features
 
-logger = logging.getLogger(__name__)
-
 if features['process']['present']:
     import psutil
 

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -39,6 +39,8 @@ from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
 from sarracenia.featuredetection import features
 
+logger = logging.getLogger(__name__)
+
 if features['process']['present']:
     import psutil
 

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -40,16 +40,14 @@ from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
 from sarracenia.featuredetection import features
 
+logger = logging.getLogger(__name__)
+
 if features['process']['present']:
     import psutil
 else:
     logger.error("missing psutil class cannot monitor process memory usage")
 
-
 import sys
-
-logger = logging.getLogger(__name__)
-
 
 class Resources(FlowCB):
     def __init__(self, options):
@@ -71,8 +69,7 @@ class Resources(FlowCB):
             mem = 0
 
         ost = os.times()
-        logger.info(
-            f"Current Memory cpu_times: user={ost.user} system={ost.system}")
+        logger.info(f"Current cpu_times: user={ost.user} system={ost.system}")
 
         # We must set a threshold **after** the config file has been parsed.
         if self.threshold is None:
@@ -94,9 +91,7 @@ class Resources(FlowCB):
 
                 self.threshold = int(self.o.MemoryMultiplier * mem)
 
-            logger.info(
-                f"Memory threshold set to: {naturalSize(self.threshold)}"
-            )
+            logger.info(f"Memory threshold set to: {naturalSize(self.threshold)}")
 
         logger.info(
             f"Current Memory usage: {naturalSize(mem)} / "

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -35,19 +35,16 @@ Returns:
 import logging
 
 import os
-import psutil
 from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime
 from sarracenia.featuredetection import features
 
-logger = logging.getLogger(__name__)
-
 if features['process']['present']:
     import psutil
-else:
-    logger.error("missing psutil class cannot monitor process memory usage")
 
 import sys
+
+logger = logging.getLogger(__name__)
 
 class Resources(FlowCB):
     def __init__(self, options):

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -64,7 +64,7 @@ class Log(FlowCB):
         if set(['gather']) & self.o.logEvents:
             logger.info( f' messageCountMax: {messageCountMax} ')
 
-        return []
+        return (True, [])
 
     def _messageStr(self, msg):
         if self.o.logMessageDump:

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -244,5 +244,5 @@ class Log(FlowCB):
     def on_housekeeping(self):
         if set(['on_housekeeping']) & self.o.logEvents:
             self.stats()
-            logger.info("housekeeping")
+            logger.debug("housekeeping")
         self.__reset()

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -115,7 +115,6 @@ class Poll(FlowCB):
 
       * options are passed to sarracenia.Transfer classes for their use as well.
 
-
       Poll uses sarracenia.transfer (ftp, sftp, https, etc... )classes to 
       requests lists of files using those protocols using built-in logic.  
 

--- a/sarracenia/flowcb/poll/airnow.py
+++ b/sarracenia/flowcb/poll/airnow.py
@@ -27,7 +27,7 @@ class Airnow(FlowCB):
 
     def poll(self):
 
-        sleep = self.o.sleep
+        sleep = self.o.scheduled_interval
 
         gathered_messages = []
         for Hours in range(1, 3):

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -53,12 +53,12 @@ class Message(FlowCB):
     def on_housekeeping(self):
         if hasattr(self,'poster') and self.poster:
             m = self.poster.metricsReport()
-            logger.info(
+            logger.debug(
                 f"messages: good: {m['txGoodCount']} bad: {m['txBadCount']} bytes: {m['txByteCount']}"
             )
             self.poster.metricsReset()
         else:
-            logger.info( "no metrics available" )
+            logger.debug( "no metrics available" )
 
     def on_start(self):
         if hasattr(self,'poster') and self.poster:

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -84,9 +84,9 @@ class Retry(FlowCB):
 
         """
         if not features['retry']['present'] or not self.o.retry_refilter:
-            return []
+            return (True, [])
 
-        if qty <= 0: return []
+        if qty <= 0: return (True, [])
 
         message_list = self.download_retry.get(qty)
 
@@ -99,7 +99,7 @@ class Retry(FlowCB):
              m['_deleteOnPost'] = set( [ '_isRetry' ] )
 
 
-        return message_list
+        return (True, message_list)
 
 
     def after_accept(self, worklist) -> None:

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -171,7 +171,7 @@ class Retry(FlowCB):
         self.post_retry.cleanup()
 
     def on_housekeeping(self) -> None:
-        logger.info("on_housekeeping")
+        logger.debug("on_housekeeping")
 
         self.download_retry.on_housekeeping()
         self.post_retry.on_housekeeping()

--- a/sarracenia/flowcb/run.py
+++ b/sarracenia/flowcb/run.py
@@ -76,7 +76,7 @@ class Run(FlowCB):
         if hasattr(self.o,
                    'run_gather') and self.o.run_gather is not None:
             self.run_script(self.o.run_gather)
-        return []
+        return (True, [])
 
     def after_accept(self, worklist):
         """

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -93,7 +93,7 @@ class Scheduled(FlowCB):
         self.wait_until_next()
 
         if self.stop_requested or self.housekeeping_needed:
-            return []
+            return (True, [])
 
         logger.info('time to run')
 
@@ -105,7 +105,7 @@ class Scheduled(FlowCB):
             m = sarracenia.Message.fromFileInfo(relPath, self.o, st)
             gathered_messages.append(m)
 
-        return gathered_messages
+        return (True, gathered_messages)
 
     def on_housekeeping(self):
 

--- a/sarracenia/flowcb/scheduled/poll.py
+++ b/sarracenia/flowcb/scheduled/poll.py
@@ -1,0 +1,55 @@
+import logging
+import requests
+import base64
+
+import datetime
+import os
+import sys
+import time
+
+from datetime import date
+
+import sarracenia
+from sarracenia.flowcb.scheduled import Scheduled
+
+logger = logging.getLogger(__name__)
+
+
+
+
+class Poll(Scheduled):
+    """
+      
+    """
+
+    def gather(self,messageCountMax): # placeholder
+        """
+
+           This gather aborts further gathers if the next interval has not yet arrived.
+
+        """
+        logger.info( f"waiting for next poll")
+        self.wait_until_next()
+
+        return  not (self.stop_requested or self.housekeeping_needed), [] 
+
+
+if __name__ == '__main__':
+
+    import sarracenia.config
+    import types
+    import sarracenia.flow
+
+    options = sarracenia.config.default_config()
+    flow = sarracenia.flow.Flow(options)
+    flow.o.scheduled_interval= 5
+    flow.o.pollUrl = "https://dd.weather.gc.ca/bulletins/alphanumeric/"
+    if sys.platform.startswith( "win" ):
+        flow.o.directory = "C:\\temp\poll"
+    else:
+        flow.o.directory = "/tmp/scheduled_poll/${%Y%m%d}"
+    logging.basicConfig(level=logging.DEBUG)
+
+    me = Poll(flow.o)
+    me.gather(flow.o.batch)
+    logger.info("Done")

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -138,7 +138,7 @@ class Wiski(Scheduled):
         self.wait_until_next()
 
         while (1):
-            if self.stop_requested:
+            if self.stop_requested or self.housekeeping_needed:
                 return messages
         
             self.token = self.submit_tokenization_request()

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -139,7 +139,7 @@ class Wiski(Scheduled):
 
         while (1):
             if self.stop_requested or self.housekeeping_needed:
-                return messages
+                return (True, messages)
         
             self.token = self.submit_tokenization_request()
             authenticated_url = self.main_url
@@ -172,7 +172,7 @@ class Wiski(Scheduled):
         for station_id in k.get_station_list().station_id:
 
             if self.stop_requested:
-                return messages
+                return (False, messages)
 
             timeseries = k.get_timeseries_list(station_id = station_id ).ts_id
             #logger.info( f"looping over the timeseries: {timeseries}" )
@@ -197,7 +197,7 @@ class Wiski(Scheduled):
                 f.close() 
                 messages.append( sarracenia.Message.fromFileData( fname, self.o, os.stat(fname) ) )
     
-        return messages
+        return (True, messages)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION

closes #974 

So this implements the refactoring for #974 .

It worries me, in that I'm not sure what side effects the change will have.  @reidsunderland do you have an easy way to test if the queueing thing is fixed by the branch?  The branch is: https://github.com/MetPX/sarracenia/tree/scheduled_poll
The testing in the flow tests is pretty limited, just a straight vanilla SFTP with a short sleep, a VIP and failover.

Things I am wondering about:

* It doesn't do a poll on startup, currently.  it waits for one interval before the first poll.  easy to fix... should we?

* So now in poll, the loop towards the end of the run() routine is only used to sleep for 1 second at a time... and the real waiting 
  is done in the scheduled.poll plugin instead.

  In watch... still using long sleeps in that loop at the end...  Is this an opportunity to simplify sr_watch also... so it also uses the 
  same methods?  Is there an advantage to doing it that way?
 
* I'm wondering if there is a way to have watch use a shared duplicate suppression cache the same way as poll does, populating itself with the output exchange binding queue.  Same benefit as poll, run on two machines with a vip and failover.

* wondering if this change might be an opportunity to simplify sarracenia.flow/__init__.py run() routine.  It feels too complicated.


