### PR TITLE
updatePaths work without being supplied new_dir and new_path

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -769,10 +769,22 @@ class Message(dict):
         ])
         if new_dir:
             msg['new_dir'] = new_dir
+        elif 'new_dir' in msg:
+            new_dir = msg['new_dir']
+        else:
+            new_dir = ''
 
         if new_file or new_file == '':
             msg['new_file'] = new_file
-
+        elif 'new_file' in msg:
+            new_file = msg['new_file']
+        elif 'new_relPath' in msg:
+            new_file = os.path.basename(msg['rel_relPath'])
+        elif 'relPath' in msg:
+            new_file = os.path.basename(msg['relPath'])
+        else:
+            new_file = 'ErrorInSarraceniaMessageUpdatePaths.txt'
+    
         newFullPath = new_dir + '/' + new_file
         
         # post_baseUrl option set in msg overrides other possible options

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -773,7 +773,7 @@ class Message(dict):
         if new_file or new_file == '':
             msg['new_file'] = new_file
 
-        relPath = new_dir + '/' + new_file
+        newFullPath = new_dir + '/' + new_file
         
         # post_baseUrl option set in msg overrides other possible options
         if 'post_baseUrl' in msg:
@@ -802,23 +802,23 @@ class Message(dict):
             pbd_str = options.variableExpansion(options.post_baseDir, msg)
             parsed_baseUrl = sarracenia.baseUrlParse(baseUrl_str)
 
-            if relPath.startswith(pbd_str):
-                relPath = new_dir.replace(pbd_str, '', 1) + '/' + new_file
+            if newFullPath.startswith(pbd_str):
+                newFullPath = new_dir.replace(pbd_str, '', 1) + '/' + new_file
 
-            if (len(parsed_baseUrl.path) > 1) and relPath.startswith(
+            if (len(parsed_baseUrl.path) > 1) and newFullPath.startswith(
                     parsed_baseUrl.path):
-                relPath = relPath.replace(parsed_baseUrl.path, '', 1)
+                newFullPath = newFullPath.replace(parsed_baseUrl.path, '', 1)
 
         if ('new_dir' not in msg) and options.post_baseDir:
             msg['new_dir'] = options.post_baseDir
             
         msg['new_baseUrl'] = baseUrl_str
 
-        if len(relPath) > 0 and relPath[0] == '/':
-            relPath = relPath[1:]
+        if len(newFullPath) > 0 and newFullPath[0] == '/':
+            newFullPath = newFullPath[1:]
 
-        msg['new_relPath'] = relPath
-        msg['new_subtopic'] = relPath.split('/')[0:-1]
+        msg['new_relPath'] = newFullPath
+        msg['new_subtopic'] = newFullPath.split('/')[0:-1]
 
         for i in ['relPath', 'subtopic', 'baseUrl']:
             if not i in msg:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1925,7 +1925,11 @@ class Flow:
                 if self.o.dry_run:
                     cwd = cdir
                 else:
-                    self.proto[self.scheme].cd(cdir)
+                    try:
+                         self.proto[self.scheme].cd(cdir)
+                    except Exception as ex:
+                         logger.error("chdir %s: %s" % (cdir, ex))
+                         return False
 
             remote_offset = 0
             exactLength=False

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2659,10 +2659,7 @@ class sr_GlobalState:
                 v3_cfg.write('# topicCopy on is only there for bug-for-bug compat with v2. turn it off if you can.\n')
                 v3_cfg.write('#topicCopy on\n')
 
-            if component in [ 'sarra', 'subscribe' ]:
-                v3_cfg.write('#v2 sftp handling is always absolute, sr3 is relative. This plugin helps during conversion, remove when all sr3:\n')
-                v3_cfg.write('flowcb accept.sftp_absolute\n')
-            if component in [ 'sender' ]:
+            if component in [ 'sarra', 'sender', 'subscribe' ]:
                 v3_cfg.write('#v2 sftp handling is always absolute, sr3 is relative. might need this, remove when all sr3:\n')
                 v3_cfg.write('#flowcb accept.sftp_absolute\n')
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -79,9 +79,10 @@ class Sftp(Transfer):
 
     # cd
     def cd(self, path):
-        logger.debug("sr_sftp cd %s" % path)
         alarm_set(self.o.timeout)
+        logger.debug("first cd to %s" % self.originalDir)
         self.sftp.chdir(self.originalDir)
+        logger.debug("then cd to %s" % path)
         self.sftp.chdir(path)
         self.pwd = path
         alarm_cancel()


### PR DESCRIPTION
For @reidsunderland and @petersilva , this routine in the sarracenia.Message class does not satisfy the Princple of Least Astonishment.  If you have a python method that has =None for a value... you should be able to omit it.

looking through the code, it is clear that the code will crash if either one or both of new_dir and new_file arguments are omitted. in all places in the existing code, both args are supplied.

However to make it nicer to use for plugin writers, added logic to infer the correct values from existing message fields whenever possible.

