### PR TITLE
Scheduled flow with HTTP metadata: add variable expansion for the path

### DIFF
--- a/sarracenia/flowcb/scheduled/http_with_metadata.py
+++ b/sarracenia/flowcb/scheduled/http_with_metadata.py
@@ -44,6 +44,9 @@ class Http_with_metadata(Scheduled):
         for relPath in self.o.path:
             st = FmdStat()
 
+            # Do variable expansion on the path
+            relPath = self.o.variableExpansion(relPath)
+
             if self.o.post_baseUrl[-1] == '/':
                 url = self.o.post_baseUrl + relPath
             else:


### PR DESCRIPTION
This will let us have paths like this:

```
path ${%Y%m%d}/${%Y%m%d}_0000_F06_wind_340_a.gif
```