### PR TITLE
NASA PODAAC checksum change

### DIFF
--- a/sarracenia/flowcb/poll/poll_NASA_CMR.py
+++ b/sarracenia/flowcb/poll/poll_NASA_CMR.py
@@ -340,6 +340,11 @@ class Poll_nasa_cmr(sarracenia.flowcb.FlowCB):
                         sumstr = {"method":"md5", "value":md5}
                     except:
                         logger.warning(f"Could not get MD5 Checksum for {data_url}, posting without it.")
+                        sumstr = {"method":"cod", "value":"md5"}
+                # source is podaac but md5_url isn't available
+                elif self.o.dataSource == "podaac":
+                    # tell downloads to use md5
+                    sumstr = {"method":"cod", "value":"md5"}
 
                 # finally create the message!
                 if data_url:


### PR DESCRIPTION
fix a possible problem found by @andreleblanc11, where a PODAAC sourc…e doesn't have an md5sum when first posted, then the md5sum becomes available later, it will re-post and re-download