### PR TITLE
Issue974 yet another scheduled_poll refactor PR

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -935,17 +935,28 @@ POLLING
 Polling is doing the same job as a post, except for files on a remote server.
 In the case of a poll, the post will have its url built from the *pollUrl* 
 option, with the product's path (*directory*/"matched file").  There is one 
-post per file.  The file's size is taken from the directory "ls"... but its 
+post per file. The file's size is taken from the directory "ls"... but its 
 checksum cannot be determined, so the default identity method is "cod", asking
 clients to calculate the identity Checksum On Download.
 
+To set when to poll, use the *scheduled_interval* or *scheduled_hour* and *scheduled_minute*
+settings. for example::
+
+   scheduled_interval 30m
+
+to poll the remote resources every thirty minutes. Alternatively::
+
+   scheduled_hour 1,13,19
+   scheduled_minute 27
+
+specifies that poll be run at 1:27, 13:27, and 19:27 each day.
+ 
 By default, sr_poll sends its post notification message to the broker with default exchange
 (the prefix *xs_* followed by the broker username). The *post_broker* is mandatory.
 It can be given incomplete if it is well defined in the credentials.conf file.
 
 Refer to `sr3_post(1) <../Reference/sr3_post.1.html>`_ - to understand the complete notification process.
 Refer to `sr_post(7) <../Reference/sr_post.7.html>`_ - to understand the complete notification format.
-
 
 These options set what files the user wants to be notified for and where
  it will be placed, and under which name.
@@ -1115,7 +1126,8 @@ notify about the new product.
 
 The notification protocol is defined here `sr_post(7) <../Reference/sr_post.7.html>`_
 
-**poll** connects to a *broker*.  Every *sleep* seconds, it connects to
+**poll** connects to a *broker*.  Every *scheduled_interval* seconds (or can used
+combination of *scheduled_hour* and *scheduled_minute*) , it connects to
 a *pollUrl* (sftp, ftp, ftps). For each of the *directory* defined, it lists
 the contents.  Polling is only intended to be used for recently modified
 files. The *fileAgeMax* option eliminates files that are too old 

--- a/docs/source/Explanation/SarraPluginDev.rst
+++ b/docs/source/Explanation/SarraPluginDev.rst
@@ -585,12 +585,17 @@ for detailed information about call signatures and return values, etc...
 |                     | permanent name.                                    |
 |                     |                                                    |
 |                     | return the new name for the downloaded/sent file.  |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 | download(self,msg)  | replace built-in downloader return true on success |
 |                     | takes message as argument.                         |
 +---------------------+----------------------------------------------------+
 | gather(self)        | gather messages from a source, returns a list of   |
 |                     | messages.                                          |
+|                     | can also return a tuple where the first element    |
+|                     | is a boolean flag keep_going indicating whether    |
+|                     | to stop gather processing.                         |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 |                     | Called every housekeeping interval (minutes)       |
 |                     | used to clean cache, check for occasional issues.  |

--- a/docs/source/How2Guides/Email_Ingesting_With_Sarracenia.rst
+++ b/docs/source/How2Guides/Email_Ingesting_With_Sarracenia.rst
@@ -50,7 +50,7 @@ What did we get?::
    post_broker amqp://tsource@${FLOWBROKER}
    post_exchange xs_tsource
    
-   sleep 60
+   scheduled_interval 60
    
    pollUrl <scheme>://<user>@<host>:<port>/
    

--- a/docs/source/How2Guides/FlowCallbacks.rst
+++ b/docs/source/How2Guides/FlowCallbacks.rst
@@ -215,7 +215,11 @@ Other entry_points, extracted from sarracenia/flowcb/__init__.py ::
 
 
     def gather(self):
-        Task: gather notification messages from a source... return a list of notification messages.
+        Task: gather notification messages from a source... return either:
+              * a list of notification messages, or
+              * a tuple, (bool:keep_going, list of messages)
+              * to curtail further gathers in this cycle.
+                
         return []
 
     def metrics_report(self) -> dict:

--- a/docs/source/How2Guides/Hydro_Examples.rst
+++ b/docs/source/How2Guides/Hydro_Examples.rst
@@ -40,7 +40,7 @@ station observations and predictions data through a GET RESTful web service, ava
 and Currents website <https://tidesandcurrents.noaa.gov/api/>`_. For example, if you want to access the 
 water temperature data from the last hour in Honolulu, you can navigate to `https://tidesandcurrents.noaa.gov/api/datagetter?range=1&station=1612340&product=water_temperature&units=metric&time_zone=gmt&application=web_services&format=csv`.
 A new observation gets recorded every six minutes, so if you wanted to advertise solely new data through
-Sarracenia, you would configure an sr_poll instance to connect to the API, sleep every hour, and build
+Sarracenia, you would configure an sr_poll instance to connect to the API, set a one hour *scheduled_interval* , and build
 it a GET request to announce every time it woke up (this operates under the potentially misguided assumption 
 that the data source is maintaining their end of the bargain). To download this shiny new file, you would connect
 an sr_subscribe to the same exchange it got announced on, and it would retrieve the URL, which a *do_download*

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1578,6 +1578,25 @@ sanity_log_dead <interval> (default: 1.5*housekeeping)
 The **sanity_log_dead** option sets how long to consider too long before restarting
 a component.
 
