### PR TITLE
please stop infinite loop by calling self

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -450,7 +450,6 @@ class Flow:
         logger.info(
             f'ok, telling {len(self.plugins["please_stop"])} callbacks about it.'
         )
-        self.runCallbacksTime('please_stop')
         self._stop_requested = True
         self.metrics["flow"]['stop_requested'] = True
 
@@ -579,7 +578,7 @@ class Flow:
             total_messages += last_gather_len
 
             if (self.o.messageCountMax > 0) and (total_messages > self.o.messageCountMax):
-                self.please_stop()
+                self.runCallbacksTime('please_stop')
 
             current_rate = total_messages / run_time
             elapsed = now - last_time
@@ -593,7 +592,7 @@ class Flow:
                     # Sleep for a while. Messages can't be retried before housekeeping has run...
                     current_sleep = 60
                 else:
-                    self.please_stop()
+                    self.runCallbacksTime('please_stop')
 
             if spamming and (current_sleep < 5):
                 current_sleep *= 2


### PR DESCRIPTION
after adding *please_stop* as a thing in a flow that gets called, had to update
the existing routine to not call the call backs, because that now results in an infinite loop.

start up a flow, hit ^c and it scrolls off the screen until stack exhaustion.
sigh...

cause by fixes for #1064.

