### PR TITLE
Issue984 flow run refactor (branches from the other polling PR)

### DIFF
--- a/docs/source/Explanation/SarraPluginDev.rst
+++ b/docs/source/Explanation/SarraPluginDev.rst
@@ -585,12 +585,17 @@ for detailed information about call signatures and return values, etc...
 |                     | permanent name.                                    |
 |                     |                                                    |
 |                     | return the new name for the downloaded/sent file.  |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 | download(self,msg)  | replace built-in downloader return true on success |
 |                     | takes message as argument.                         |
 +---------------------+----------------------------------------------------+
 | gather(self)        | gather messages from a source, returns a list of   |
 |                     | messages.                                          |
+|                     | can also return a tuple where the first element    |
+|                     | is a boolean flag keep_going indicating whether    |
+|                     | to stop gather processing.                         |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 |                     | Called every housekeeping interval (minutes)       |
 |                     | used to clean cache, check for occasional issues.  |

--- a/docs/source/How2Guides/FlowCallbacks.rst
+++ b/docs/source/How2Guides/FlowCallbacks.rst
@@ -215,7 +215,11 @@ Other entry_points, extracted from sarracenia/flowcb/__init__.py ::
 
 
     def gather(self):
-        Task: gather notification messages from a source... return a list of notification messages.
+        Task: gather notification messages from a source... return either:
+              * a list of notification messages, or
+              * a tuple, (bool:keep_going, list of messages)
+              * to curtail further gathers in this cycle.
+                
         return []
 
     def metrics_report(self) -> dict:

--- a/docs/source/fr/CommentFaire/FlowCallbacks.rst
+++ b/docs/source/fr/CommentFaire/FlowCallbacks.rst
@@ -182,6 +182,8 @@ Autres entry_points, extraits de sarracenia/flowcb/__init__.py ::
 
     def gather(self):
         Task: gather notification messages from a source... return a list of notification messages.
+              can also return tuple (keep_going, new_messages) where keep_going is a flag 
+              that when False stops processing of further gather routines.
         return []
 
     """

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -554,6 +554,10 @@ pour des informations détaillées sur les signatures d’appel et les valeurs d
 +---------------------+----------------------------------------------------+
 | gather(self)        | Rassembler les messages a la source, retourne une  |
 |                     | une liste de messages.                             |
+|                     | on peut également retourner un tuple dont le       |
+|                     | première élément est une valeur booléen keep_going |
+|                     | qui peut arreter l´execution des gather.           |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 |                     | Appelé à chaque intervalle housekeeping (minutes). |
 |                     | utilisé pour nettoyer le cache, vérifier les       |

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1984,6 +1984,11 @@ class Config:
 
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
+        else:
+            if self.sleep > 1:
+                self.scheduled_interval = self.sleep
+                self.sleep=1
+
 
         if self.vip and not features['vip']['present']:
             logger.critical( f"vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1094,6 +1094,7 @@ class Flow:
     def gather(self) -> None:
         so_far=0
         keep_going=True
+        logger.info( f"FIXME: {self.plugins['gather']=} " )
         for p in self.plugins["gather"]:
             try:
                 retval = p(self.o.batch-so_far)
@@ -1117,6 +1118,32 @@ class Flow:
             # if we gathered enough with a subset of plugins then return.
             if not keep_going or so_far >= self.o.batch:
                 return
+
+        # if the last gather (often scheduled) said we should stop, then return.
+        if not keep_going:
+            return
+
+        logger.info("FIXME, ok! run a poll now") 
+
+        # gather is an extended version of poll.
+        if self.o.component != 'poll':
+            return
+
+
+        if len(self.worklist.incoming) > 0:
+            logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
+            self.worklist.poll_catching_up = True
+            return
+        else:
+            self.worklist.poll_catching_up = False
+
+        if self.have_vip:
+            logger.info( f"yup, have vip... FIXME: {self.plugins['poll']=} " )
+            for plugin in self.plugins['poll']:
+                new_incoming = plugin()
+                if len(new_incoming) > 0:
+                    self.worklist.incoming.extend(new_incoming)
+
 
 
     def do(self) -> None:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -402,6 +402,27 @@ class Flow:
                         logger.error( f'flowCallback plugin {p}/ack crashed: {ex}' )
                         logger.debug( "details:", exc_info=True )
 
+    def _run_vip_update(self, had_vip) -> bool:
+
+            self.have_vip = self.has_vip()
+            retval=had_vip
+            if (self.o.component == 'poll') and not self.have_vip:
+                if had_vip:
+                    logger.info("now passive on vips %s" % self.o.vip )
+                    with open( self.o.novipFilename, 'w' ) as f:
+                        f.write(str(nowflt()) + '\n' )
+                    retval=False
+            else:
+                if not had_vip:
+                    logger.info("now active on vip %s" % self.have_vip )
+                    retval=True
+                    if os.path.exists( self.o.novipFilename ):
+                        os.unlink( self.o.novipFilename )
+            return retval
+
+
+
+
     def run(self):
         """
           This is the core routine of the algorithm, with most important data driven
