### PR TITLE
Make persistent a configurable option (v2)

### DIFF
--- a/doc/fr/sr_subscribe.1.rst
+++ b/doc/fr/sr_subscribe.1.rst
@@ -547,10 +547,11 @@ Une fois connecté à un courtier AMQP, l'utilisateur doit créer une file d'att
 
 Mise en file d'attente sur broker :
 
-- **queue <nom> (par défaut : q_<brokerUser>.<programName>.<configName>.<configName>)**
-- **durable <booléen> (par défaut : False)**
+- **queue <nom> (par défaut : q_<brokerUser>.<programName>.<configName>)**
+- **durable <booléen> (par défaut : True)**
 - **expire <durée> (par défaut : 5m == cinq minutes. À OUTREPASSER)**
 - **message_ttl <durée> (par défaut : Aucun)**
+- **persistent    <boolean>      (default: True)**
 - **prefetch <N> (par défaut : 1)**
 - **reset <booléen> (par défaut : False)**
 - **restore <booléen> (par défaut : False)**
@@ -565,15 +566,15 @@ les cas moins habituels, l'utilisateur peut avoir besoin a remplacer les valeurs
 par défaut. La file d'attente est l'endroit où les avis sont conservés
 sur le serveur pour chaque abonné.
 
-[ queue|queue_name <nom> (par défaut : q_<brokerUser>.<programName>.<configName>.<configName>) ]
+[ queue|queue_name <nom> (par défaut : q_<brokerUser>.<programName>.<configName>) ]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Par défaut, les composants créent un nom de file d'attente qui doit être unique.
 Le nom_de_la_files_d'attente par défaut composants créent suit.. :  
-**q_<brokerUser>.<programName>.<configName><configName>** . Les utilisateurs 
+**q_<brokerUser>.<programName>.<configName>** . Les utilisateurs 
 peuvent remplacer la valeur par défaut à condition qu'elle commence par 
 **q_<brokerUser>**. Certaines variables peuvent aussi être utilisées dans 
-le nom_de_la_file d'attente comme **${BROKER_USER},${PROGRAMME},${CONFIG},${HOSTNAME}**
+le nom_de_la_file d'attente comme **q_<brokerUser>.<programName>.<configName>.<random>.<random>** 
 
 Quand plusieurs processus (*instances*) roulent sur un même serveurs, ils 
 partagent le même *home* alors ils vont tous partager le même fil.  On peut
@@ -582,7 +583,7 @@ dans les cas ou on veut que le même queue soit partagé en dépit de ne pas
 avoir de *home* partagé.
 
 
-durable <booléen> (par défaut : False)
+durable <booléen> (par défaut : True)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 L'option **durable**, si elle est définie sur True, signifie que la file d'attente est écrite.
@@ -613,6 +614,20 @@ message_ttl <durée> (par défaut : Aucun)
 L'option **message_ttl** (*message time to live*) définit la durée de vie
 d´un message dans la file d'attente. Passé ce délai, le message est retiré de 
 la file d'attente par le courtier.
