### PR TITLE
Issue1104 msg rate cpu

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1601,6 +1601,15 @@ This test will only apply if a flow is actually transferring messages.
 The rate is only visible in *sr3 --full status* 
 
 This may indicate that the routing is inordinately expensive or the transfers inordinately slow.
+Examples that could contribute to this:
+
+* one hundred regular expressions must be evaluated per message received. Regex's, when cumulated, can get expensive.
+
+* a complex plugin that does heavy transformations on data in route.
+
+* repeating an operation for each message, when doing it once per batch would do.
+
+
 It defaults to inactive, but may be set to identify transient issues.
 
 runStateThreshold_hung <interval> (default: 450)

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1591,6 +1591,18 @@ a file before it is aged out of a the queue.  Default is two days.  If a file ha
 been transferred after two days of attempts, it is discarded.
 
 
+runStateThreshold_cpuSlow <count> (default: 0)
+----------------------------------------------
+
+The *runStateThreshold_cpuSlow* setting sets the minimum rate of transfer expected for flow
+processing messages. If the messages processed per cpu second rate drops below this threshold,
+then the flow will be identified as "cpuSlow." (shown as cpuS on the *sr3 status* display.)
+This test will only apply if a flow is actually transferring messages.
+The rate is only visible in *sr3 --full status* 
+
+This may indicate that the routing is inordinately expensive or the transfers inordinately slow.
+It defaults to inactive, but may be set to identify transient issues.
+
 runStateThreshold_hung <interval> (default: 450)
 ------------------------------------------------
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1581,6 +1581,14 @@ Ce test ne s'appliquera que si un flux transfère réellement des messages.
 Le taux n'est visible que dans *sr3 --full status*
 
 Cela peut indiquer que l'acheminement est excessivement coûteux ou que les transferts sont excessivement lents.
+Exemples qui pourraient y contribuer :
+
+* une centaine d'expressions régulières doivent être évaluées par message reçu. les expressions régulières, une fois cumulées, peuvent coûter cher.
+
+* un plugin complexe qui effectue de lourdes transformations sur les données en cours de route.
+
+* répéter une opération pour chaque message, alors qu'il suffirait de la faire une fois par lot.
+
 Par défaut, il est inactif, mais peut être défini pour identifier des problèmes temporaires.
 
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1571,6 +1571,18 @@ L’option **retry_ttl** (nouvelle tentative de durée de vie) indique combien d
 un fichier avant qu’il ne soit  rejeté de la fil d’attente.  Le défaut est de deux jours.  Si un fichier n’a pas
 été transféré après deux jours de tentatives, il est jeté.
 