@@ -461,7 +482,8 @@ class Flow:
             if now > next_housekeeping or stopping:
                 next_housekeeping = self._runHousekeeping(now)
 
-            self.have_vip = self.has_vip()
+            had_vip = self._run_vip_update(had_vip)
+
             self.worklist.incoming = []
 
             if (self.o.component == 'poll') or self.have_vip:
@@ -487,22 +509,10 @@ class Flow:
                     self.worklist.incoming = []
                     continue
 
-                if (self.o.component == 'poll') and not self.have_vip:
-                    if had_vip:
-                        logger.info("now passive on vips %s" % self.o.vip )
-                        with open( self.o.novipFilename, 'w' ) as f:
-                            f.write(str(nowflt()) + '\n' )
-                        had_vip=False
-                else:
-                    if not had_vip:
-                        logger.info("now active on vip %s" % self.have_vip )
-                        had_vip=True
-                        if os.path.exists( self.o.novipFilename ):
-                            os.unlink( self.o.novipFilename )
 
-                    # normal processing, when you are active.
-                    self.work()
-                    self.post()
+                # normal processing, when you are active.
+                self.work()
+                self.post()
 
             now = nowflt()
             run_time = now - start_time

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1119,10 +1119,6 @@ class Flow:
             if not keep_going or so_far >= self.o.batch:
                 return
 
-        # if the last gather (often scheduled) said we should stop, then return.
-        if not keep_going:
-            return
-
         logger.info("FIXME, ok! run a poll now") 
 
         # gather is an extended version of poll.

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -475,13 +475,6 @@ class Flow:
 
                 logger.critical( f"FIXME back from gather, {len(self.worklist.incoming)=}  ")
 
-                if len(self.worklist.incoming) > 0:
-                    logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
-                    self.worklist.poll_catching_up = True
-                    return
-                else:
-                    self.worklist.poll_catching_up = False
-
                 last_gather_len = len(self.worklist.incoming)
                 if (last_gather_len == 0):
                     spamming = True
@@ -1141,6 +1134,12 @@ class Flow:
         if self.o.component != 'poll':
             return
 
+        if len(self.worklist.incoming) > 0:
+            logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
+            self.worklist.poll_catching_up = True
+            return
+        else:
+            self.worklist.poll_catching_up = False
 
         if self.have_vip:
             logger.info( f"yup, have vip... ok run poll now FIXME: {self.plugins['poll']=} " )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -419,6 +419,7 @@ class Flow:
         current_rate = 0
         total_messages = 1
         start_time = nowflt()
+        now=start_time
         had_vip = False
         current_sleep = self.o.sleep
         last_time = start_time
@@ -459,6 +460,9 @@ class Flow:
                         'starting last pass (without gather) through loop for cleanup.'
                     )
                     stopping = True
