### PR TITLE
fix #1095 crash in sender when size missing from message

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2470,6 +2470,8 @@ class Flow:
                     % local_file)
                 time.sleep(0.01)
                 return False
+            elif 'size' not in msg:
+                msg['size'] = os.path.getsize(local_file)
 
             offset = 0
             if ('blocks' in msg) and (msg['blocks']['method'] == 'inplace'):


### PR DESCRIPTION
close #1095 

proper fix in code so we don't need the work-around.
