### PR TITLE
Issue992 - re-parse values using correct type for add_options from flow_callbacks.

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -322,9 +322,9 @@ r"""
 
 
 def isTrue(S):
-    s = S.lower()
-    if s == 'true' or s == 'yes' or s == 'on' or s == '1': return True
-    return False
+    if type(S) is list:
+        S = S[-1]
+    return S.lower() in ['true', 'yes', 'on', '1']
 
 
 def get_package_lib_dir():

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -152,7 +152,7 @@ list_options = [ 'path', 'vip' ]
 set_options = [ 'logEvents', 'fileEvents' ]
 
 set_choices = { 
-    'logEvents' : sarracenia.flowcb.entry_points + [ 'reject' ],
+    'logEvents' : set(sarracenia.flowcb.entry_points + [ 'reject' ]),
     'fileEvents' : set( [ 'create', 'delete', 'link', 'mkdir', 'modify', 'rmdir' ] )
  }
 # FIXME: doesn't work... wonder why?
@@ -1039,8 +1039,6 @@ class Config:
                     sv= old_value | sv
                 elif op == '-' :
                     sv= old_value - sv
-                else:
-                    sv=set([v])
         return sv
 
     def add_option(self, option, kind='list', default_value=None, all_values=None ):


### PR DESCRIPTION
close #992 

repackaging of stuff from work with @mshak2 on wis2... there were enough patches that it made sense to deal with this separately. The problem is explained in #992.   when options were declared in callbacks, and their type was not list (the default) they would be parse as lists anyways, because parsing encountered the type declarations after already having parsed the values.

At the end of option processing... there is already logic to re-examine "undeclared" variables. The existing logic removes variables that were declared in callbacks from the undeclared lists so that we don't generate bogus "undeclared" messages. These patches add, that when you find a declared option... re-parse the value to have it match the type declared for the option.

The string parsing for set values, was done weirdly with code in two places, Since we now needed it in a third place, the original two were consolidated into a set value parsing routine, and call it from all three places.