### PR TITLE
disabled configs were showing as "unknown"

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1072,7 +1072,7 @@ class sr_GlobalState:
                                 hung_instances += 1
                                 self.states[c][cfg]['hung_instances'].append(i)
 
-                    flow_status = 'unknown'
+                    flow_status = 'unknown' if self.configs[c][cfg]['status'] != 'disabled' else 'disabled'
                     if hung_instances > 0 and (observed_instances > 0):
                          flow_status = 'hung'
                     elif observed_instances < int(self.configs[c][cfg]['instances']):


### PR DESCRIPTION
I did *sr3 disable post/t_dd1_f00*  and afterward sr3 status shows it as "unkn" unknown status.
It should show disabled.


```
host% sr3 status
status:
Component/Config                         Processes   Connection        Lag                              Rates
                                         State   Run Retry  msg data   Queued  LagMax LagAvg  Last  %rej     pubsub messages   RxData     TxData
                                         -----   --- -----  --- ----   ------  ------ ------  ----  ----     ------ --------   ------     ------
cpost/pelle_dd1_f04                      stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
cpost/pelle_dd2_f05                      stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
cpost/veille_f34                         idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
cpump/xvan_f14                           idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
cpump/xvan_f15                           idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
poll/sftp_f62                            idle    1/1     0 100%   0%      0    0.00s    0.00s 16228.0s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
poll/sftp_f63                            wVip    1/1     0 100%   0%      0    0.00s    0.00s 16227.4s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
post/shim_f63                            stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
post/t_dd1_f00                           unkn    1/1     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
post/t_dd2_f00                           stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
post/test2_f61                           stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
report/tsarra_f20                        idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
sarra/download_f20                       idle    1/1     0 100%   0%      0    0.00s    0.00s 16262.0s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
sender/tsource2send_f50                  idle    1/1     0 100%   0%      1    0.00s    0.00s 16249.9s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
shovel/rabbitmqtt_f22                    idle    1/1     0 100%   0%      0    0.00s    0.00s 16254.7s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/amqp_f30                       idle    1/1     0 100%   0%      0    0.00s    0.00s 16262.0s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/cdnld_f21                      idle    1/1     0 100%   0%    194    0.00s    0.00s 16277.4s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/cfile_f44                      idle    1/1     0 100%   0%      1    0.00s    0.00s 16274.4s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/cp_f61                         idle    1/1     0 100%   0%      0    0.00s    0.00s 16249.7s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/ftp_f70                        idle    1/1     0 100%   0%      0    0.00s    0.00s 16237.8s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/mirror_f80                     idle    1/1     0 100%   0%      0    0.00s    0.00s 16235.4s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/q_f71                          idle    5/5     0 100%   0%      0    0.00s    0.00s 16217.1s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/rabbitmqtt_f31                 idle    1/1     0 100%   0%      0    0.00s    0.00s 16254.6s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
subscribe/u_sftp_f60                     idle    1/1     0 100%   0%      0    0.00s    0.00s 16249.7s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
watch/f40                                idle    1/1     0 100%   0%      0    0.00s    0.00s 16256.4s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s
      Total Running Configs:  20 ( Processes: 23 missing: 0 stray: 0 )
                     Memory: uss:896.6 MiB rss:1.2 GiB vms:3.3 GiB
                   CPU Time: User:1051.34s System:189.66s
           Pub/Sub Received: 0 msgs/s (0 Bytes/s), Sent:  0 msgs/s (0 Bytes/s) Queued: 196 Retry: 0, Mean lag: 0.00s
              Data Received: 0 Files/s (0 Bytes/s), Sent: 0 Files/s (0 Bytes/s)
host%

```