### PR TITLE
Fix mkdir failures on hpc

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -457,7 +457,6 @@ class sr_GlobalState:
             for cfg in self.configs[c]:
                     #print( f" {self.configs[c][cfg]['statehost']=} " )
                     if 'options' in self.configs[c][cfg] and self.configs[c][cfg]['options'].statehost:
-                        print('statehost')
                         state_dir=self.user_cache_dir + os.sep + self.hostdir + os.sep + c + os.sep + cfg
                     else:
                         state_dir=self.user_cache_dir + os.sep + c + os.sep + cfg

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -380,7 +380,7 @@ class sr_GlobalState:
         other_config_dir = sarracenia.user_config_dir(savename, self.appauthor)
 
         if not os.path.exists(other_config_dir):
-            os.mkdir(other_config_dir)
+            pathlib.Path(other_config_dir).mkdir(parents=True, exist_ok=True)
 
         for f in ['default.conf', 'admin.conf']:
             to = other_config_dir + os.sep + f
@@ -901,14 +901,15 @@ class sr_GlobalState:
                 }
         for c in self.components:
             if not os.path.exists( self.user_cache_dir + os.sep + c ):
-                os.mkdir(self.user_cache_dir + os.sep + c )
+                pathlib.Path(self.user_cache_dir + os.sep + c ).mkdir(parents=True, exist_ok=True)
             if (c not in self.states) or (c not in self.configs):
                 continue
 
             for cfg in self.configs[c]:
                 if cfg not in self.states[c]:
                     print('missing state for %s/%s' % (c,cfg))
-                    os.mkdir(self.user_cache_dir + os.sep + c + os.sep + cfg)
+                    if not os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg):
+                        pathlib.Path(self.user_cache_dir + os.sep + c + os.sep + cfg).mkdir(parents=True, exist_ok=True)
                     # add config as state in .cache under right directory.
                     self.states[c][cfg] = {}
                     self.states[c][cfg]['instance_pids'] = {}


### PR DESCRIPTION
things that broke on HPC... and noticed a useless message.
```

[me@host ~]$ sr3 status
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
statehost
missing state for winnow/winnow-ss5-04
Traceback (most recent call last):
  File "/home/pas037/.local/bin/sr3", line 11, in <module>
    load_entry_point('metpx-sr3==3.0.53', 'console_scripts', 'sr3')()
  File "/usr/lib/python3.6/site-packages/sarracenia/sr.py", line 2963, in main
    gs = sr_GlobalState(cfg, cfg.configurations)
  File "/usr/lib/python3.6/site-packages/sarracenia/sr.py", line 1212, in __init__
    self._resolve()
  File "/usr/lib/python3.6/site-packages/sarracenia/sr.py", line 909, in _resolve
    os.mkdir(self.user_cache_dir + os.sep + c + os.sep + cfg)
FileExistsError: [Errno 17] File exists: '/home/pas037/.cache/sr3/winnow/winnow-ss5-04'
[me@host ~]$

```
