### PR TITLE
Transfer documentation and a fix for all tests...

### DIFF
--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -379,6 +379,7 @@ class Poll(FlowCB):
 
 
         # assert at this point we have an sftp_obj...
+        # filter out files we don't have the necessary permissions for.
         if 'sftp_obj' in locals() and ((sftp_obj.st_mode
                                         & self.o.permDefault) == self.o.permDefault):
             return sftp_obj

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -156,6 +156,10 @@ class Retry(FlowCB):
 
     def on_cleanup(self) -> None:
         logger.debug('starting retry cleanup')
+
+        if not hasattr(self,'download_retry'):
+            self.on_start()
+
         self.download_retry.cleanup()
         self.post_retry.cleanup()
 

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -106,15 +106,19 @@ class Transfer():
          chmod  (perm)
          rename (old,new)
 
-     Note that the ls() call returns either:
+     Note that the ls() call returns are polymorphic. One of:
 
      * a dictionary where the key is the name of the file in the directory,
        and the value is an SFTPAttributes structure for if (from paramiko.)
+       (sftp.py as an example)
      * a dictionary where the key is the name of the file, and the value is a string
        that looks like the output of a linux ls command.
+       (ftp.py as an example.)
      * a seqeence of bytes... will be parsed as an html page.
+       (https.py as an example)
 
-     The first format is the vastly preferred one. The others are inferior.
+     The first format is the vastly preferred one. The others are fallbacks when the first
+     is not available.
      The flowcb/poll/__init__.py lsdir() routing will turn ls tries to transform any of 
      these return values into the first form (a dictionary of SFTPAttributes)
      Each SFTPAttributes structure needs st_mode set, and folders need stat.S_IFDIR set.

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -95,10 +95,6 @@ class Transfer():
          cd     (dir)
          delete (path)
     
-     Note that the ls() call returns a dictionary where the key is the name of the file in the directory,
-     and the value is an SFTPAttributes structure for if (from paramiko.)
-
-     Each SFTPAttributes structure needs st_mode set, and folders need stat.S_IFDIR set.
 
      if sending:: 
 
@@ -109,7 +105,27 @@ class Transfer():
          umask  ()
          chmod  (perm)
          rename (old,new)
-    
+
+     Note that the ls() call returns either:
+
+     * a dictionary where the key is the name of the file in the directory,
+       and the value is an SFTPAttributes structure for if (from paramiko.)
+     * a dictionary where the key is the name of the file, and the value is a string
+       that looks like the output of a linux ls command.
+     * a seqeence of bytes... will be parsed as an html page.
+
+     The first format is the vastly preferred one. The others are inferior.
+     The flowcb/poll/__init__.py lsdir() routing will turn ls tries to transform any of 
+     these return values into the first form (a dictionary of SFTPAttributes)
+     Each SFTPAttributes structure needs st_mode set, and folders need stat.S_IFDIR set.
+
+     if the lsdir() routine gets a sequence of bytes, the on_html_page() and on_html_parser_init(,
+     or perhaps handle_starttag(..) and handle_data() routines) will be used to turn them into
+     the first form.
+
+     web services with different such formats can be accommodated by subclassing and overriding
+     the handle_* entry points.
+
      uses options (on Sarracenia.config data structure passed to constructor/factory.)
      * credentials - used to authentication information.
      * sendTo  - server to connect to.

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -79,7 +79,7 @@ def alarm_set(time):
 
 class Transfer():
     """
-     This is a sort of abstract base classe for implementing transfer protocols.
+     This is a sort of abstract base class for implementing transfer protocols.
      Implemented subclasses include support for: local files, https, sftp, and ftp. 
 
      This class has routines that do i/o given descriptors opened by the sub-classes,
@@ -95,6 +95,11 @@ class Transfer():
          cd     (dir)
          delete (path)
     
+     Note that the ls() call returns a dictionary where the key is the name of the file in the directory,
+     and the value is an SFTPAttributes structure for if (from paramiko.)
+
+     Each SFTPAttributes structure needs st_mode set, and folders need stat.S_IFDIR set.
+
      if sending:: 
 
          put    ( msg, remote_file, local_file, remote_offset=0, local_offset=0, length=0 )

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -114,7 +114,7 @@ class Transfer():
      * a dictionary where the key is the name of the file, and the value is a string
        that looks like the output of a linux ls command.
        (ftp.py as an example.)
-     * a seqeence of bytes... will be parsed as an html page.
+     * a sequence of bytes... will be parsed as an html page.
        (https.py as an example)
 
      The first format is the vastly preferred one. The others are fallbacks when the first

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -162,7 +162,7 @@ class File(Transfer):
         return self.cwd
 
     # ls
-    def ls(self):
+    def ls(self) -> dict:
         logger.debug("sr_file ls")
         self.entries = {}
         self.root = self.path

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -318,7 +318,7 @@ class Ftp(Transfer):
         return pwd
 
     # ls
-    def ls(self) -> dict:
+    def ls(self) -> dict[str,str]:
         logger.debug("sr_ftp ls")
         self.entries = {}
         alarm_set(self.o.timeout)

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -318,7 +318,7 @@ class Ftp(Transfer):
         return pwd
 
     # ls
-    def ls(self):
+    def ls(self) -> dict:
         logger.debug("sr_ftp ls")
         self.entries = {}
         alarm_set(self.o.timeout)

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -219,7 +219,7 @@ class Https(Transfer):
 
 # ls
 
-    def ls(self) -> str:
+    def ls(self) -> bytes:
         logger.debug("sr_http ls")
 
         # open self.http

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -219,7 +219,7 @@ class Https(Transfer):
 
 # ls
 
-    def ls(self):
+    def ls(self) -> dict:
         logger.debug("sr_http ls")
 
         # open self.http

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -219,7 +219,7 @@ class Https(Transfer):
 
 # ls
 
-    def ls(self) -> dict:
+    def ls(self) -> str:
         logger.debug("sr_http ls")
 
         # open self.http

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -385,7 +385,7 @@ class Sftp(Transfer):
         return cwd
 
     # ls
-    def ls(self):
+    def ls(self) -> dict:
         logger.debug("sr_sftp ls")
         self.entries = {}
         # timeout is at least 30 secs, say we wait for max 5 mins

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -385,7 +385,7 @@ class Sftp(Transfer):
         return cwd
 
     # ls
-    def ls(self) -> dict:
+    def ls(self) -> dict[ str, paramiko.SFTPAttributes ]:
         logger.debug("sr_sftp ls")
         self.entries = {}
         # timeout is at least 30 secs, say we wait for max 5 mins


### PR DESCRIPTION

after working with @gcglinton, @reidsunderland, @andreleblanc11 on the new s3 transfer class, I added some documentation about how to write transfer classes.  The principle unfathomable part is what the ls() entry point returns, which is quite odd.  It is the right thing to do, but it requires explanation, included in the commits.

Also noticed that after AM protocol work with @andreleblanc11 the cleanup() function of the retry class was crashing many tests.  Have to add some initialization to get the cleanup to work.