+
+            if now > next_housekeeping or stopping:
+                next_housekeeping = self._runHousekeeping(now)
 
             self.have_vip = self.has_vip()
             if (self.o.component == 'poll') or self.have_vip:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -474,8 +474,6 @@ class Flow:
 
                 if not stopping:
                     self.gather()
-                else:
-                    self.worklist.incoming = []
 
                 last_gather_len = len(self.worklist.incoming)
                 if (last_gather_len == 0):
@@ -485,21 +483,6 @@ class Flow:
                     spamming = False
 
                 self.filter()
-                self._runCallbacksWorklist('after_accept')
-
-                logger.debug(
-                        'B filtered incoming: %d, ok: %d (directories: %d), rejected: %d, failed: %d stop_requested: %s have_vip: %s'
-                    % (len(self.worklist.incoming), len(
-                        self.worklist.ok), len(self.worklist.directories_ok),
-                       len(self.worklist.rejected), len(
-                           self.worklist.failed), self._stop_requested,
-                           self.have_vip))
-
-                self.ack(self.worklist.ok)
-                self.worklist.ok = []
-                self.ack(self.worklist.rejected)
-                self.worklist.rejected = []
-                self.ack(self.worklist.failed)
 
                 # this for duplicate cache synchronization.
                 if self.worklist.poll_catching_up:
@@ -521,65 +504,7 @@ class Flow:
                             os.unlink( self.o.novipFilename )
 
                     # normal processing, when you are active.
-                    self.do()
-
-                    # need to acknowledge here, because posting will delete message-id
-                    self.ack(self.worklist.ok)
-                    self.ack(self.worklist.rejected)
-                    self.ack(self.worklist.failed)
-
-                    # adjust message after action is done, but before 'after_work' so adjustment is possible.
-                    for m in self.worklist.ok:
-                        if ('new_baseUrl' in m) and (m['baseUrl'] !=
-                                                     m['new_baseUrl']):
-                            m['old_baseUrl'] = m['baseUrl']
-                            m['_deleteOnPost'] |= set(['old_baseUrl'])
-                            m['baseUrl'] = m['new_baseUrl']
-                        if ('new_retrievePath' in m) :
-                            m['old_retrievePath'] = m['retrievePath']
-                            m['retrievePath'] = m['new_retrievePath']
-                            m['_deleteOnPost'] |= set(['old_retrievePath'])
-
-                        # if new_file does not match relPath, then adjust relPath so it does.
-                        if 'relPath' in m and m['new_file'] != m['relPath'].split('/')[-1]:
-                            if not 'new_relPath' in m:
-                                if len(m['relPath']) > 1:
-                                    m['new_relPath'] = '/'.join( m['relPath'].split('/')[0:-1] + [ m['new_file'] ])
-                                else:
-                                    m['new_relPath'] = m['new_file']
-                            else:
-                                if len(m['new_relPath']) > 1:
-                                    m['new_relPath'] = '/'.join( m['new_relPath'].split('/')[0:-1] + [ m['new_file'] ] )
-                                else:
-                                    m['new_relPath'] = m['new_file']
-
-                        if ('new_relPath' in m) and (m['relPath'] != m['new_relPath']):
-                            m['old_relPath'] = m['relPath']
-                            m['_deleteOnPost'] |= set(['old_relPath'])
-                            m['relPath'] = m['new_relPath']
-                            m['old_subtopic'] = m['subtopic']
-                            m['_deleteOnPost'] |= set(['old_subtopic','subtopic'])
-                            m['subtopic'] = m['new_subtopic']
-
-                        if '_format' in m:
-                            m['old_format'] = m['_format']
-                            m['_deleteOnPost'] |= set(['old_format'])
-                        m['_format'] = m['post_format']
-
-                        # restore adjustment to fileOp
-                        if 'post_fileOp' in m:
-                            m['fileOp'] = m['post_fileOp']
-
-                        if self.o.download and 'retrievePath' in m:
-                            # retrieve paths do not propagate after download.
-                            del m['retrievePath'] 
-
-                        
-                    self._runCallbacksWorklist('after_work')
-
-                    self.ack(self.worklist.rejected)
-                    self.worklist.rejected = []
-                    self.ack(self.worklist.failed)
+                    self.work()
 
                     if len(self.plugins["post"]) > 0:
                         self.post()
