### PR TITLE
fix crash where 'dictionary changed size during iteration'

### DIFF
--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -81,8 +81,8 @@ class Retry(FlowCB):
 
         # eliminate calculated values so it is refiltered from scratch.
         for m in message_list:
-             for k in m:
-                 if k in m['_deleteOnPost'] or k.startswith('new_'):
+             for k in list(m.keys()):
+                 if k in m and (k in m['_deleteOnPost'] or k.startswith('new_')):
                      del m[k]
              m['_isRetry'] = True
              m['_deleteOnPost'] = set( [ '_isRetry' ] )


### PR DESCRIPTION
When using the retry_refilter option, retry's gather method would crash, because keys were being deleted from the dictionary while it was being iterated through.

Now we're iterating through a copy of the dictionary's keys when the loop starts.