### PR TITLE
Issue986 - stop converting *directory* to *path* in poll.

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -934,8 +934,8 @@ POLLING
 
 Polling is doing the same job as a post, except for files on a remote server.
 In the case of a poll, the post will have its url built from the *pollUrl* 
-option, with the product's path (*directory*/"matched file").  There is one 
-post per file.  The file's size is taken from the directory "ls"... but its 
+option, with the product's path (*path*/"matched file").  There is one 
+post per file. The file's size is taken from the directory "ls"... but its 
 checksum cannot be determined, so the default identity method is "cod", asking
 clients to calculate the identity Checksum On Download.
 
@@ -946,11 +946,10 @@ It can be given incomplete if it is well defined in the credentials.conf file.
 Refer to `sr3_post(1) <../Reference/sr3_post.1.html>`_ - to understand the complete notification process.
 Refer to `sr_post(7) <../Reference/sr_post.7.html>`_ - to understand the complete notification format.
 
-
 These options set what files the user wants to be notified for and where
  it will be placed, and under which name.
 
-- **directory <path>           (default: .)**
+- **path <path>           (default: .)**
 - **accept    <regexp pattern> [rename=] (must be set)**
 - **reject    <regexp pattern> (optional)**
 - **permDefault     <integer>        (default: 0o400)**
@@ -959,15 +958,7 @@ These options set what files the user wants to be notified for and where
 nodupe_fileAgeMax should be less than nodupe_ttl when using duplicate suppression,
 to avoid re-ingesting of files that have aged out of the nodupe cache.
 
-The option *filename* can be used to set a global rename to the products.
-Ex.:
-
-**filename  rename=/naefs/grib2/**
-
-For all posts created, the *rename* option would be set to '/naefs/grib2/filename'
-because I specified a directory (path that ends with /).
-
-The option *directory*  defines where to get the files on the server.
+The option *path*  defines where to get the files on the server.
 Combined with  **accept** / **reject**  options, the user can select the
 files of interest and their directories of residence.
 
@@ -975,12 +966,8 @@ The  **accept**  and  **reject**  options use regular expressions (regexp) to ma
 These options are processed sequentially.
 The URL of a file that matches a  **reject**  pattern is not published.
 Files matching an  **accept**  pattern are published.
-Again a *rename*  can be added to the *accept* option... matching products
-for that *accept* option would get renamed as described... unless the *accept* matches
-one file, the *rename* option should describe a directory into which the files
-will be placed (prepending instead of replacing the file name).
 
-The directory can have some patterns. These supported patterns concern date/time .
+The path can have some patterns. These supported patterns concern date/time .
 They are fixed...
 
 **${YYYY}         current year**
@@ -995,14 +982,13 @@ They are fixed...
 
 ::
 
-  ex.   directory /mylocaldirectory/myradars
-        accept    .*RADAR.*
+  ex.   path /mylocaldirectory/myradars
+        path /mylocaldirectory/mygribs
+        path /mylocaldirectory/${YYYYMMDD}/mydailies
 
-        directory /mylocaldirectory/mygribs
+        accept    .*RADAR.*
         reject    .*Reg.*
         accept    .*GRIB.*
-
-        directory /mylocaldirectory/${YYYYMMDD}/mydailies
         accept    .*observations.*
 
 The **permDefault** option allows users to specify a linux-style numeric octal

--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -39,6 +39,14 @@ Installation Instructions
 git
 ---
 
+3.0.53
+------
+
+*CHANGE*: *directory* option in poll will no longer be converted to *path* silently.
+Use *path* explicitly instead. It is still converted when upgrading from v2 with
+*sr3 convert*, but in v3 configurations, *directory* now acts as it does in all other
+components as a download specifier.
+
 3.0.52
 ------
 

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -38,6 +38,15 @@ Instructions d’installation
 git
 ---
 
+3.0.53
+------
+
+*CHANGEMENT* : l'option *directory* dans le sondage ne sera plus convertie en *path* silencieusement.
+Utilisez *path* explicitement à la place. Il est toujours converti lors de la mise à niveau depuis la v2 avec
+*sr3 convert*, mais dans les configurations v3, *directory* agit désormais comme dans tous les autres
+composants comme spécificateur de chemin de destination de téléchargement.
+
+
 3.0.52
 ------
 

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -941,9 +941,9 @@ SONDAGE (POLLING)
 
 On peut faire le même travail que post, sauf que les fichiers sont sur un serveur distant.
 Dans le cas d’un sondage (en anglais: poll), l’URL de la publication sera générée à partir de l´option *pollUrl*,
-avec le chemin d’accès du produit (*directory*/« fichier correspondant »).  Il y en a une publication
+avec le chemin d’accès du produit (*path* « fichier correspondant »).  Il y en a une publication
 par fichier. La taille du fichier est prise dans le répertoire « ls »... mais sa somme