+scheduled_interval,scheduled_hour,scheduled_minute
+--------------------------------------------------
+
+When working with scheduled flows, such as polls, one can configure a duration
+(no units defaults to seconds, suffixes: m-minute, h-hour) at which to run a 
+given activity::
+
+  scheduled_interval 30
+
+run the flow or poll every 30 seconds.  If no duration is set, then the 
+flowcb.scheduled.Scheduled class will look for the other two time specifiers::
+
+  scheduled_hour 1,4,5,23
+  scheduled_minute 14,17,29
+
+
+which will have the poll run each day at: 01:14, 01:17, 01:29, then the same minutes
+after each of 4h, 5h and 23h.
+
 
 shim_defer_posting_to_exit (EXPERIMENTAL)
 -----------------------------------------
@@ -1613,10 +1632,13 @@ shim_skip_parent_open_files (EXPERIMENTAL)
 sleep <time>
 ------------
 
-The time to wait between generating events.  When files are written frequently, it is counter productive
+The time to wait between generating events. When files are written frequently, it is counter productive
 to produce a post for every change, as it can produce a continuous stream of changes where the transfers
-cannot be done quickly enough to keep up.  In such circumstances, one can group all changes made to a file
+cannot be done quickly enough to keep up. In such circumstances, one can group all changes made to a file
 in *sleep* time, and produce a single post.
+
+When sleep is set > 0 for use with a *poll* it has the effect to setting *scheduled_interval*  to that value
+for compatibility reasons.  It is better for poll to use *scheduled* settings explicitly going forward.
 
 statehost <False|True> ( default: False )
 -----------------------------------------

--- a/docs/source/fr/CommentFaire/FlowCallbacks.rst
+++ b/docs/source/fr/CommentFaire/FlowCallbacks.rst
@@ -182,6 +182,8 @@ Autres entry_points, extraits de sarracenia/flowcb/__init__.py ::
 
     def gather(self):
         Task: gather notification messages from a source... return a list of notification messages.
+              can also return tuple (keep_going, new_messages) where keep_going is a flag 
+              that when False stops processing of further gather routines.
         return []
 
     """

--- a/docs/source/fr/CommentFaire/Ingestion_de_email_avec_Sarracenia.rst
+++ b/docs/source/fr/CommentFaire/Ingestion_de_email_avec_Sarracenia.rst
@@ -50,7 +50,7 @@ Qu’avons-nous obtenu?::
    post_broker amqp://tsource@${FLOWBROKER}
    post_exchange xs_tsource
    
-   sleep 60
+   scheduled_interval 60
    
    pollUrl <scheme>://<user>@<host>:<port>/
    

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -946,6 +946,17 @@ par fichier. La taille du fichier est prise dans le répertoire « ls »... mais
 de contrôle ne peut pas être déterminée, lors la stratégie de calcul de est ¨cod¨ qui signifie
 que ca devrait être calculé lors du transfert.
 
+Pour définir la fréquence de sondage, on se sert de *scheduled_*, tel que::
+
+    scheduled_interal 30m
+
+pour sonder à toute les trente minutes, ou bien::
+
+    scheduled_hour 1,13,19
+    scheduled_minute 27
+
+pour sonder trois fois par jour à 1h27, 13h27 et 19h27.
+    
 Par défaut, sr_poll envoie son message de publication au courtier avec l'échange par défaut
 (le préfixe *xs_* suivi du nom d’utilisateur du courtier). Le *post_broker* est obligatoire.
 Il peut être incomplet s’il est bien défini dans le fichier credentials.conf.
@@ -1117,7 +1128,7 @@ informe qu'il y a nouveau produit.
 
 Le protocle de notification est défini ici `sr3_post(7) <../Reference/sr3_post.7.html>`_
 
-**poll** se connecte à un *broker*.  À toutes les secondes de *sleep*, il se connecte à
+**poll** se connecte à un *broker*. À toutes les secondes de *scheduled_interval* (où bien à des moment spécifié par *scheduled_hour* et *scheduled_minute*), il se connecte à
 une *pollUrl* (sftp, ftp, ftps). Pour chacun des *directory* définis, les contenus sont listés.
 Le poll est seulement destinée à être utilisée pour les fichiers récemment modifiés.
 L’option *fileAgeMax* élimine les fichiers trop anciens. Lorsqu’un fichier correspondant

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -554,6 +554,10 @@ pour des informations détaillées sur les signatures d’appel et les valeurs d
 +---------------------+----------------------------------------------------+
 | gather(self)        | Rassembler les messages a la source, retourne une  |
 |                     | une liste de messages.                             |
+|                     | on peut également retourner un tuple dont le       |
+|                     | première élément est une valeur booléen keep_going |
+|                     | qui peut arreter l´execution des gather.           |
+|                     |                                                    |
 +---------------------+----------------------------------------------------+
 |                     | Appelé à chaque intervalle housekeeping (minutes). |
 |                     | utilisé pour nettoyer le cache, vérifier les       |

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1551,6 +1551,25 @@ sanity_log_dead <interva;le> (défaut: 1.5*housekeeping)
 
 L’option **sanity_log_dead** définit la durée à prendre en compte avant de redémarrer un composant.
 
+scheduled_interval,scheduled_hour,scheduled_minute
+--------------------------------------------------
+
+Lorsque vous travaillez avec des flux cédulés, tels que des sondages, vous pouvez configurer une durée
+(unité: seconde par défaut, suffixes : m-minute, h-heure) à laquelle exécuter un
+sondage devrait être lancer::
+
+  scheduled_interval 30
+
+Ceci partirai le flux ou sondage toutes les 30 secondes. Si aucune *scheduled_interval* n'est 
+définie, alors La classe flowcb.scheduled.Scheduled recherchera les deux autres 
+spécificateurs de temps ::
+
+  scheduled_hour 1,4,5,23
+  scheduled_minute 14,17,29
+
+afin de specifier de partir un sondage chaque jour à: 01h14, 01h17, 01h29, puis les mêmes minutes
+après chacune des 4h, 5h et 23h.
+
 shim_defer_posting_to_exit (EXPERIMENTAL)
 -----------------------------------------
 
@@ -1587,6 +1606,11 @@ Temps d’attente entre la génération d’événements. Lorsqu'on écrit fréq
 de produire un poste pour chaque changement, car il peut produire un flux continu de changements où les transferts
 ne peut pas être fait assez rapidement pour suivre le rythme.  Dans de telles circonstances, on peut regrouper toutes
 les modifications apportées à un fichier pendant le temps de *sleep*, et produire un seul poste.
+
+Lorsque *sleep* est donné une valeur >0 pour être utilisé avec un *poll*, cela a pour effet de 
+définir *scheduled_interval*, pour des raisons de compatibilité. 
+Il est préférable que le sondage utilise explicitement les paramètres  *scheduled_interval*,
+*scheduled_hour*, et/ou *scheduled_minute* plutôt que *sleep*.
 
 statehost <booléen> ( défaut: False )
 -------------------------------------

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -322,9 +322,9 @@ r"""
 
 
 def isTrue(S):
