### PR TITLE
multi-instances will be partial, not missing

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1981,7 +1981,7 @@ class sr_GlobalState:
             component_path = self._find_component_path(c)
             if component_path == '':
                 continue
-            if self.configs[c][cfg]['status'] in ['missing']:
+            if self.configs[c][cfg]['status'] in ['missing', 'partial']:
                 numi = self.configs[c][cfg]['instances']
                 for i in range(1, numi + 1):
                     if pcount % 10 == 0: print('.', end='', flush=True)


### PR DESCRIPTION
fixes #927 

after the group debug session, we had set the state to tag for missing processes as "missing"
That is the state when ALL of the instances of a flow are not running.  when only some have
crashed, the status will be "partial".  need to add that to the states for sanity to look for.

