### PR TITLE
Issue1089 fileAgeMin and fileAgeMax should be honoured by all components

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -962,8 +962,13 @@ class Flow:
             if self.o.messageAgeMax != 0 and lag > self.o.messageAgeMax:
                 self.reject(
                     m, 504,
-                    "Excessive lag: %g sec. Skipping download of: %s, " %
-                    (lag, m['new_file']))
+                    f"message too old (high lag): {lag:g} sec. skipping: {m['new_file']}, " )
+                continue
+
+            if self.o.fileAgeMax > 0 and 'mtime' in m:
+                age =  now-sarracenia.timestr2flt(m['mtime'])
+                if age > self.o.fileAgeMax:
+                    self.reject( m, 410, f"file too old: {age:g} sec. skipping: {m['new_file']}, ")
                 continue
 
             if 'fileOp' in m and 'rename' in m['fileOp']:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -965,11 +965,16 @@ class Flow:
                     f"message too old (high lag): {lag:g} sec. skipping: {m['new_file']}, " )
                 continue
 
-            if self.o.fileAgeMax > 0 and 'mtime' in m:
+            if 'mtime' in m:
                 age =  now-sarracenia.timestr2flt(m['mtime'])
-                if age > self.o.fileAgeMax:
+                if self.o.fileAgeMax > 0 and age > self.o.fileAgeMax:
                     self.reject( m, 410, f"file too old: {age:g} sec. skipping: {m['new_file']}, ")
-                continue
+                    continue
+
+                if self.o.fileAgeMin > 0 and age < self.o.fileAgeMin:
+                    logger.warning( f"file too young: queueing for retry.")
+                    self.worklist.failed.append(msg)
+                    continue
 
             if 'fileOp' in m and 'rename' in m['fileOp']:
                 url = self.o.variableExpansion(m['baseUrl'],


### PR DESCRIPTION
closes #1089

* put a check in flow/__init__.py/ filter() routine... which is used by all components.  
* files that are too old, are *rejected* (permanently dropped.)
* files that are too youn, are *failed*, which should result in them being put on the retry list for later.