-    s = S.lower()
-    if s == 'true' or s == 'yes' or s == 'on' or s == '1': return True
-    return False
+    if type(S) is list:
+        S = S[-1]
+    return S.lower() in ['true', 'yes', 'on', '1']
 
 
 def get_package_lib_dir():

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1982,9 +1982,10 @@ class Config:
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
         else:
-            if self.sleep > 1:
-                self.scheduled_interval = self.sleep
-                self.sleep=1
+            if not (hasattr(self,'scheduled_interval') or hasattr(self,'scheduled_hour') or hasattr(self,'scheduled_minute')):
+                if self.sleep > 1:
+                    self.scheduled_interval = self.sleep
+                    self.sleep=1
 
 
         if self.vip and not features['vip']['present']:

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -152,7 +152,7 @@ list_options = [ 'path', 'vip' ]
 set_options = [ 'logEvents', 'fileEvents' ]
 
 set_choices = { 
-    'logEvents' : sarracenia.flowcb.entry_points + [ 'reject' ],
+    'logEvents' : set(sarracenia.flowcb.entry_points + [ 'reject' ]),
     'fileEvents' : set( [ 'create', 'delete', 'link', 'mkdir', 'modify', 'rmdir' ] )
  }
 # FIXME: doesn't work... wonder why?
@@ -1039,8 +1039,6 @@ class Config:
                     sv= old_value | sv
                 elif op == '-' :
                     sv= old_value - sv
