### PR TITLE
fix #947, only report on .conf or .inc files

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -319,8 +319,7 @@ class sr_GlobalState:
                         state = 'include'
                         continue
                     else:
-                        cbase = cfg
-                        state = 'unknown'
+                        continue
 
                     self.configs[c][cbase] = {}
                     self.configs[c][cbase]['status'] = state


### PR DESCRIPTION
close #947 sr3 status finds things that are not configs in the config directory