@@ -1090,9 +1015,21 @@ class Flow:
                     self.reject(m, 304, "unmatched pattern %s" % url)
 
         self.worklist.incoming = filtered_worklist
-        logger.debug(
-            'end len(incoming)=%d, rejected=%d' %
-            (len(self.worklist.incoming), len(self.worklist.rejected)))
+
+        logger.debug( 'end len(incoming)=%d, rejected=%d' % (len(self.worklist.incoming), len(self.worklist.rejected)))
+
+        self._runCallbacksWorklist('after_accept')
+
+        logger.debug( 'B filtered incoming: %d, ok: %d (directories: %d), rejected: %d, failed: %d stop_requested: %s have_vip: %s'
+            % (len(self.worklist.incoming), len(self.worklist.ok), len(self.worklist.directories_ok),
+               len(self.worklist.rejected), len(self.worklist.failed), self._stop_requested, self.have_vip))
+
+        self.ack(self.worklist.ok)
+        self.worklist.ok = []
+        self.ack(self.worklist.rejected)
+        self.worklist.rejected = []
+        self.ack(self.worklist.failed)
+
 
     def gather(self) -> None:
         so_far=0
@@ -1153,6 +1090,69 @@ class Flow:
             self.worklist.incoming = []
 
         logger.debug('processing %d messages worked!' % len(self.worklist.ok))
+
+    def work(self) -> None:
+
+        self.do()
+
+        # need to acknowledge here, because posting will delete message-id
+        self.ack(self.worklist.ok)
+        self.ack(self.worklist.rejected)
+        self.ack(self.worklist.failed)
+
+        # adjust message after action is done, but before 'after_work' so adjustment is possible.
+        for m in self.worklist.ok:
+            if ('new_baseUrl' in m) and (m['baseUrl'] !=
+                                         m['new_baseUrl']):
+                m['old_baseUrl'] = m['baseUrl']
+                m['_deleteOnPost'] |= set(['old_baseUrl'])
+                m['baseUrl'] = m['new_baseUrl']
+            if ('new_retrievePath' in m) :
+                m['old_retrievePath'] = m['retrievePath']
+                m['retrievePath'] = m['new_retrievePath']
+                m['_deleteOnPost'] |= set(['old_retrievePath'])
+
+            # if new_file does not match relPath, then adjust relPath so it does.
+            if 'relPath' in m and m['new_file'] != m['relPath'].split('/')[-1]:
+                if not 'new_relPath' in m:
+                    if len(m['relPath']) > 1:
+                        m['new_relPath'] = '/'.join( m['relPath'].split('/')[0:-1] + [ m['new_file'] ])
+                    else:
+                        m['new_relPath'] = m['new_file']
+                else:
+                    if len(m['new_relPath']) > 1:
+                        m['new_relPath'] = '/'.join( m['new_relPath'].split('/')[0:-1] + [ m['new_file'] ] )
+                    else:
+                        m['new_relPath'] = m['new_file']
+
+            if ('new_relPath' in m) and (m['relPath'] != m['new_relPath']):
+                m['old_relPath'] = m['relPath']
+                m['_deleteOnPost'] |= set(['old_relPath'])
+                m['relPath'] = m['new_relPath']
+                m['old_subtopic'] = m['subtopic']
+                m['_deleteOnPost'] |= set(['old_subtopic','subtopic'])
+                m['subtopic'] = m['new_subtopic']
+
+            if '_format' in m:
+                m['old_format'] = m['_format']
+                m['_deleteOnPost'] |= set(['old_format'])
+            m['_format'] = m['post_format']
+
+            # restore adjustment to fileOp
+            if 'post_fileOp' in m:
+                m['fileOp'] = m['post_fileOp']
+
+            if self.o.download and 'retrievePath' in m:
+                # retrieve paths do not propagate after download.
+                del m['retrievePath'] 
+
+        self._runCallbacksWorklist('after_work')
+
+        self.ack(self.worklist.rejected)
+        self.worklist.rejected = []
+        self.ack(self.worklist.failed)
+
+
 
     def post(self) -> None:
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -405,22 +405,19 @@ class Flow:
 
     def _run_vip_update(self) -> bool:
 