-                else:
-                    sv=set([v])
         return sv
 
     def add_option(self, option, kind='list', default_value=None, all_values=None ):

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1984,6 +1984,11 @@ class Config:
 
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
+        else:
+            if self.sleep > 1:
+                self.scheduled_interval = self.sleep
+                self.sleep=1
+
 
         if self.vip and not features['vip']['present']:
             logger.critical( f"vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1010,6 +1010,39 @@ class Config:
         w = 'with ' if fn or flatten or strip else ''
         return f'{s} {pattern} into {maskDir} {w}mirror:{mirror}{strip}{flatten}{fn}'
 
+    def _parse_set_string( self, v:str, old_value: set ) -> set:
+        """
+           given a set string, return a python set.
+        """
+        sv=set()
+        if type(v) is list:
+            sv=set(v)
+        elif type(v) is set:
+            sv=v
+        elif type(v) is str:
+            v=v.replace('|',',')
+            if v == 'None': 
+                sv=set([])
+            else:
+                if v[0] in [ '+', '-']:
+                    op=v[0]
+                    v=v[1:]
+                else:
+                    op='r'
+
+                if ',' in v: 
+                    sv=set(v.split(','))
+                else: 
+                    sv=set([v])
+
+                if op == '+':
+                    sv= old_value | sv
+                elif op == '-' :
+                    sv= old_value - sv
+                else:
+                    sv=set([v])
+        return sv
+
     def add_option(self, option, kind='list', default_value=None, all_values=None ):
         r"""
            options can be declared in any plugin. There are various *kind* of options, where the declared type modifies the parsing.
@@ -1080,32 +1113,7 @@ class Config:
                 setattr(self, option, octal_number(int(v,base=8)))
         elif kind == 'set':  
             set_options.append(option)
-            sv=set()
-            if type(v) is list:
-                sv=set(v)
-            elif type(v) is set:
-                sv=v
-            elif type(v) is str:
-                if v == 'None': 
-                    sv=set([])
-                else:
-                    if v[0] in [ '+', '-']:
-                        op=v[0]
-                        v=v[1:]
-                    else:
-                        op='r'
-
-                    if ',' in v: 
-                        sv=set(v[1:].split(','))
-                    else: 
-                        sv=set([v[1:]])
-
-                    if op == '+':
-                        sv= getattr(self,option) | sv
-                    elif op == '-' :
-                        sv= getattr(self,option) - sv
-                    else:
-                        sv=set([v])
+            sv = self._parse_set_string(v,set())
             setattr(self, option, sv)
             if all_values:
                 set_choices[option] = all_values
@@ -1617,25 +1625,13 @@ class Config:
                         setattr(self,k,set_choices[k])
                     continue
                 v=v.replace('|',',')
-                if v[0] in ['-','+']:
-                    op=v[0]
-                    v=v[1:]
-                else:
-                    op='r'
-
-                if op == '+':
-                    vs = getattr(self,k) | set(v.split(','))
-                elif op == '-':
-                    vs = getattr(self,k) - set(v.split(','))
-                else:
-                    vs = set( v.split(',') )
-
+                vs = self._parse_set_string(v,getattr(self,k))
                 setattr(self, k, vs )
 
                 if k in set_choices :
                     for i in getattr(self,k):
                         if i not in set_choices[k]:
-                            logger.error( f'{self.files}:{lineno} invalid entry for {k}:  {i}. Must be one of: {set_choices[k]}' )
+                            logger.error( f'{self.files}:{lineno} invalid entry {i} in {k}. Must be one of: {set_choices[k]}' )
 
             elif k in str_options:
                 if ( k == 'directory' ) and not self.download:
@@ -2002,6 +1998,28 @@ class Config:
         for f,l,u in self.undeclared:
             if u not in alloptions:
                 logger.error( f"{f}:{l} undeclared option: {u}")
+            elif u in flag_options:
+                if type( getattr(self,u) ) is not bool:
+                    setattr(self,u,isTrue(getattr(self,u)))
+            elif u in float_options:
+                if type( getattr(self,u) ) is not float:
+                    setattr(self,u,float(getattr(self,u)))
+            elif u in set_options:
+                if type( getattr(self,u) ) is not set:
+                    setattr(self,u,self._parse_set_string(getattr(self,u),set()))
+            elif u in str_options:
+                if type( getattr(self,u) ) is not str:
+                    setattr(self,u,str(getattr(self,u)))
+            elif u in count_options:
+                if type( getattr(self,u) ) not in [ int, float ]:
+                    setattr(self,u,humanfriendly.parse_size(getattr(self,u)))
+            elif u in size_options:
+                if type( getattr(self,u) ) not in [ int, float ]:
+                    setattr(self,u,humanfriendly.parse_size(getattr(self,u)))
+            elif u in duration_options:
+                if type( getattr(self,u) ) not in [ int, float ]:
+                    setattr(self,u,durationToSeconds(getattr(self,u)))
+            # list options are the default, so no need to regularize
 
         no_defaults=set()
         for u in alloptions:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -211,7 +211,7 @@ class Flow:
 
         # metrics - dictionary with names of plugins as the keys
         self.metricsFlowReset()
-        self.had_vip = False
+        self.had_vip = True
 
     def metricsFlowReset(self) -> None:
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -451,22 +451,19 @@ class Flow:
             if self._stop_requested:
                 if stopping:
                     logger.info('clean stop from run loop')
-
                     self.close()
                     break
                 else:
-                    logger.info(
-                        'starting last pass (without gather) through loop for cleanup.'
-                    )
+                    logger.info( 'starting last pass (without gather) through loop for cleanup.')
                     stopping = True
 
             self.have_vip = self.has_vip()
+            self.worklist.incoming = []
+
             if (self.o.component == 'poll') or self.have_vip:
 
                 if ( self.o.messageRateMax > 0 ) and (current_rate > 0.8*self.o.messageRateMax ):
                     logger.info("current_rate (%.2f) vs. messageRateMax(%.2f)) " % (current_rate, self.o.messageRateMax))
-
-                self.worklist.incoming = []
 
                 if not stopping:
                     self.gather()
@@ -501,39 +498,7 @@ class Flow:
 
                     # normal processing, when you are active.
                     self.work()
-
-                    if len(self.plugins["post"]) > 0:
-                        self.post()
-                        self._runCallbacksWorklist('after_post')
-
-                    self._runCallbacksWorklist('report')
-                    self._runCallbackMetrics()
-
-                    if hasattr(self.o, 'metricsFilename' ) and os.path.isdir(os.path.dirname(self.o.metricsFilename)):
-                        metrics=json.dumps(self.metrics)
-                        with open(self.o.metricsFilename, 'w') as mfn:
-                             mfn.write(metrics+"\n")
-                        if self.o.logMetrics:
-                            if self.o.logRotateInterval >= 24*60*60:
-                                tslen=8
-                            elif self.o.logRotateInterval > 60:
-                                tslen=14
-                            else:
-                                tslen=16
-                            timestamp=time.strftime("%Y%m%d-%H%M%S", time.gmtime())
-                            with open(self.o.metricsFilename + '.' + timestamp[0:tslen], 'a') as mfn:
-                                mfn.write( f'\"{timestamp}\" : {metrics},\n')
-
-                            # removing old metrics files
-                            logger.info( f"looking for old metrics for {self.o.metricsFilename}" )
-                            old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
-                            for o in old_metrics:
-                                logger.info( f"removing old metrics file: {o} " )
-                                os.unlink(o)
-
-                    self.worklist.ok = []
-                    self.worklist.directories_ok = []
-                    self.worklist.failed = []
+                    self.post()
 
             now = nowflt()
             run_time = now - start_time
@@ -1152,19 +1117,51 @@ class Flow:
 
     def post(self) -> None:
 
-        # work-around for python3.5 not being able to copy re.match issue: 
-        # https://github.com/MetPX/sarracenia/issues/857 
-        if sys.version_info.major == 3 and sys.version_info.minor <= 6:
-            for m in self.worklist.ok:
-                if '_matches' in m:
-                    del m['_matches']
+        if len(self.plugins["post"]) > 0:
 
-        for p in self.plugins["post"]:
-            try:
-                p(self.worklist)
-            except Exception as ex:
-                logger.error( f'flowCallback plugin {p} crashed: {ex}' )
-                logger.debug( "details:", exc_info=True )
+            # work-around for python3.5 not being able to copy re.match issue: 
+            # https://github.com/MetPX/sarracenia/issues/857 
+            if sys.version_info.major == 3 and sys.version_info.minor <= 6:
+                for m in self.worklist.ok:
+                    if '_matches' in m:
+                        del m['_matches']
+
+            for p in self.plugins["post"]:
+                try:
+                    p(self.worklist)
+                except Exception as ex:
+                    logger.error( f'flowCallback plugin {p} crashed: {ex}' )
+                    logger.debug( "details:", exc_info=True )
+
+        self._runCallbacksWorklist('after_post')
+        self._runCallbacksWorklist('report')
+        self._runCallbackMetrics()
+
+        if hasattr(self.o, 'metricsFilename' ) and os.path.isdir(os.path.dirname(self.o.metricsFilename)):
+            metrics=json.dumps(self.metrics)
+            with open(self.o.metricsFilename, 'w') as mfn:
+                 mfn.write(metrics+"\n")
+            if self.o.logMetrics:
+                if self.o.logRotateInterval >= 24*60*60:
+                    tslen=8
+                elif self.o.logRotateInterval > 60:
+                    tslen=14
+                else:
+                    tslen=16
+                timestamp=time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+                with open(self.o.metricsFilename + '.' + timestamp[0:tslen], 'a') as mfn:
+                    mfn.write( f'\"{timestamp}\" : {metrics},\n')
+
+                # removing old metrics files
+                logger.info( f"looking for old metrics for {self.o.metricsFilename}" )
+                old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
+                for o in old_metrics:
+                    logger.info( f"removing old metrics file: {o} " )
+                    os.unlink(o)
+
+        self.worklist.ok = []
+        self.worklist.directories_ok = []
+        self.worklist.failed = []
 
     def write_inline_file(self, msg) -> bool:
         """

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -495,11 +495,10 @@ class Flow:
                 if self.worklist.poll_catching_up:
                     self.ack(self.worklist.incoming)
                     self.worklist.incoming = []
-                    continue
 
-                # normal processing, when you are active.
-                self.work()
-                self.post()
+                else: # normal processing, when you are active.
+                    self.work()
+                    self.post()
 
             now = nowflt()
             run_time = now - start_time

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -405,22 +405,19 @@ class Flow:
 
     def _run_vip_update(self) -> bool:
 
-            self.have_vip = self.has_vip()
-            if (self.o.component == 'poll') and not self.have_vip:
-                if self.had_vip:
-                    logger.info("now passive on vips %s" % self.o.vip )
-                    with open( self.o.novipFilename, 'w' ) as f:
-                        f.write(str(nowflt()) + '\n' )
-                    self.had_vip=False
-            else:
-                if not self.had_vip:
-                    logger.info("now active on vip %s" % self.have_vip )
-                    self.had_vip=True
-                    if os.path.exists( self.o.novipFilename ):
-                        os.unlink( self.o.novipFilename )
-
-
-
+        self.have_vip = self.has_vip()
+        if (self.o.component == 'poll') and not self.have_vip:
+            if self.had_vip:
+                logger.info("now passive on vips %s" % self.o.vip )
+                with open( self.o.novipFilename, 'w' ) as f:
+                    f.write(str(nowflt()) + '\n' )
+                self.had_vip=False
+        else:
+            if not self.had_vip:
+                logger.info("now active on vip %s" % self.have_vip )
+                self.had_vip=True
+                if os.path.exists( self.o.novipFilename ):
+                    os.unlink( self.o.novipFilename )
 
     def run(self):
         """

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -211,6 +211,7 @@ class Flow:
 
         # metrics - dictionary with names of plugins as the keys
         self.metricsFlowReset()
+        self.had_vip = False
 
     def metricsFlowReset(self) -> None:
 
@@ -402,23 +403,21 @@ class Flow:
                         logger.error( f'flowCallback plugin {p}/ack crashed: {ex}' )
                         logger.debug( "details:", exc_info=True )
 
-    def _run_vip_update(self, had_vip) -> bool:
+    def _run_vip_update(self) -> bool:
 
             self.have_vip = self.has_vip()
-            retval=had_vip
             if (self.o.component == 'poll') and not self.have_vip:
-                if had_vip:
+                if self.had_vip:
                     logger.info("now passive on vips %s" % self.o.vip )
                     with open( self.o.novipFilename, 'w' ) as f:
                         f.write(str(nowflt()) + '\n' )
-                    retval=False
+                    self.had_vip=False
             else:
-                if not had_vip:
+                if not self.had_vip:
                     logger.info("now active on vip %s" % self.have_vip )
-                    retval=True
+                    self.had_vip=True
                     if os.path.exists( self.o.novipFilename ):
                         os.unlink( self.o.novipFilename )
-            return retval
 
 
 
@@ -440,7 +439,7 @@ class Flow:
         current_rate = 0
         total_messages = 1
         start_time = nowflt()
-        had_vip = False
+        now=start_time
         current_sleep = self.o.sleep
         last_time = start_time
         self.metrics['flow']['last_housekeeping'] = start_time
@@ -453,15 +452,6 @@ class Flow:
         logger.info(
             f'pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}'
         )
-        if not self.has_vip():
-            logger.info( f'starting up passive, as do not possess any vip from: {self.o.vip}' )
-            with open( self.o.novipFilename, 'w' ) as f:
-                f.write(str(start_time) + '\n' )
-        else:
-            if os.path.exists( self.o.novipFilename ):
-                os.unlink( self.o.novipFilename )
-
-        self.runCallbacksTime(f'on_start')
 
         spamming = True
         last_gather_len = 0
@@ -478,10 +468,12 @@ class Flow:
                     logger.info( 'starting last pass (without gather) through loop for cleanup.')
                     stopping = True
 
+            self._run_vip_update()
+
             if now > next_housekeeping or stopping:
                 next_housekeeping = self._runHousekeeping(now)
-
-            had_vip = self._run_vip_update(had_vip)
+            elif now == start_time:
+                self.runCallbacksTime(f'on_start')
 
             self.worklist.incoming = []
 
@@ -507,7 +499,6 @@ class Flow:
                     self.ack(self.worklist.incoming)
                     self.worklist.incoming = []
                     continue
-
 
                 # normal processing, when you are active.
                 self.work()

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -81,20 +81,3 @@ class Poll(Flow):
         if not features['ftppoll']['present']:
             if hasattr( self.o, 'pollUrl' ) and ( self.o.pollUrl.startswith('ftp') ):
                 logger.critical( f"attempting to configure an FTP poll pollUrl={self.o.pollUrl}, but missing python modules: {' '.join(features['ftppoll']['modules_needed'])}" )
-
-    def do(self):
-        """
-            stub to do the work: does nothing, marking everything done.
-            to be replaced in child classes that do transforms or transfers.
-        """
-
-        # mark all remaining messages as rejected.
-        if self.worklist.poll_catching_up:
-            # in catchup mode, just reading previously posted messages.
-            self.worklist.rejected = self.worklist.incoming
-        else:
-            self.worklist.ok = self.worklist.incoming
-
-        logger.debug('processing %d messages worked! (stop requested: %s)' %
-                     (len(self.worklist.incoming), self._stop_requested))
-        self.worklist.incoming = []

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -31,7 +31,6 @@ default_options = {
     'timeCopy': True,
     'randomize': False,
     'post_on_start': False,
-    'sleep': -1,
     'nodupe_ttl': 7 * 60 * 60,
     'fileAgeMax': 30 * 24 * 60 * 60,
 }

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -87,10 +87,16 @@ class FlowCB:
               * gather_more ... bool whether to continue gathering 
               * messages ... list of messages 
 
-              in a poll, gather is always called, regardless of vip posession.
-              in all other components, gather is only called when in posession
+              or just return a list of messages.
+
+              In a poll, gather is always called, regardless of vip posession.
+
+              In all other components, gather is only called when in posession
               of the vip.
-        return (True, [])
+
+        return (True, list)
+         OR
+        return list
 
     def after_accept(self,worklist) -> None::
 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -80,14 +80,17 @@ class FlowCB:
 
         Task: acknowledge messages from a gather source.
 
-    def gather(self, messageCountMax) -> list::
+    def gather(self, messageCountMax) -> (gather_more, messages) ::
 
-        Task: gather messages from a source... return a list of messages 
+        Task: gather messages from a source... return a tuple:
+
+              * gather_more ... bool whether to continue gathering 
+              * messages ... list of messages 
 
               in a poll, gather is always called, regardless of vip posession.
               in all other components, gather is only called when in posession
               of the vip.
-        return []
+        return (True, [])
 
     def after_accept(self,worklist) -> None::
 

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -485,4 +485,4 @@ class Am(FlowCB):
                 except Exception as e:
                     logger.error(f"Unable to generate bulletin file. Error message: {e}")
 
-        return newmsg 
+        return (True, newmsg) 

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -692,19 +692,19 @@ class File(FlowCB):
         if len(self.queued_messages) > self.o.batch:
             messages = self.queued_messages[0:self.o.batch]
             self.queued_messages = self.queued_messages[self.o.batch:]
-            return messages
+            return (True, messages)
 
         elif len(self.queued_messages) > 0:
             messages = self.queued_messages
             self.queued_messages = []
 
             if self.o.sleep < 0:
-                return messages
+                return (True, messages)
         else:
             messages = []
 
         if self.primed:
-            return self.wakeup()
+            return (True, self.wakeup())
 
         cwd = os.getcwd()
 
@@ -740,4 +740,4 @@ class File(FlowCB):
             messages = messages[0:self.o.batch]
 
         self.primed = True
-        return messages
+        return (True, messages)

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -30,14 +30,16 @@ class Message(FlowCB):
 
     def gather(self, messageCountMax) -> list:
         """
-           return a current list of messages.
+           return:
+              True ... you can gather from other sources. and:
+              a list of messages obtained from this source.
         """
         if hasattr(self,'consumer') and hasattr(self.consumer,'newMessages'):
-            return self.consumer.newMessages()
+            return (True, self.consumer.newMessages())
         else:
             logger.warning( f'not connected. Trying to connect to {self.o.broker}')
             self.consumer = sarracenia.moth.Moth.subFactory(self.od)
-            return []
+            return (True, [])
 
     def ack(self, mlist) -> None:
 

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -64,7 +64,7 @@ class Log(FlowCB):
         if set(['gather']) & self.o.logEvents:
             logger.info( f' messageCountMax: {messageCountMax} ')
 
-        return []
+        return (True, [])
 
     def _messageStr(self, msg):
         if self.o.logMessageDump:

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -115,7 +115,6 @@ class Poll(FlowCB):
 
       * options are passed to sarracenia.Transfer classes for their use as well.
 
-
       Poll uses sarracenia.transfer (ftp, sftp, https, etc... )classes to 
       requests lists of files using those protocols using built-in logic.  
 

--- a/sarracenia/flowcb/poll/airnow.py
+++ b/sarracenia/flowcb/poll/airnow.py
@@ -27,7 +27,7 @@ class Airnow(FlowCB):
 
     def poll(self):
 
-        sleep = self.o.sleep
+        sleep = self.o.scheduled_interval
 
         gathered_messages = []
         for Hours in range(1, 3):

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -84,9 +84,9 @@ class Retry(FlowCB):
 
         """
         if not features['retry']['present'] or not self.o.retry_refilter:
-            return []
+            return (True, [])
 
-        if qty <= 0: return []
+        if qty <= 0: return (True, [])
 
         message_list = self.download_retry.get(qty)
 
@@ -99,7 +99,7 @@ class Retry(FlowCB):
              m['_deleteOnPost'] = set( [ '_isRetry' ] )
 
 
-        return message_list
+        return (True, message_list)
 
 
     def after_accept(self, worklist) -> None:

--- a/sarracenia/flowcb/run.py
+++ b/sarracenia/flowcb/run.py
@@ -76,7 +76,7 @@ class Run(FlowCB):
         if hasattr(self.o,
                    'run_gather') and self.o.run_gather is not None:
             self.run_script(self.o.run_gather)
-        return []
+        return (True, [])
 
     def after_accept(self, worklist):
         """

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -184,7 +184,7 @@ class Scheduled(FlowCB):
 
             if next_appointment is None:
                 # done for the day...
-                tomorrow = datetime.date.today()+datetime.timedelta(days=1)
+                tomorrow = datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)+datetime.timedelta(days=1)
                 midnight = datetime.time(0,0,tzinfo=datetime.timezone.utc)
                 midnight = datetime.datetime.combine(tomorrow,midnight)
                 self.update_appointments(midnight)

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -93,7 +93,7 @@ class Scheduled(FlowCB):
         self.wait_until_next()
 
         if self.stop_requested or self.housekeeping_needed:
-            return []
+            return (True, [])
 
         logger.info('time to run')
 
@@ -105,7 +105,7 @@ class Scheduled(FlowCB):
             m = sarracenia.Message.fromFileInfo(relPath, self.o, st)
             gathered_messages.append(m)
 
-        return gathered_messages
+        return (True, gathered_messages)
 
     def on_housekeeping(self):
 

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -100,7 +100,7 @@ class Scheduled(FlowCB):
         self.wait_until_next()
 
         if self.stop_requested or self.housekeeping_needed:
-            return (True, [])
+            return (False, [])
 
         logger.info('time to run')
 

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -177,10 +177,18 @@ class Scheduled(FlowCB):
         if ( len(self.o.scheduled_hour) > 0 ) or ( len(self.o.scheduled_minute) > 0 ):
             now = datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
             next_appointment=None
+            missed_appointments=[]
             for t in self.appointments: 
                 if now < t: 
                     next_appointment=t
                     break
+                else:
+                    logger.info( f'already too late to {t} skipping' )
+                    missed_appointments.append(t)
+
+            if missed_appointments:
+                for ma in missed_appointments:
+                    self.appointments.remove(ma)
 
             if next_appointment is None:
                 # done for the day...

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -86,6 +86,7 @@ class Scheduled(FlowCB):
 
         now=datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
         self.update_appointments(now)
+        self.first_interval=True
 
     def gather(self,messageCountMax):
 
@@ -166,6 +167,10 @@ class Scheduled(FlowCB):
     def wait_until_next( self ):
 
         if self.o.scheduled_interval > 0:
+            if self.first_interval:
+                self.first_interval=False
+                return
+
             self.wait_seconds(datetime.timedelta(seconds=self.o.scheduled_interval))
             return
 

--- a/sarracenia/flowcb/scheduled/poll.py
+++ b/sarracenia/flowcb/scheduled/poll.py
@@ -1,0 +1,55 @@
+import logging
+import requests
+import base64
+
+import datetime
+import os
+import sys
+import time
+
+from datetime import date
+
+import sarracenia
+from sarracenia.flowcb.scheduled import Scheduled
+
+logger = logging.getLogger(__name__)
+
+
+
+
+class Poll(Scheduled):
+    """
+      
+    """
+
+    def gather(self,messageCountMax): # placeholder
+        """
+
+           This gather aborts further gathers if the next interval has not yet arrived.
+
+        """
+        logger.info( f"waiting for next poll")
+        self.wait_until_next()
+
+        return  not (self.stop_requested or self.housekeeping_needed), [] 
+
+
+if __name__ == '__main__':
+
+    import sarracenia.config
+    import types
+    import sarracenia.flow
+
+    options = sarracenia.config.default_config()
+    flow = sarracenia.flow.Flow(options)
+    flow.o.scheduled_interval= 5
+    flow.o.pollUrl = "https://dd.weather.gc.ca/bulletins/alphanumeric/"
+    if sys.platform.startswith( "win" ):
+        flow.o.directory = "C:\\temp\poll"
+    else:
+        flow.o.directory = "/tmp/scheduled_poll/${%Y%m%d}"
+    logging.basicConfig(level=logging.DEBUG)
+
+    me = Poll(flow.o)
+    me.gather(flow.o.batch)
+    logger.info("Done")

--- a/sarracenia/flowcb/scheduled/poll.py
+++ b/sarracenia/flowcb/scheduled/poll.py
@@ -52,4 +52,6 @@ if __name__ == '__main__':
 
     me = Poll(flow.o)
     me.gather(flow.o.batch)
-    logger.info("Done")
+    logger.info("first done")
+    me.gather(flow.o.batch)
+    logger.info("Second Done")

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -138,7 +138,7 @@ class Wiski(Scheduled):
         self.wait_until_next()
 
         while (1):
-            if self.stop_requested:
+            if self.stop_requested or self.housekeeping_needed:
                 return messages
         
             self.token = self.submit_tokenization_request()

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -139,7 +139,7 @@ class Wiski(Scheduled):
 
         while (1):
             if self.stop_requested or self.housekeeping_needed:
-                return (True, messages)
+                return (False, messages)
         
             self.token = self.submit_tokenization_request()
             authenticated_url = self.main_url

--- a/sarracenia/flowcb/scheduled/wiski.py
+++ b/sarracenia/flowcb/scheduled/wiski.py
@@ -139,7 +139,7 @@ class Wiski(Scheduled):
 
         while (1):
             if self.stop_requested or self.housekeeping_needed:
-                return messages
+                return (True, messages)
         
             self.token = self.submit_tokenization_request()
             authenticated_url = self.main_url
@@ -172,7 +172,7 @@ class Wiski(Scheduled):
         for station_id in k.get_station_list().station_id:
 
             if self.stop_requested:
-                return messages
+                return (False, messages)
 
             timeseries = k.get_timeseries_list(station_id = station_id ).ts_id
             #logger.info( f"looping over the timeseries: {timeseries}" )
@@ -197,7 +197,7 @@ class Wiski(Scheduled):
                 f.close() 
                 messages.append( sarracenia.Message.fromFileData( fname, self.o, os.stat(fname) ) )
     
-        return messages
+        return (True, messages)
 
 if __name__ == '__main__':
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2696,6 +2696,8 @@ class sr_GlobalState:
                     elif ( k == 'post_baseUrl' ) and line[1][-1] != '/':
                             line[1]+='/'
                             # see: https://github.com/MetPX/sarracenia/issues/841
+                    elif (k == 'sleep' ) and (component == 'poll'):
+                        k = 'scheduled_interval'
                     if k in convert_to_v3:
                         if len(line) > 1:
                             v = line[1].replace('.py', '', 1)


### PR DESCRIPTION
closes #974 

This is a third PR ( of the poll refactor work, replacing https://github.com/MetPX/sarracenia/pull/985 (which in turn replaced another one) which had five separate commits, that individually do not pass the flow tests, so would break git bisection. Want to keep bisection working, so re-created the branch with those five commits squashed together.

Once that was done, added a refactor of the Flow class's (sarracenia.flow.Flow) run() routine.  It was very long (288 lines) 

  * made called routines for flow algorithm phases:  *gather, filter, work, post* routines  more responsible (moved code into them.)
  * the phase routines now call the relevant plugin entry points
  * the phase routines now re-arrange the worklists.
 
Once the run() routine was shortened (to 155 lines... better, but not really good... enough to understand the algorithm) it felt safe to re-arrange algorithmic flow so that a "poll" can now download, identically to other components.  (the *work* phase used to not be run when running a poll.)

comments from original PR (with annotations for what was tackled):

* It doesn't do a poll on startup, currently. it waits for one interval before the first poll. easy to fix... should we?
  (**FIXED** by:  3e4ba34c0efa600ba9fef274127b2f298f005228 , adjusted by: 06fa2d36089634a02d9bd82c32a22cadc1499a44 )

So now in poll, the loop towards the end of the run() routine is only used to sleep for 1 second at a time... and the real waiting is done in the scheduled.poll plugin instead.

*  In watch... still using long sleeps in that loop at the end... Is this an opportunity to simplify sr_watch also... so it also uses the same methods? Is there an advantage to doing it that way?

* I'm wondering if there is a way to have watch use a shared duplicate suppression cache the same way as poll does, 
   populating itself with the output exchange binding queue. Same benefit as poll, run on two machines with a vip and 
   failover. (not done...)

* wondering if this change might be an opportunity to simplify sarracenia.flow/init.py run() routine. It feels too complicated.
   (**DONE** 71fe41d9e52947282398c1d0132771a778275933 ac9b1026f4b260d256a7815a68971bf96e31bfe4 32b2554627e769f865ee088ea353302244982c0f 06fa2d36089634a02d9bd82c32a22cadc1499a44 52219cd2194681826df755fd2deb2b34ae89f0ad )    Now poll runs work() aka do() so if "directory" were normal... it could be used by poll, see other PR  https://github.com/MetPX/sarracenia/pull/987




