### PR TITLE
locally installed plugins are not selected because we prepend system …

### DIFF
--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -255,10 +255,10 @@ def load_library(factory_path, options):
             packagename, classname = factory_path.rsplit('.', 1)
 
     try:
-        module = importlib.import_module('sarracenia.flowcb.' + packagename)
+        module = importlib.import_module(packagename)
         class_ = getattr(module, classname)
     except ModuleNotFoundError:
-        module = importlib.import_module(packagename)
+        module = importlib.import_module('sarracenia.flowcb.' + packagename)
         class_ = getattr(module, classname)
  
     if hasattr(options, 'settings'):


### PR DESCRIPTION
…classes to them first... stop that.

noticed by @reidsunderland  ... 