-            self.have_vip = self.has_vip()
-            if (self.o.component == 'poll') and not self.have_vip:
-                if self.had_vip:
-                    logger.info("now passive on vips %s" % self.o.vip )
-                    with open( self.o.novipFilename, 'w' ) as f:
-                        f.write(str(nowflt()) + '\n' )
-                    self.had_vip=False
-            else:
-                if not self.had_vip:
-                    logger.info("now active on vip %s" % self.have_vip )
-                    self.had_vip=True
-                    if os.path.exists( self.o.novipFilename ):
-                        os.unlink( self.o.novipFilename )
-
-
-
+        self.have_vip = self.has_vip()
+        if (self.o.component == 'poll') and not self.have_vip:
+            if self.had_vip:
+                logger.info("now passive on vips %s" % self.o.vip )
+                with open( self.o.novipFilename, 'w' ) as f:
+                    f.write(str(nowflt()) + '\n' )
+                self.had_vip=False
+        else:
+            if not self.had_vip:
+                logger.info("now active on vip %s" % self.have_vip )
+                self.had_vip=True
+                if os.path.exists( self.o.novipFilename ):
+                    os.unlink( self.o.novipFilename )
 
     def run(self):
         """

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -66,13 +66,14 @@ class Poll(Flow):
         if not 'scheduled' in ','.join(self.plugins['load']):
             self.plugins['load'].append('sarracenia.flowcb.scheduled.poll.Poll')
 
-        if not 'poll' in ','.join(self.plugins['load']):
+        if not 'flowcb.poll.Poll' in ','.join(self.plugins['load']):
             logger.info( f"adding poll plugin, because missing from: {self.plugins['load']}" ) 
             self.plugins['load'].append('sarracenia.flowcb.poll.Poll')
 
         if options.vip:
             self.plugins['load'].insert( 0, 'sarracenia.flowcb.gather.message.Message')
 
+        self.plugins['load'].insert( 0, 'sarracenia.flowcb.post.message.Message')
 
         if self.o.nodupe_ttl < self.o.fileAgeMax:
             logger.warning( f"nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904")

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -63,16 +63,16 @@ class Poll(Flow):
             else:
                 logger.info( f"Good! post_exchange: {px} and exchange: {self.o.exchange} match so multiple instances to share a poll." )
 
+        if not 'scheduled' in ','.join(self.plugins['load']):
+            self.plugins['load'].append('sarracenia.flowcb.scheduled.Scheduled')
+
         if not 'poll' in ','.join(self.plugins['load']):
             logger.info( f"adding poll plugin, because missing from: {self.plugins['load']}" ) 
             self.plugins['load'].append('sarracenia.flowcb.poll.Poll')
 
         if options.vip:
-            self.plugins['load'].insert(
-                0, 'sarracenia.flowcb.gather.message.Message')
+            self.plugins['load'].insert( 0, 'sarracenia.flowcb.gather.message.Message')
 
-        self.plugins['load'].insert(0,
-                                    'sarracenia.flowcb.post.message.Message')
 
         if self.o.nodupe_ttl < self.o.fileAgeMax:
             logger.warning( f"nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904")
@@ -97,22 +97,3 @@ class Poll(Flow):
         logger.debug('processing %d messages worked! (stop requested: %s)' %
                      (len(self.worklist.incoming), self._stop_requested))
         self.worklist.incoming = []
-
-
-    def gather(self):
-
-        super().gather()
-
-        if len(self.worklist.incoming) > 0:
-            logger.info('ingesting %d postings into duplicate suppression cache' % len(self.worklist.incoming) )
-            self.worklist.poll_catching_up = True
-            return 
-        else:
-            self.worklist.poll_catching_up = False
-
-        if self.have_vip:
-            for plugin in self.plugins['poll']:
-                new_incoming = plugin()
-                if len(new_incoming) > 0:
-                    self.worklist.incoming.extend(new_incoming)
-

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -64,7 +64,7 @@ class Poll(Flow):
                 logger.info( f"Good! post_exchange: {px} and exchange: {self.o.exchange} match so multiple instances to share a poll." )
 
         if not 'scheduled' in ','.join(self.plugins['load']):
-            self.plugins['load'].append('sarracenia.flowcb.scheduled.Scheduled')
+            self.plugins['load'].append('sarracenia.flowcb.scheduled.poll.Poll')
 
         if not 'poll' in ','.join(self.plugins['load']):
             logger.info( f"adding poll plugin, because missing from: {self.plugins['load']}" ) 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -87,10 +87,16 @@ class FlowCB:
               * gather_more ... bool whether to continue gathering 
               * messages ... list of messages 
 
-              in a poll, gather is always called, regardless of vip posession.
-              in all other components, gather is only called when in posession
+              or just return a list of messages.
+
+              In a poll, gather is always called, regardless of vip posession.
+
+              In all other components, gather is only called when in posession
               of the vip.
-        return (True, [])
+
+        return (True, list)
+         OR
+        return list
 
     def after_accept(self,worklist) -> None::
 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -80,14 +80,17 @@ class FlowCB:
 
         Task: acknowledge messages from a gather source.
 
-    def gather(self, messageCountMax) -> list::
+    def gather(self, messageCountMax) -> (gather_more, messages) ::
 
-        Task: gather messages from a source... return a list of messages 
+        Task: gather messages from a source... return a tuple:
+
+              * gather_more ... bool whether to continue gathering 
+              * messages ... list of messages 
 
               in a poll, gather is always called, regardless of vip posession.
               in all other components, gather is only called when in posession
               of the vip.
-        return []
+        return (True, [])
 
     def after_accept(self,worklist) -> None::
 

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -485,4 +485,4 @@ class Am(FlowCB):
                 except Exception as e:
                     logger.error(f"Unable to generate bulletin file. Error message: {e}")
 
-        return newmsg 
+        return (True, newmsg) 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -692,19 +692,19 @@ class File(FlowCB):
         if len(self.queued_messages) > self.o.batch:
             messages = self.queued_messages[0:self.o.batch]
             self.queued_messages = self.queued_messages[self.o.batch:]
-            return messages
+            return (True, messages)
 
         elif len(self.queued_messages) > 0:
             messages = self.queued_messages
             self.queued_messages = []
 
             if self.o.sleep < 0:
-                return messages
+                return (True, messages)
         else:
             messages = []
 
         if self.primed:
-            return self.wakeup()
+            return (True, self.wakeup())
 
         cwd = os.getcwd()
 
@@ -740,4 +740,4 @@ class File(FlowCB):
             messages = messages[0:self.o.batch]
 
         self.primed = True
-        return messages
+        return (True, messages)

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -30,14 +30,16 @@ class Message(FlowCB):
 
     def gather(self, messageCountMax) -> list:
         """