-de contrôle ne peut pas être déterminée, lors la stratégie de calcul de est ¨cod¨ qui signifie
+de contrôle ne peut pas être déterminée, alors la stratégie de calcul de est ¨cod¨ qui signifie
 que ca devrait être calculé lors du transfert.
 
 Par défaut, sr_poll envoie son message de publication au courtier avec l'échange par défaut
@@ -956,7 +956,7 @@ Référez `sr3_post(7) <../Reference/sr3_post.7.html>`_ - pour comprendre le for
 Ces options définissent les fichiers pour lesquels l’utilisateur souhaite être averti et où
  il sera placé, et sous quel nom.
 
-- **directory <path>           (par défaut: .)**
+- **path <path>           (par défaut: .)**
 - **accept    <regexp pattern> [rename=] (doit être défini)**
 - **reject    <regexp pattern> (facultatif)**
 - **permDefault     <integer>        (par défaut: 0o400)**
@@ -965,15 +965,7 @@ Ces options définissent les fichiers pour lesquels l’utilisateur souhaite êt
 fileAgeMax doit être inférieur à nodupe_ttl lors de l'utilisation de la suppression des doublons,
 pour éviter la réingestion de fichiers obsolètes une fois partie du cache nodupe.
 
-L’option *filename* peut être utilisée pour définir un changement de nom global pour les produits.
-Ex.:
-
-**filename  rename=/naefs/grib2/**
-
-Pour tous les messages créés, l’option *rename* serait définie à '/naefs/grib2/filename'
-parce que j’ai spécifié un répertoire (chemin qui se termine par /).
-
-L’option *directory* définit où obtenir les fichiers sur le serveur.
+L’option *path* définit où obtenir les fichiers sur le serveur.
 Combiné avec les options **accept** / **reject**, l’utilisateur peut sélectionner
 les fichiers d’intérêt et leurs répertoires de résidence.
 
@@ -982,10 +974,6 @@ une correspondance avec l’URL.
 Ces options sont traitées séquentiellement.
 L’URL d’un fichier qui correspond à un modèle **reject** n’est pas publiée.
 Les fichiers correspondant à un modèle **accept** sont publiés.
-Encore une fois, un *rename* peut être ajouté à l’option *accept*... les produits qui correspondent
-a l'option *accept* seront renommé comme décrit... à moins que le *accept* corresponde à
-un fichier, l’option *rename* doit décrire un répertoire dans lequel les fichiers
-seront placé (en préfix au lieu de remplacer le nom du fichier).
 
 Le répertoire peut avoir des modèles. Ces modèles pris en charge concernent la date/l’heure.
 Ils sont fixes...
@@ -1002,14 +990,14 @@ Ils sont fixes...
 
 ::
 
-  ex.   directory /mylocaldirectory/myradars
-        accept    .*RADAR.*
+  ex.   path /mylocaldirectory/myradars
+        path /mylocaldirectory/mygribs
+        path /mylocaldirectory/${YYYYMMDD}/mydailies
 
-        directory /mylocaldirectory/mygribs
+
+        accept    .*RADAR.*
         reject    .*Reg.*
         accept    .*GRIB.*
-
-        directory /mylocaldirectory/${YYYYMMDD}/mydailies
         accept    .*observations.*
 
 L’option **permDefault** permet aux utilisateurs de spécifier un masque d'autorisation octal numérique
@@ -1023,10 +1011,9 @@ Les options **permDefault** spécifient un masque, c’est-à-dire que les autor
 au moins ce qui est spécifié.
 
 Comme pour tous les autres composants, l’option **vip** peut être utilisée pour indiquer
-qu’un poll doit être actif sur seulement un seul nœud d’un cluster. Notez que quand
-d’autres nœuds participant au poll et wu’ils n’ont pas le vip, ils
+qu’un poll doit être actif sur seulement un seul nœud d’un cluster. 
 
-les fichiers qui sont plus vieux que fileAgeMax sont ignorés. Cela
+Les fichiers qui sont plus vieux que fileAgeMax sont ignorés. Cela
 peut être modifié à n’importe quelle limite de temps spécifiée dans les configurations en utilisant
 l’option *fileAgeMax <duration>*. Par défaut, dans les composants
 autre que poll, cette option est désactivé en étant défini à zéro (0). Comme il s’agit d’une
@@ -1118,7 +1105,7 @@ informe qu'il y a nouveau produit.
 Le protocle de notification est défini ici `sr3_post(7) <../Reference/sr3_post.7.html>`_
 
 **poll** se connecte à un *broker*.  À toutes les secondes de *sleep*, il se connecte à
-une *pollUrl* (sftp, ftp, ftps). Pour chacun des *directory* définis, les contenus sont listés.
+une *pollUrl* (sftp, ftp, ftps). Pour chacun des *path* définis, les contenus sont listés.
 Le poll est seulement destinée à être utilisée pour les fichiers récemment modifiés.
 L’option *fileAgeMax* élimine les fichiers trop anciens. Lorsqu’un fichier correspondant
 à un modèle donné est trouvé by *accept*, **poll** crée un message de notification pour ce produit.

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1638,6 +1638,9 @@ class Config:
                             logger.error( f'{self.files}:{lineno} invalid entry for {k}:  {i}. Must be one of: {set_choices[k]}' )
 
             elif k in str_options:
+                if ( k == 'directory' ) and not self.download:
+                    logger.info( f"{self.files}:{lineno} if download is false, directory has no effect" )
+
                 v = ' '.join(line[1:])
                 if v == 'None':
                     v=None

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1447,8 +1447,6 @@ class Config:
                     k = 'sendTo'
             elif k == 'broker' and component == 'poll' :
                 k = 'post_broker'
-            elif k == 'directory' and component == 'poll' :
-                k = 'path'
 
             if (k in convert_to_v3): 
                 self.log_flowcb_needed |= '_log' in k

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -422,12 +422,11 @@ class Poll(FlowCB):
         return False, {}, {}
 
     def poll_directory(self, pdir):
+
         #logger.debug("poll_directory %s %s" % (pdir))
-        npost = 0
         msgs = []
 
         # cd to that directory
-
         logger.debug(" cd %s" % pdir)
         ok = self.cd(pdir)
         if not ok: return []
@@ -462,12 +461,6 @@ class Poll(FlowCB):
         return msgs
 
     def poll_file_post(self, desc, destDir, remote_file):
-
-        FileOption = None
-        for mask in self.pulllst:
-            pattern, maskDir, maskFileOption, mask_regexp, accepting, mirror, strip, pstrip, flatten = mask
-            if mask_regexp.match(remote_file) and accepting:
-                FileOption = maskFileOption
 
         path = destDir + '/' + remote_file
 
@@ -539,25 +532,10 @@ class Poll(FlowCB):
 
         # If there is a file operation, and it isn't a rename, then some fields are irrelevant/wrong.
         if 'fileOp' in msg and 'rename' not in msg['fileOp']: 
-            if 'Identity' in msg:
-                del msg['Indentity']
+            if 'identity' in msg:
+                del msg['identity']
             if 'size' in msg:
                 del msg['size']
-
-        this_rename = self.o.rename
-
-        # FIX ME generalized fileOption
-        if FileOption is not None:
-            parts = FileOption.split('=')
-            option = parts[0].strip()
-            if option == 'rename' and len(parts) == 2:
-                this_rename = parts[1].strip()
-
-        if this_rename is not None and this_rename[-1] == '/':
-            this_rename += remote_file
-
-        if this_rename is not None:
-            msg['rename'] = this_rename
 
         return [msg]
 
@@ -582,20 +560,12 @@ class Poll(FlowCB):
 
     def poll(self) -> list:
 
-        # General Attributes
-
-        self.pulllst = []
-
         msgs = []
-        # number of post files
-
-        npost = 0
-
-        # connection did not work
 
         try:
             self.dest.connect()
         except:
+            # connection did not work
             logger.error("sr_poll/post_new_url: unable to connect to %s" %
                          self.o.pollUrl)
             logger.debug('Exception details: ', exc_info=True)
@@ -604,19 +574,7 @@ class Poll(FlowCB):
             time.sleep(nap)
             return []
 
-        # loop on all directories where there are pulls to do
-
         for destDir in self.o.path:
-
-            # setup of poll directory info
-
-            #self.pulllst = self.pulls[destDir]
-
-            #path = destDir
-            #path = path.replace('${', '')
-            #path = path.replace('}', '')
-            #path = path.replace('/', '_')
-            #lsPath = self.o.cfg_run_dir + os.sep + 'ls' + path
 
             currentDir = self.o.variableExpansion(destDir)
 


### PR DESCRIPTION
closes #986 

A year or two ago, in one of the re-factors of poll, *directory* stopped being used,
replaced by path.  but then since v2 uses directory, an automated conversion of *directory* to *path* was added.

That made *directory* essentially the same as a path, but only in the *poll* component.  Path is an upstream thing you are querying in all components.
directory (everywhere except poll) is a directive about what directory to put
files in when transferring... the destination directory.

This PR removes automated conversion of directory to path in poll component,
so that:

* *directory* means the same thing in all components now (and not something different in poll vs. other components.)
* *path* means the same thing in all components (refers to the thing being queried or listed as a source of files.)
* if we start having polls that download, *directory* will be available.
* Add a message notifying when a directory message does not accomplish anything.
* Also... the poll documentation still referred to directory, rather than path...  This change in behaviour is about a year or two old?  I guess it wasn't changed because they were synonyms... but now that they aren't, it is important to align.

Note that sr3 convert still converts v2 *directory* statements into v3 *path* statements... because ... umm that's correct... v2 directories were ... different from v3 ones.
