### PR TITLE
Change chmod -> utime, i think it was a typo?

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2742,7 +2742,7 @@ class Flow:
                 except:
                     pass
 
-        if hasattr(proto, 'chmod'):
+        if hasattr(proto, 'utime'):
             if self.o.timeCopy and 'mtime' in msg and msg['mtime']:
                 mtime = sarracenia.timestr2flt(msg['mtime'])
                 atime = mtime


### PR DESCRIPTION
I think this was supposed to be hasattr(proto, 'utime'). The chmod method is never used inside this if statement, but utime is. The call to utime is wrapped in a try/except, so this wouldn't have caused a crash.