-           return a current list of messages.
+           return:
+              True ... you can gather from other sources. and:
+              a list of messages obtained from this source.
         """
         if hasattr(self,'consumer') and hasattr(self.consumer,'newMessages'):
-            return self.consumer.newMessages()
+            return (True, self.consumer.newMessages())
         else:
             logger.warning( f'not connected. Trying to connect to {self.o.broker}')
             self.consumer = sarracenia.moth.Moth.subFactory(self.od)
-            return []
+            return (True, [])
 
     def ack(self, mlist) -> None:
 

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -64,7 +64,7 @@ class Log(FlowCB):
         if set(['gather']) & self.o.logEvents:
             logger.info( f' messageCountMax: {messageCountMax} ')
 
-        return []
+        return (True, [])
 
     def _messageStr(self, msg):
         if self.o.logMessageDump:

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -115,7 +115,6 @@ class Poll(FlowCB):
 
       * options are passed to sarracenia.Transfer classes for their use as well.
 
-
       Poll uses sarracenia.transfer (ftp, sftp, https, etc... )classes to 
       requests lists of files using those protocols using built-in logic.  
 

--- a/sarracenia/flowcb/poll/airnow.py
+++ b/sarracenia/flowcb/poll/airnow.py
@@ -27,7 +27,7 @@ class Airnow(FlowCB):
 
     def poll(self):
 
-        sleep = self.o.sleep
+        sleep = self.o.scheduled_interval
 
         gathered_messages = []
         for Hours in range(1, 3):

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -84,9 +84,9 @@ class Retry(FlowCB):
 
         """
         if not features['retry']['present'] or not self.o.retry_refilter:
