### PR TITLE
Enable blocked tests

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -31,7 +31,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
+       which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server, partitioned_flow ]
        osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
 
     runs-on: ${{ matrix.osver }}

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -20,7 +20,7 @@ pip3 install pyftpdlib paramiko net-tools
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
 # See issue #407, #445.
-for PKG in amqp appdirs dateparser watchdog netifaces humanize jsonpickle paho-mqtt psutil xattr rangehttpserver; do
+for PKG in amqp appdirs dateparser flufl.lock humanize jsonpickle netifaces paho-mqtt psutil watchdog xattr ; do
     PKG_INSTALLED="`pip3 list | grep ${PKG}`"
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -20,7 +20,7 @@ pip3 install pyftpdlib paramiko net-tools
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
 # See issue #407, #445.
-for PKG in amqp appdirs dateparser flufl.lock humanize jsonpickle netifaces paho-mqtt psutil watchdog xattr ; do
+for PKG in amqp appdirs dateparser flufl.lock humanize jsonpickle netifaces paho-mqtt psutil rangehttpserver watchdog xattr ; do
     PKG_INSTALLED="`pip3 list | grep ${PKG}`"
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"


### PR DESCRIPTION
Add running the partitioned_flow flow tests to the standard suite, so that breakage in blocked transfers will be noticed in future.
This stuff is basically working, but need to keep it that way as the code evolves.

(best to squash merge, had a broken commit in the middle.)

