### PR TITLE
updatePaths no longer fails when called with just options

### DIFF
--- a/tests/sarracenia/__init___test.py
+++ b/tests/sarracenia/__init___test.py
@@ -351,8 +351,9 @@ class Test_Message():
         #Test set 1
         options = sarracenia.config.default_config()
         msg = sarracenia.Message()
-        with pytest.raises(Exception):
-            msg.updatePaths(options)
+        # this was a behaviour changed in https://github.com/MetPX/sarracenia/pull/1034
+        #with pytest.raises(Exception):
+        #    msg.updatePaths(options)
 
         msg = sarracenia.Message()
         msg.updatePaths(options, new_dir, new_file)


### PR DESCRIPTION

After fixing updatePaths, it turned out there was a unit test that was counting on an exception being raised when
called without arguments (new_dir and new_file) being set.