+runStateThreshold_cpuSlow <count> (par défaut : 0)
+---------------------------------------------------
+
+Le paramètre *runStateThreshold_cpuSlow* définit le taux de transfert minimum attendu pour le flux
+de messages. Si le débit des messages traités par seconde CPU tombe en dessous de ce seuil,
+alors le flux sera identifié comme « cpuSlow ». (affiché comme cpuS sur l'écran *sr3 status*.)
+Ce test ne s'appliquera que si un flux transfère réellement des messages.
+Le taux n'est visible que dans *sr3 --full status*
+
+Cela peut indiquer que l'acheminement est excessivement coûteux ou que les transferts sont excessivement lents.
+Par défaut, il est inactif, mais peut être défini pour identifier des problèmes temporaires.
+
 
 runStateThreshold_hung <intervalle> (défaut: 450s)
 --------------------------------------------------

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -92,7 +92,6 @@ default_options = {
     'dry_run': False,
     'filename': None,
     'flowMain': None,
-    'runStateThreshold_idle': 900,
     'inflight': None,
     'inline': False,
     'inlineOnly': False,
@@ -101,7 +100,6 @@ default_options = {
     'logMetrics': False,
     'logStdout': False,
     'metrics_writeInterval': 5,
-    'runStateThreshold_lag': 30,
     'nodupe_driver': 'disk',
     'nodupe_ttl': 0,
     'overwrite': True,
@@ -119,8 +117,11 @@ default_options = {
     'report': False,
     'retryEmptyBeforeExit': False,
     'retry_refilter': False,
-    'runStateThreshold_retry': 1000,
+    'runStateThreshold_cpuSlow': 0,
     'runStateThreshold_hung': 450,
+    'runStateThreshold_idle': 900,
+    'runStateThreshold_lag': 30,
+    'runStateThreshold_retry': 1000,
     'runStateThreshold_slow': 0,
     'sourceFromExchange': False,
     'sourceFromMessage': False,
@@ -136,7 +137,7 @@ default_options = {
 count_options = [
     'batch', 'count', 'exchangeSplit', 'instances', 'logRotateCount', 'no', 
     'post_exchangeSplit', 'prefetch', 'messageCountMax', 'messageRateMax', 
-    'messageRateMin', 'runStateThreshold_reject', 'runStateThreshold_retry', 'runStateThreshold_slow'
+    'messageRateMin', 'runStateThreshold_cpuSlow', 'runStateThreshold_reject', 'runStateThreshold_retry', 'runStateThreshold_slow', 
 ]
 
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -218,7 +218,8 @@ class Flow:
 
         self.new_metrics = { 'flow': { 'stop_requested': False, 'last_housekeeping': 0,  
               'transferConnected': False, 'transferConnectStart': 0, 'transferConnectTime':0, 
-              'transferRxBytes': 0, 'transferTxBytes': 0, 'transferRxFiles': 0, 'transferTxFiles': 0 } }
+              'transferRxBytes': 0, 'transferTxBytes': 0, 'transferRxFiles': 0, 'transferTxFiles': 0,
+              'last_housekeeping_cpuTime': 0, 'cpuTime' : 0, } }
 
         # carry over some metrics... that don't reset.
         if hasattr(self,'metrics'):
@@ -364,6 +365,8 @@ class Flow:
                 except Exception as ex:
                     logger.error( f'flowCallback plugin {p}/metricsReport crashed: {ex}' )
                     logger.debug( "details:", exc_info=True )
+        ost = os.times()
+        self.metrics['flow']['cpuTime'] = ost.user+ost.system-self.metrics['flow']['last_housekeeping_cpuTime']
 
     def _runCallbackPoll(self):
         if hasattr(self, "Poll"):
@@ -412,6 +415,9 @@ class Flow:
         self.runCallbacksTime('on_housekeeping')
         self.metricsFlowReset()
         self.metrics['flow']['last_housekeeping'] = now
+        ost = os.times()
+        self.metrics['flow']['last_housekeeping_cpuTime'] = ost.user+ost.system
+        self.metrics['flow']['cpuTime'] = ost.user+ost.system
 
         next_housekeeping = now + self.o.housekeeping
         self.metrics['flow']['next_housekeeping'] = next_housekeeping
@@ -529,6 +535,8 @@ class Flow:
         current_sleep = self.o.sleep
         last_time = start_time
         self.metrics['flow']['last_housekeeping'] = start_time
+        ost=os.times()
+        self.metrics['flow']['last_housekeeping_cpuTime'] =  ost.user+ost.system
 
         if self.o.logLevel == 'debug':
             logger.debug("options:")
@@ -600,6 +608,7 @@ class Flow:
             elapsed = now - last_time
 
             self.metrics['flow']['msgRate'] = current_rate
+            self.metrics['flow']['msgRateCpu'] = total_messages / (self.metrics['flow']['cpuTime']+self.metrics['flow']['last_housekeeping_cpuTime'] )
 
             if (last_gather_len == 0) and (self.o.sleep < 0):
                 if (self.o.retryEmptyBeforeExit and "retry" in self.metrics

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -55,14 +55,14 @@ import urllib.parse
 
 logger = logging.getLogger(__name__)
 
-empty_metrics={ "byteRate":0, "rejectCount":0, "last_housekeeping":0, "messagesQueued": 0, 
+empty_metrics={ "byteRate":0, "cpuTime":0, "rejectCount":0, "last_housekeeping":0, "messagesQueued": 0, 
         "lagMean": 0, "latestTransfer": 0, "rejectPercent":0, "transferRxByteRate":0, "transferTxByteRate": 0,
         "rxByteCount":0, "rxGoodCount":0, "rxBadCount":0, "txByteCount":0, "txGoodCount":0, "txBadCount":0, 
         "lagMax":0, "lagTotal":0, "lagMessageCount":0, "disconnectTime":0, "transferConnectTime":0, 
         "transferRxLast": 0, "transferTxLast": 0, "rxLast":0, "txLast":0, 
         "transferRxBytes":0, "transferRxFiles":0, "transferTxBytes": 0, "transferTxFiles": 0, 
         "msgs_in_post_retry": 0, "msgs_in_download_retry":0, "brokerQueuedMessageCount": 0, 
-        'time_base': 0, 'byteTotal': 0, 'byteRate': 0, 'msgRate': 0, 'retry': 0, 'transferLast': 0,
+        'time_base': 0, 'byteTotal': 0, 'byteRate': 0, 'msgRate': 0, 'msgRateCpu': 0, 'retry': 0, 'transferLast': 0,
         'connectPercent': 0, 'byteConnectPercent': 0
         }
 
@@ -894,7 +894,7 @@ class sr_GlobalState:
                 'rxLagTime':0, 'rxLagCount':0, 
                 'rxMessageQueued':0, 'rxMessageRetry':0, 
                 'txMessageQueued':0, 'txMessageRetry':0, 
-                'rxMessageRate':0, 'rxDataRate':0, 'rxFileRate':0, 'rxMessageByteRate':0, 
+                'rxMessageRate':0, 'rxMessageRateCpu':0, 'rxDataRate':0, 'rxFileRate':0, 'rxMessageByteRate':0, 
                 'txMessageRate':0, 'txDataRate':0, 'txFileRate':0, 'txMessageByteRate':0
                 }
         for c in self.components:
@@ -953,6 +953,8 @@ class sr_GlobalState:
                                             metrics['txLast'] = newval
                                         if 'messageLast' not in metrics or (newval > metrics['messageLast']):
                                             metrics['messageLast'] = newval
+                                    elif k in [ "cpuTime" ]:
+                                        metrics['cpuTime'] += newval
                                     else:
                                         metrics[k] += newval
                                 #else:
@@ -999,9 +1001,14 @@ class sr_GlobalState:
             
                             m['byteRate'] = byteTotal/time_base
                             m['msgRate']  = (m["rxGoodCount"]+m["rxBadCount"])/time_base
+                            if m['cpuTime'] > 0:
+                                m['msgRateCpu'] = (m["rxGoodCount"]+m["rxBadCount"])/m['cpuTime']
+                            else:
+                                m['msgRateCpu'] = 0
 
                             self.cumulative_stats['rxMessageByteRate'] += m['byteRate']
                             self.cumulative_stats['rxMessageRate'] +=  m['msgRate']
+                            self.cumulative_stats['rxMessageRateCpu'] +=  m['msgRateCpu']
     
                             m['transferRxByteRate'] = m['transferRxBytes']/time_base
                             m['transferRxFileRate'] = m['transferRxFiles']/time_base
@@ -1109,6 +1116,10 @@ class sr_GlobalState:
                         flow_status = 'idle'
                     else:
                         flow_status = 'running'
+
+                    if self.states[c][cfg]['metrics']['msgRate'] > 0 and \
+                           self.states[c][cfg]['metrics']['msgRateCpu'] < self.configs[c][cfg]['options'].runStateThreshold_cpuSlow:
+                        flow_status = 'cpuSlow'
 
                     self.states[c][cfg]['resource_usage'] = copy.deepcopy(resource_usage)
                     self.configs[c][cfg]['status'] = flow_status
@@ -1285,7 +1296,7 @@ class sr_GlobalState:
             'sender', 'shovel', 'subscribe', 'watch', 'winnow'
         ]
         # active means >= 1 process exists on the node.
-        self.status_active =  ['hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'waitVip' ]
+        self.status_active =  ['cpuSlow', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'waitVip' ]
         self.status_values = self.status_active + [ 'disabled', 'include', 'missing', 'stopped', 'unknown' ]
 
         self.bin_dir = os.path.dirname(os.path.realpath(__file__))
@@ -2505,7 +2516,7 @@ class sr_GlobalState:
         line = "%-40s %-11s %7s %10s %19s %14s %38s " % ("Component/Config", "Processes", "Connection", "Lag", "", "Rates", "" )
 
         if self.options.displayFull:
-            line += "%-40s %17s %33s %40s" % ("Counters (per housekeeping)", "", "Data Counters", "" )
+            line += "%10s %-40s %17s %33s %40s" % ("", "Counters (per housekeeping)", "", "Data Counters", "" )
             line += "%s %-21s " % (" ", "Memory" ) 
 
         if self.options.displayFull:
@@ -2518,8 +2529,8 @@ class sr_GlobalState:
             underline = "%-40s %-5s %5s %5s %4s %4s %8s %7s %5s %5s %5s %10s %-10s %-10s %-10s " % ("", "-----", "---", "-----", "---", "----", "------", "------", "------", "----", "----", "------", "--------", "------", "------" )
 
             if self.options.displayFull:
-                line      += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s" % \
-                        ( "subBytes", "Accepted", "Rejected", "Malformed", "pubBytes", "pubMsgs", "pubMal", "rxData", "rxFiles", "txData", "txFiles", "Since" )
+                line      += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s" % \
+                        ( "Msg/scpu", "subBytes", "Accepted", "Rejected", "Malformed", "pubBytes", "pubMsgs", "pubMal", "rxData", "rxFiles", "txData", "txFiles", "Since" )
                 underline += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s %10s " % \
                         ( "-------", "--------", "--------", "---------", "-------", "------", "-----", "-----", "-------", "------", "-------", "-----" )
 
@@ -2588,7 +2599,8 @@ class sr_GlobalState:
                             )
 
                     if self.options.displayFull :
-                        line += " %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %7.2fs" % ( \
+                        line += " %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %7.2fs" % ( \
+                            naturalSize(m['msgRateCpu']).replace("B","m").replace("mytes","msgs"), \
                             naturalSize(m['rxByteCount']), \
                             naturalSize(m['rxGoodCount']).replace("B","m").replace("myte","msg"), \
                             naturalSize(m["rejectCount"]).replace("B","m").replace("myte","msg"), \

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2600,7 +2600,7 @@ class sr_GlobalState:
                             naturalSize(m["transferRxFiles"]).replace("B","F").replace("Fyte","File"), \
                             naturalSize(m["transferTxBytes"]), \
                             naturalSize(m["transferTxFiles"]).replace("B","F").replace("Fyte","File"), \
-                            time_base )
+                            m["time_base"] )
                 else:
                     line += " %10s %10s %9s %5s %5s %10s %8s" % ( "-", "-", "-", "-", "-", "-", "-" )
                     if self.options.displayFull:


### PR DESCRIPTION
close #1104 

adds a metric to understand how expensive routing each message is.
currently only deals with received messages.  Should we fold in transmitted messages also?
same metric? other metric? 

Typically the complexity is not on transmission, but rather reception (filtering is there.)


sample output (during a static flow test) look at the... nth column... um... titled msg/scpu

```
SSC-5CD2310S60% sr3 --full status
status:
Component/Config                         Processes   Connection        Lag                              Rates                                                   Counters (per housekeeping)                                                    Data Counters                                           Memory                             CPU Time
                                         State   Run Retry  msg data   Queued  LagMax LagAvg  Last  %rej     pubsub messages   RxData     TxData       Msg/scpu   subBytes   Accepted   Rejected  Malformed   pubBytes    pubMsgs     pubMal     rxData    rxFiles     txData    txFiles    Since       uss        rss        vms       user     system
                                         -----   --- -----  --- ----   ------  ------ ------  ----  ----     ------ --------   ------     ------        -------   --------   --------  ---------    -------     ------      -----      -----    -------     ------  -------      -----        ---        ---        ---       ----     ------
cpost/pelle_dd1_f04                      stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files    0.00s    0 Bytes    0 Bytes    0 Bytes        0.00       0.00
cpost/pelle_dd2_f05                      stop    0/0     0   0%   0%      0    0.00s    0.00s 0      0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files    0.00s    0 Bytes    0 Bytes    0 Bytes        0.00       0.00
cpost/veille_f34                         idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  131.10s    5.1 MiB    8.9 MiB   15.9 MiB        0.22       0.18
cpump/xvan_f14                           idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files   56.61s    5.6 MiB    9.5 MiB   16.8 MiB        0.13       0.16
cpump/xvan_f15                           idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files   92.23s    3.2 MiB    5.0 MiB   16.3 MiB        0.09       0.07
poll/sftp_f62                            cpuS    1/1     0 100%   0%      0    1.26s    0.66s 66.5s 687.2%  7.7 KiB/s  10 msgs/s  0 Bytes/s  0 Bytes/s   227 msgs  500.9 KiB    1.4 Kim    9.5 Kim     0 msgs  500.9 KiB    1.4 Kim     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  129.36s   53.2 MiB   68.1 MiB  235.9 MiB        6.26       0.90
poll/sftp_f63                            wVip    1/1     0 100%   0%      0   20.18s    8.79s 65.7s  0.0%  3.9 KiB/s  10 msgs/s  0 Bytes/s  0 Bytes/s    1.9 Kim  500.9 KiB    1.4 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  129.29s   44.2 MiB   58.5 MiB   82.9 MiB        1.53       0.17
post/shim_f63                            stop    0/0          -          -         -     -     -          -        -        -       -          -          -          -          -          -          -          -          -          -          -          -          -          -          -          -
post/t_dd1_f00                           stop    0/0     0 100%   0%      0   12.24s    7.02s 115.5s  0.0%  3.3 KiB/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs    10 msgs     0 msgs  437.3 KiB    1.0 Kim     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  131.07s    0 Bytes    0 Bytes    0 Bytes        0.00       0.00
post/t_dd2_f00                           stop    0/0     0 100%   0%      0   12.46s    7.15s 115.3s  0.0%  3.4 KiB/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs    10 msgs     0 msgs  445.2 KiB    1.0 Kim     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  131.11s    0 Bytes    0 Bytes    0 Bytes        0.00       0.00
post/test2_f61                           stop    0/0     0 100%   0%      0    0.49s    0.48s 90.6s  0.0% 133 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs   11.9 KiB    25 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files   91.23s    0 Bytes    0 Bytes    0 Bytes        0.00       0.00
report/tsarra_f20                        idle    1/1     0 100%   0%      0    0.00s    0.00s n/a    0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  129.77s   39.3 MiB   53.4 MiB   77.7 MiB        0.87       0.03
sarra/download_f20                       idle    1/1     0 100%   0%      0    0.00s    0.00s 103.8s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files    5.68s   41.5 MiB   55.9 MiB   81.2 MiB        4.61       0.73
sender/tsource2send_f50                  cpuS    1/1     0 100%  95%      0    7.82s    4.00s 94.2s  0.0% 31.8 KiB/s  10 msgs/s  0 Bytes/s 12.8 KiB/s   124 msgs    2.0 MiB    1.4 Kim     0 msgs     0 msgs    2.0 MiB    1.4 Kim     0 msgs    0 Bytes    0 Files    1.6 MiB    1.4 KiF  129.61s   42.8 MiB   57.3 MiB  225.6 MiB        9.90       2.32
shovel/rabbitmqtt_f22                    run     1/1     0 100%   0%      0    4.07s    2.46s 99.3s  0.0% 31.9 KiB/s  10 msgs/s  0 Bytes/s  0 Bytes/s    1.0 Kim    2.0 MiB    1.4 Kim     0 msgs     0 msgs    2.0 MiB    1.4 Kim     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files  129.37s   40.2 MiB   54.4 MiB   79.0 MiB        1.91       0.31
subscribe/amqp_f30                       cpuS    1/1     0 100%  95%      0   24.00s   14.87s 103.8s  0.0%  4.5 KiB/s  10 msgs/s 12.8 KiB/s  0 Bytes/s   403 msgs  580.8 KiB    1.4 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    1.6 MiB    1.4 KiF    0 Bytes    0 Files  129.27s   40.1 MiB   54.6 MiB   79.0 MiB        3.60       0.78
subscribe/cdnld_f21                      cpuS    1/1     0 100%  98%    163   15.21s    9.85s 114.6s  0.1%  4.8 KiB/s  13 msgs/s 12.8 KiB/s  0 Bytes/s   337 msgs  615.4 KiB    1.7 Kim     2 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    1.6 MiB    1.7 KiF    0 Bytes    0 Files  129.27s   42.3 MiB   62.2 MiB   89.3 MiB        5.18       0.80
subscribe/cfile_f44                      cpuS    1/1     0 100%  98%      1    2.01s    0.95s 112.7s  0.0%  4.6 KiB/s  11 msgs/s 12.8 KiB/s  0 Bytes/s   388 msgs  596.5 KiB    1.5 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    1.6 MiB    1.5 KiF    0 Bytes    0 Files  129.43s   42.2 MiB   61.8 MiB   89.2 MiB        4.19       0.55
subscribe/cp_f61                         run     1/1     0 100%  89%      0    8.87s    5.71s 93.8s  0.0% 15.8 KiB/s  10 msgs/s  4.7 KiB/s  0 Bytes/s    1.3 Kim    2.0 MiB    1.4 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs  604.8 KiB  321 Files    0 Bytes    0 Files  129.34s   40.2 MiB   54.6 MiB   79.2 MiB        1.66       0.24
subscribe/ftp_f70                        cpuS    1/1     0 100%  87%      0    6.73s    3.51s 84.8s  0.0%  4.3 KiB/s   8 msgs/s 12.8 KiB/s  0 Bytes/s   258 msgs  550.5 KiB    1.1 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    1.6 MiB    1.1 KiF    0 Bytes    0 Files  129.42s   40.0 MiB   54.6 MiB   78.9 MiB        4.14       1.02
subscribe/mirror_f80                     cpuS    1/1     0 100%  87%      0    3.33s    1.40s 76.5s  0.0%  8.1 KiB/s  21 msgs/s 12.7 KiB/s  0 Bytes/s   445 msgs    1.0 MiB    2.8 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    1.6 MiB    2.8 KiF    0 Bytes    0 Files  129.64s   42.1 MiB   61.7 MiB   88.2 MiB        5.64       1.53
subscribe/q_f71                          cpuS    5/5     0 100%  11%      0   11.31s    3.54s 45.6s  0.1%  3.9 KiB/s  10 msgs/s 12.8 KiB/s  0 Bytes/s    14 msgs  500.9 KiB    1.4 Kim      1 msg     0 msgs    0 Bytes     0 msgs     0 msgs    1.6 MiB    1.4 KiF    0 Bytes    0 Files  129.34s  218.7 MiB  319.2 MiB    1.5 GiB      100.80       3.16
subscribe/rabbitmqtt_f31                 run     1/1     0 100%  90%      0    7.19s    3.75s 97.9s  0.0% 15.8 KiB/s  10 msgs/s  4.7 KiB/s  0 Bytes/s    1.4 Kim    2.0 MiB    1.4 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs  604.8 KiB  321 Files    0 Bytes    0 Files  129.38s   40.2 MiB   54.7 MiB   78.2 MiB        1.52       0.26
subscribe/u_sftp_f60                     run     1/1     0 100%  89%      0    8.85s    5.65s 93.8s  0.0% 15.8 KiB/s  10 msgs/s  4.7 KiB/s  0 Bytes/s    1.3 Kim    2.0 MiB    1.4 Kim     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs  604.8 KiB  321 Files    0 Bytes    0 Files  129.60s   40.2 MiB   54.7 MiB   79.2 MiB        1.65       0.21
watch/f40                                run     1/1     0 100%   0%      0    0.00s    0.00s 100.0s  0.0%  0 Bytes/s   0 msgs/s  0 Bytes/s  0 Bytes/s     0 msgs    0 Bytes     0 msgs     0 msgs     0 msgs    0 Bytes     0 msgs     0 msgs    0 Bytes    0 Files    0 Bytes    0 Files    7.87s   50.6 MiB   69.7 MiB  307.6 MiB       10.31       3.00
      Total Running Configs:  19 ( Processes: 23 missing: 0 stray: 0 )
                     Memory: uss:871.6 MiB rss:1.2 GiB vms:3.2 GiB
                   CPU Time: User:164.21s System:16.42s
           Pub/Sub Received: 176 msgs/s (167.5 KiB/s), Sent:  49 msgs/s (42.3 KiB/s) Queued: 164 Retry: 0, Mean lag: 4.93s
              Data Received: 106 Files/s (107.6 KiB/s), Sent: 10 Files/s (12.8 KiB/s)
SSC-5CD2310S60%
```

I set the runStateThrehold_cpuSlow to 1000 ... which is kind of high for this, so a lot of flows show up as cpuS in the second column.