-            return []
+            return (True, [])
 
-        if qty <= 0: return []
+        if qty <= 0: return (True, [])
 
         message_list = self.download_retry.get(qty)
 
@@ -99,7 +99,7 @@ class Retry(FlowCB):
              m['_deleteOnPost'] = set( [ '_isRetry' ] )
 
 
-        return message_list
+        return (True, message_list)
 
 
     def after_accept(self, worklist) -> None:

--- a/sarracenia/flowcb/run.py
+++ b/sarracenia/flowcb/run.py
@@ -76,7 +76,7 @@ class Run(FlowCB):
         if hasattr(self.o,
                    'run_gather') and self.o.run_gather is not None:
             self.run_script(self.o.run_gather)
-        return []
+        return (True, [])
 
     def after_accept(self, worklist):
         """

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -184,7 +184,7 @@ class Scheduled(FlowCB):
 
             if next_appointment is None:
                 # done for the day...
-                tomorrow = datetime.date.today()+datetime.timedelta(days=1)
+                tomorrow = datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)+datetime.timedelta(days=1)
                 midnight = datetime.time(0,0,tzinfo=datetime.timezone.utc)
                 midnight = datetime.datetime.combine(tomorrow,midnight)
                 self.update_appointments(midnight)

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -93,7 +93,7 @@ class Scheduled(FlowCB):
         self.wait_until_next()
 
         if self.stop_requested or self.housekeeping_needed:
-            return []
+            return (True, [])
 
         logger.info('time to run')
 
@@ -105,7 +105,7 @@ class Scheduled(FlowCB):
             m = sarracenia.Message.fromFileInfo(relPath, self.o, st)
             gathered_messages.append(m)
 
-        return gathered_messages
+        return (True, gathered_messages)
 
     def on_housekeeping(self):
 

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -177,10 +177,18 @@ class Scheduled(FlowCB):
         if ( len(self.o.scheduled_hour) > 0 ) or ( len(self.o.scheduled_minute) > 0 ):
             now = datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
             next_appointment=None
+            missed_appointments=[]
             for t in self.appointments: 
                 if now < t: 
                     next_appointment=t
                     break
+                else:
+                    logger.info( f'already too late to {t} skipping' )
+                    missed_appointments.append(t)
+
+            if missed_appointments:
+                for ma in missed_appointments:
+                    self.appointments.remove(ma)
 
             if next_appointment is None:
                 # done for the day...

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -86,6 +86,7 @@ class Scheduled(FlowCB):
 
         now=datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
         self.update_appointments(now)
+        self.first_interval=True
 
     def gather(self,messageCountMax):
 
@@ -166,6 +167,10 @@ class Scheduled(FlowCB):
     def wait_until_next( self ):
 
         if self.o.scheduled_interval > 0:
+            if self.first_interval:
+                self.first_interval=False
+                return
+
             self.wait_seconds(datetime.timedelta(seconds=self.o.scheduled_interval))
             return
 

--- a/sarracenia/flowcb/scheduled/poll.py
+++ b/sarracenia/flowcb/scheduled/poll.py
@@ -1,0 +1,55 @@
+import logging
+import requests
+import base64
+
+import datetime
+import os
+import sys
+import time
+
+from datetime import date
+
+import sarracenia
+from sarracenia.flowcb.scheduled import Scheduled
+
+logger = logging.getLogger(__name__)
+
+
+
+
+class Poll(Scheduled):
+    """
+      
+    """
+
+    def gather(self,messageCountMax): # placeholder
+        """
+
+           This gather aborts further gathers if the next interval has not yet arrived.
+
+        """
+        logger.info( f"waiting for next poll")
+        self.wait_until_next()
+
+        return  not (self.stop_requested or self.housekeeping_needed), [] 
+
+
+if __name__ == '__main__':
+
+    import sarracenia.config
+    import types
+    import sarracenia.flow
+
+    options = sarracenia.config.default_config()
+    flow = sarracenia.flow.Flow(options)
+    flow.o.scheduled_interval= 5
+    flow.o.pollUrl = "https://dd.weather.gc.ca/bulletins/alphanumeric/"
+    if sys.platform.startswith( "win" ):
+        flow.o.directory = "C:\\temp\poll"
+    else:
+        flow.o.directory = "/tmp/scheduled_poll/${%Y%m%d}"
+    logging.basicConfig(level=logging.DEBUG)
+
+    me = Poll(flow.o)
+    me.gather(flow.o.batch)
+    logger.info("Done")

--- a/sarracenia/flowcb/scheduled/poll.py
+++ b/sarracenia/flowcb/scheduled/poll.py
@@ -52,4 +52,6 @@ if __name__ == '__main__':
 
     me = Poll(flow.o)
     me.gather(flow.o.batch)
-    logger.info("Done")
+    logger.info("first done")
+    me.gather(flow.o.batch)
+    logger.info("Second Done")

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -138,7 +138,7 @@ class Wiski(Scheduled):
         self.wait_until_next()
 
         while (1):
-            if self.stop_requested:
+            if self.stop_requested or self.housekeeping_needed:
                 return messages
         
             self.token = self.submit_tokenization_request()

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -139,7 +139,7 @@ class Wiski(Scheduled):
 
         while (1):
             if self.stop_requested or self.housekeeping_needed:
-                return messages
+                return (True, messages)
         
             self.token = self.submit_tokenization_request()
             authenticated_url = self.main_url
@@ -172,7 +172,7 @@ class Wiski(Scheduled):
         for station_id in k.get_station_list().station_id:
 
             if self.stop_requested:
-                return messages
+                return (False, messages)
 
             timeseries = k.get_timeseries_list(station_id = station_id ).ts_id
             #logger.info( f"looping over the timeseries: {timeseries}" )
@@ -197,7 +197,7 @@ class Wiski(Scheduled):
                 f.close() 
                 messages.append( sarracenia.Message.fromFileData( fname, self.o, os.stat(fname) ) )
     
-        return messages
+        return (True, messages)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION

poll can now run download like all the other components... kind of a happy side effect of just refactoring the code to make it easier to understand.

builds on https://github.com/MetPX/sarracenia/pull/985

The run() routine is 288 lines ... it is too long to think about.  Refactored code chunks into separate routines
just to shorten the code in run()  The code didn't change much at all, it is just re-arranged.
Moved:
* took all the message reformatting, callback invocation and worklist acknowledgements around the do() routing and created
  a work() function as a wrapper for it.
* similarly moved the callback invocation and ack and worklist changes and from run() to the end of the filter() function.
* did similar thing for the post() routine moving stuff from run() into post.
* made a _run_vip_update routine outside of run() but called from it.
  * now could move *on_start* callback invocation so that run_vip_update() is called from a single place.

run() is now 159 lines.  Changes in behaviour:

* when poll has the vip it calls do(), so similar to all other components it can do a download in a single component if desired.
* now novipfile management done in one place, also calls to housekeeping processing reduced from 2 to 1.

This PR includes the PR it is based on since that one isn't merged yet... will see how it goes if the other one gets merged first.
