### PR TITLE
flakey flow test failing when polls killed with -9 cannot remove novip state file

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -212,7 +212,8 @@ class Flow:
 
         # metrics - dictionary with names of plugins as the keys
         self.metricsFlowReset()
-        self.had_vip = True
+
+        self.had_vip = not os.path.exists( self.o.novipFilename )
 
     def metricsFlowReset(self) -> None:
 
@@ -426,6 +427,7 @@ class Flow:
           loop in it. This implements the General Algorithm (as described in the Concepts Explanation Guide) 
           check if stop_requested once in a while, but never return otherwise.
         """
+
 
         if not self.loadCallbacks(self.plugins['load']):
            return


### PR DESCRIPTION
so... set had_vip the previous state based on the presence/absence of the novip file.
so it it does have the vip... it triggers the transition to remove it.

This is the reason flakey flow test suite are failing with two polls in wvip sometimes...

this is the test that fails, usually with both sftp polls being in wVip state.
```

test 36 success: there should be 1 process in wVip state

```

The real cause is that the vip flipped, but since it already had the vip (default true..)
it doesn't remove the novip file.