+
+persistent <boolean> (par défaut : True)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+L'option **persistent** définit le *delivery_mode* pour un message AMQP. Lorsqu'il
+est choisi, les messages persistants seront publiés (``delivery_mode=2``). Lorsqu'ils
+ne le sont pas, ils seront placés en mode transitoire (non durables, ``delivery_mode=1``).
+ 
+Les messages persistants sont écrits sur le disque par le courtier et survivront au 
+redémarrage du courtier. Tous les messages transitoires dans une file d’attente seront
+perdus au redémarrage d’un courtier. Une remarque : les messages persistants ne survivront
+pas le redémarrage du courtier *quand ils résident dans une file d'attente durable*. 
+Non-durable les files d'attente, y compris tous les messages qu'elles contiennent, 
+seront perdues au redémarrage d'un courtier.
 
 prefetch <N> (par défaut : 1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/sr_subscribe.1.rst
+++ b/doc/sr_subscribe.1.rst
@@ -564,6 +564,7 @@ Setting the queue on broker :
 - **durable       <boolean>      (default: True)**
 - **expire        <duration>      (default: 5m  == five minutes. RECOMMEND OVERRIDING)**
 - **message_ttl   <duration>      (default: None)**
+- **persistent    <boolean>      (default: True)**
 - **prefetch      <N>            (default: 1)**
 - **reset         <boolean>      (default: False)**
 - **restore       <boolean>      (default: False)**
@@ -615,7 +616,9 @@ durable <boolean> (default: True)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The  **durable** option, if set to True, means writes the queue
-on disk if the broker is restarted.
+on disk if the broker is restarted. Note: only persistent messages in a
+queue will be retained in a durable queue after a broker restart. Persistent messages
+can be published by enabling the **persistent** option (it is enabled by default).
 
 expire <duration> (default: 5m  == five minutes. RECOMMEND OVERRIDING)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -640,6 +643,18 @@ message_ttl <duration>  (default: None)
 
 The  **message_ttl**  option set the time a message can live in the queue.
 Past that time, the message is taken out of the queue by the broker.
+
+persistent <boolean> (default: True)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The **persistent** option sets the *delivery_mode* for an AMQP message. When True,
+persistent messages will be published (``delivery_mode=2``), when False, transient
+(non-durable, ``delivery_mode=1``) messages will be published.
+
+Persistent messages are written to disk by the broker, and will survive a broker restart.
+Any transient messages in a queue will be lost when a broker is restarted. Note: persistent
+messages will only survive a broker restart *when they reside in a durable queue*. Non-durable
+queues, including all messages inside them, will be lost when a broker is restarted.
 
 prefetch <N> (default: 1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sarra/sr_config.py
+++ b/sarra/sr_config.py
@@ -337,7 +337,8 @@ class sr_config:
            ( self.expire, self.reset, self.message_ttl, self.prefetch, self.accept_unmatch, self.delete, self.poll_without_vip ) )
         self.logger.info( "\theartbeat=%s sanity_log_dead=%s default_mode=%03o default_mode_dir=%03o default_mode_log=%03o discard=%s durable=%s" % \
            ( self.heartbeat, self.sanity_log_dead, self.chmod, self.chmod_dir, self.chmod_log, self.discard, self.durable ) )
-        self.logger.info( "\tdeclare_queue=%s declare_exchange=%s bind_queue=%s" % ( self.declare_queue, self.declare_exchange, self.bind_queue ) )
+        self.logger.info( "\tpersistent=%s declare_queue=%s" % ( self.persistent, self.declare_queue) )
+        self.logger.info( "\tdeclare_exchange=%s bind_queue=%s" % ( self.declare_exchange, self.bind_queue ) )
         self.logger.info( "\tpost_on_start=%s preserve_mode=%s preserve_time=%s realpath_post=%s base_dir=%s follow_symlinks=%s" % \
            ( self.post_on_start, self.preserve_mode, self.preserve_time, self.realpath_post, self.base_dir, self.follow_symlinks ) )
         self.logger.info( "\tmirror=%s flatten=%s realpath_post=%s strip=%s base_dir=%s report_back=%s log_reject=%s" % \
@@ -719,6 +720,7 @@ class sr_config:
         self.prefetch             = 25
         self.max_queue_size       = 25000
         self.set_passwords        = True
+        self.persistent           = True
 
         self.accept_unmatch       = None     # default changes depending on program
         self.masks                = []       # All the masks (accept and reject)
@@ -1868,6 +1870,14 @@ class sr_config:
                         n = 1
                      else :
                         self.durable = self.isTrue(words1)
+                        n = 2
+                
+                elif words0 == 'persistent'   : # See sr_config.7 ++
+                     if (words1 is None) or words[0][0:1] == '-' : 
+                        self.persistent = True
+                        n = 1
+                     else :
+                        self.persistent = self.isTrue(words1)
                         n = 2
 
                 elif words0 in ['events','e']:  # See sr_watch.1

--- a/sarra/sr_message.py
+++ b/sarra/sr_message.py
@@ -487,7 +487,8 @@ class sr_message():
 
            # publish
            if ok:
-               self.report_publisher.publish(self.report_exchange,self.report_topic,self.report_notice,self.headers)
+               self.report_publisher.publish(self.report_exchange,self.report_topic,
+                                             self.report_notice,self.headers,self.persistent)
 
         self.logger.debug("%d %s : %s %s %s" % (code,message,self.report_topic,self.report_notice,self.hdrstr))
 
@@ -730,7 +731,8 @@ class sr_message():
                     print( "%s/%s" % ( self.base_url, self.relpath ) )
                     ok= True
                else:
-                    ok = self.publisher.publish(self.exchange+suffix, self.topic, body, None, self.message_ttl)
+                    ok = self.publisher.publish(self.exchange+suffix, self.topic, body,
+                                                None, self.message_ttl, self.persistent)
            else:
                #in v02, sum is the correct header. FIXME: roundtripping not quite right yet.
                if 'identity' in self.headers.keys(): 
@@ -772,7 +774,8 @@ class sr_message():
                     print( "%s/%s" % ( self.base_url, self.relpath ) )
                     ok=True
                else:
-                    ok = self.publisher.publish(self.exchange+suffix,self.topic,self.notice,self.headers,self.message_ttl)
+                    ok = self.publisher.publish(self.exchange+suffix,self.topic,self.notice,
+                                                self.headers,self.message_ttl,self.persistent)
 
         self.set_hdrstr()
 

--- a/sarra/sr_message.py
+++ b/sarra/sr_message.py
@@ -72,6 +72,7 @@ class sr_message():
         self.log_reject  = parent.log_reject
         self.post_topic_prefix  = parent.post_topic_prefix
         self.post_version  = parent.post_version
+        self.persistent    = parent.persistent
         self.report_publisher = None
         self.publisher     = None
         self.pub_exchange  = None
@@ -488,7 +489,7 @@ class sr_message():
            # publish
            if ok:
                self.report_publisher.publish(self.report_exchange,self.report_topic,
-                                             self.report_notice,self.headers,self.persistent)
+                                             self.report_notice,self.headers,persistent=self.persistent)
 
         self.logger.debug("%d %s : %s %s %s" % (code,message,self.report_topic,self.report_notice,self.hdrstr))
 
@@ -732,7 +733,7 @@ class sr_message():
                     ok= True
                else:
                     ok = self.publisher.publish(self.exchange+suffix, self.topic, body,
-                                                None, self.message_ttl, self.persistent)
+                                                None, self.message_ttl, persistent=self.persistent)
            else:
                #in v02, sum is the correct header. FIXME: roundtripping not quite right yet.
                if 'identity' in self.headers.keys(): 
@@ -775,7 +776,7 @@ class sr_message():
                     ok=True
                else:
                     ok = self.publisher.publish(self.exchange+suffix,self.topic,self.notice,
-                                                self.headers,self.message_ttl,self.persistent)
+                                                self.headers,self.message_ttl,persistent=self.persistent)
 
         self.set_hdrstr()
 


### PR DESCRIPTION
As discussed, add persistent as an option so we can easily do A-B testing to compare performance. I also fixed some defaults in the French documentation that looked wrong.

Thanks @andreleblanc11 for the French translation of the persistent option.