### PR TITLE
Issue980 - Add `verifyHeader` method to prevent erronous headers from passing through

### DIFF
--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -313,10 +313,10 @@ class Am(FlowCB):
 
     def correctContents(self, bulletin, bulletin_firstchars, lines, missing_ahl, bulletin_station, charset):
         """ Correct the bulletin contents, either of these ways
-            1. Remove trailing space in bulletin header
-            1. Add missing AHL headers for CA,MA,RA bulletins
-            2. Add missing AHL headers by mapping station codes
-            3. Add an extra line for SM/SI bulletins
+            1. Verify the received bulletin header.
+            2. Add missing AHL headers for CA,MA,RA bulletins
+            3. Add missing AHL headers by mapping station codes
+            4. Add an extra line for SM/SI bulletins
         """
 
         # We need to get the BBB from the header, to properly rewrite it.
@@ -326,9 +326,13 @@ class Am(FlowCB):
         ddhhmm = ''
         new_bulletin = b''
         
-        # If there's a trailing space at the end of the bulletin header. Remove it.
-        if lines[0][-1:] == b' ':
-            lines[0] = lines[0].rstrip()
+        # Check if the header is okay before proceeding to correcting rest of bulletin.
+        verified_header , failed = self.bulletinHandler.verifyHeader(lines[0]) 
+        if failed:
+            logger.critical(f"Bulletin header (after failure): {lines[0]}")
+            raise Exception
+        if verified_header != lines[0]:
+            lines[0] = verified_header
             reconstruct = 1
 
         # Ported from Sundew. Complete missing headers from bulletins starting with the first characters below.

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -325,6 +325,7 @@ class Am(FlowCB):
         reconstruct = 0
         ddhhmm = ''
         new_bulletin = b''
+        isProblem = False
         
         # Ported from Sundew. Complete missing headers from bulletins starting with the first characters below.
         if bulletin_firstchars in [ "CA", "RA", "MA" ]:

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -82,7 +82,7 @@ class Raw2bulletin(FlowCB):
         self.o.add_option('binaryInitialCharacters', 'list', [b'BUFR' , b'GRIB', b'\211PNG'])
 
     # If file was converted, get rid of extensions it had
-    def rename(self,msg):
+    def rename(self,msg,isProblem):
 
         path = msg['new_dir'] + '/' + msg['new_file']
 
@@ -133,7 +133,7 @@ class Raw2bulletin(FlowCB):
         try:
             # We can't disseminate bulletins downstream if they're missing the timestamp, but we want to keep the bulletins to troubleshoot source problems
             # We'll append "_PROBLEM" to the filename to be able to identify erronous bulletins
-            if ddhhmm == None:
+            if ddhhmm == None or isProblem:
                 timehandler = datetime.datetime.now()
 
                 # Add current time as new timestamp to filename


### PR DESCRIPTION
There is one commit that has the wrong issue number.. oops. I typed the wrong issue number in the commit. I also tried reverting the change through this thread https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message#amending-older-or-multiple-commit-messages but that also didn't work :(

The `verifyHeader` method is ported from Sundew and checks if the header contents are what they're supposed to be. 

I added the `isProblem` to the FlowCB renamer so that we can keep saving the problematic bulletins locally when they are flagged from `verifyHeader`


## For testing
- I've been running a separate sr3 AM server on my DIRT VM with a connection through the Edmonton regional (our most popular one), and have been monitoring the file output. So far it's been looking good. The bad bulletins now also get an extra layer of error messages when there header is malformed.

```
2024-04-30 00:01:32,936 [DEBUG] sarracenia.flowcb.gather.am gather Bulletin contents: b'CA\nWPK\n1.96225,140.334,21.8998\n'
2024-04-30 00:01:32,936 [ERROR] sarracenia.bulletin verifyHeader Incomplete header (less than 3 fields)
2024-04-30 00:01:32,936 [DEBUG] sarracenia.flowcb.gather.am correctContents Missing contents added
2024-04-30 00:01:32,936 [ERROR] sarracenia.flowcb.rename.raw2bulletin rename Unable to get julian time.
2024-04-30 00:01:32,936 [ERROR] sarracenia.flowcb.rename.raw2bulletin rename New filename (for problem file): CACN00_CWAO_300001__WPK_00635_PROBLEM
```

- I tested the erroneous file that caused this method to be added and it's now being dealt with properly.
- I also didn't want to test all AM regional feeds because we would still be missing the DND ones and it would make it hard to accurately compare with the data that's already on NCP 