### PR TITLE
Adjust column widths, shorten units.

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -891,6 +891,7 @@ class sr_GlobalState:
         # comparing states and configs to find missing instances, and correct state.
         self.resources={ 'uss': 0, 'rss': 0, 'vms':0, 'user_cpu': 0, 'system_cpu':0 }
         self.cumulative_stats={ 
+                'flowNameWidth': 0, 'latestTransferWidth': 0, 
                 'rxLagTime':0, 'rxLagCount':0, 
                 'rxMessageQueued':0, 'rxMessageRetry':0, 
                 'txMessageQueued':0, 'txMessageRetry':0, 
@@ -902,6 +903,9 @@ class sr_GlobalState:
                 continue
 
             for cfg in self.configs[c]:
+                if len( f"{c}/{cfg}" ) > self.cumulative_stats['flowNameWidth']:
+                    self.cumulative_stats['flowNameWidth'] = len( f"{c}/{cfg}" ) 
+
                 if cfg not in self.states[c]:
                     logger.debug('no existing state files for %s/%s' % (c,cfg))
                     self.states[c][cfg] = {}
@@ -984,9 +988,21 @@ class sr_GlobalState:
     
                         m['latestTransfer'] = "n/a"
                         if "transferLast" in m and m['transferLast'] > 0:
-                            m['latestTransfer'] = f"{now - m['transferLast']:4.1f}s"
+                            v=now - m['transferLast']
+                            if v > 100:
+                                m['latestTransfer'] = f"{round(v):4d}s"
+                            else:
+                                m['latestTransfer'] = f"{v:4.1f}s"
                         elif "messageLast" in m:
-                            m['latestTransfer'] = f"{now - m['messageLast']:4.1f}s"
+                            v=now - m['messageLast']
+                            if v > 100:
+                                m['latestTransfer'] = f"{round(v):4d}s"
+                            else:
+                                m['latestTransfer'] = f"{v:4.1f}s"
+
+                        
+                        if len(m['latestTransfer']) > self.cumulative_stats['latestTransferWidth']:
+                            self.cumulative_stats['latestTransferWidth'] = len(m['latestTransfer'])
     
                         if "last_housekeeping" in m and m["last_housekeeping"] > 0:
                             m['time_base'] = now - m[ "last_housekeeping" ] 
@@ -1035,6 +1051,8 @@ class sr_GlobalState:
                             self.cumulative_stats['txMessageRate'] +=  (m["txGoodCount"]+m["txBadCount"])/time_base
                         if m["rxGoodCount"] > 0:
                             m['rejectPercent'] = ((m['rejectCount']+m['rxBadCount'])/m['rxGoodCount'])*100
+                            if m['rejectPercent'] > 100:
+                                m['rejectPercent']=100
                         else:
                             m['rejectPercent'] = 0
 
@@ -2512,19 +2530,8 @@ class sr_GlobalState:
         """ v3 Printing prettier statuses for each component/configs found
         """
 
-        flowNameWidth=0
-        for c in sorted(self.configs):
-            for cfg in sorted(self.configs[c]):
-                f = c + os.sep + cfg
-                if f not in self.filtered_configurations:
-                    continue
-                if self.configs[c][cfg]['status'] == 'include':
-                    continue
-
-                if not (c in self.states and cfg in self.states[c]):
-                    continue
-                if len(f) > flowNameWidth:
-                    flowNameWidth = len(f)
+        flowNameWidth=self.cumulative_stats['flowNameWidth']
+        latestTransferWidth=self.cumulative_stats['latestTransferWidth']
 
         lfmt = f"%-{flowNameWidth}s %-11s %7s %10s %19s %14s %38s "
         line = lfmt % ("Component/Config", "Processes", "Connection", "Lag", "", "Rates", "" )
@@ -2536,18 +2543,18 @@ class sr_GlobalState:
         if self.options.displayFull:
             line += "%10s %10s " % ( " ", "CPU Time" )
 
-        try:
+        if True: #try:
             print(line)
 
-            lfmt      = f"%-{flowNameWidth}s %-5s %5s %5s %4s %4s %8s %7s %5s %5s %5s %10s %-10s %-10s %-10s " 
-            line      =  lfmt % ("", "State", "Run", "Retry", "msg", "data", "Queued", "LagMax", "LagAvg", "Last", "%rej", "pubsub", "messages", "RxData", "TxData" )
-            underline =  lfmt % ("", "-----", "---", "-----", "---", "----", "------", "------", "------", "----", "----", "------", "--------", "------", "------" )
+            lfmt      = f"%-{flowNameWidth}s %-5s %5s %5s %4s %4s %5s %8s %8s %{latestTransferWidth}s %5s %10s %-10s %-10s %-10s " 
+            line      =  lfmt % ("", "State", "Run", "Retry", "msg", "data", "Que", "LagMax", "LagAvg", "Last", "%rej", "pubsub", "messages", "RxData", "TxData" )
+            underline =  lfmt % ("", "-----", "---", "-----", "---", "----", "---", "------", "------", "----", "----", "------", "--------", "------", "------" )
 
             if self.options.displayFull:
-                line      += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s" % \
+                line      += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s " % \
                         ( "Msg/scpu", "subBytes", "Accepted", "Rejected", "Malformed", "pubBytes", "pubMsgs", "pubMal", "rxData", "rxFiles", "txData", "txFiles", "Since" )
-                underline += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s %10s " % \
-                        ( "-------", "--------", "--------", "---------", "-------", "------", "-----", "-----", "-------", "------", "-------", "-----" )
+                underline += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s " % \
+                        ( "-------", "--------", "--------", "---------", "-------", "------", "-----", "-----", "-------", "------", "-------", "-----", "---" )
 
                 line      += "%10s %10s %10s " % ( "uss", "rss", "vms"  )
                 underline += "%10s %10s %10s " % ( "---", "---", "---"  )
@@ -2558,7 +2565,7 @@ class sr_GlobalState:
 
             print(line)
             print(underline)
-        except:
+        else: #except:
             return
 
         configs_running = 0
@@ -2606,9 +2613,9 @@ class sr_GlobalState:
 
                 if 'metrics' in self.states[c][cfg]:
                     m=self.states[c][cfg]['metrics']
-                    line += " %5d %3d%% %3d%% %6d %7.2fs %7.2fs %-5s %4.1f%% %8s/s %8s/s %8s/s %8s/s" % ( \
-                            m['retry'], m['connectPercent'], m['byteConnectPercent'], m['messagesQueued'], m['lagMax'], m['lagMean'], \
-                            m['latestTransfer'], m['rejectPercent'],\
+                    lfmt = f"%5d %3d%% %3d%% %5d %7.2fs %7.2fs %{latestTransferWidth}s %4.1f%% %8s/s %8s/s %8s/s %8s/s "
+                    line += lfmt % ( m['retry'], m['connectPercent'], m['byteConnectPercent'], \
+                            m['messagesQueued'], m['lagMax'], m['lagMean'], m['latestTransfer'], m['rejectPercent'],\
                             naturalSize(m['byteRate']).replace("Bytes","B"), \
                             naturalSize(m['msgRate']).replace("B","m").replace("mytes","m"), \
                             naturalSize(m['transferRxByteRate']).replace("Bytes","B"), \
@@ -2616,8 +2623,8 @@ class sr_GlobalState:
                             )
 
                     if self.options.displayFull :
-                        line += " %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %7.2fs" % ( \
-                            naturalSize(m['msgRateCpu']).replace("B","m").replace("mytes","msgs"), \
+                        line += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %7.2fs " % ( \
+                            naturalSize(m['msgRateCpu']).replace("B","m").replace("mytes","m/s"), \
                             naturalSize(m['rxByteCount']).replace("Bytes","B"), \
                             naturalSize(m['rxGoodCount']).replace("B","m").replace("mytes","m"), \
                             naturalSize(m["rejectCount"]).replace("B","m").replace("mytes","m"), \
@@ -2626,14 +2633,14 @@ class sr_GlobalState:
                             naturalSize(m['txGoodCount']).replace("B","m").replace("mytes","m"), \
                             naturalSize(m["txBadCount"]).replace("B","m").replace("mytes","m"), \
                             naturalSize(m["transferRxBytes"]).replace("Bytes","B"), \
-                            naturalSize(m["transferRxFiles"]).replace("B","F").replace("Fytes","F"), \
+                            naturalSize(m["transferRxFiles"]).replace("B","F").replace("Fytes","f"), \
                             naturalSize(m["transferTxBytes"]).replace("Bytes","B"), \
-                            naturalSize(m["transferTxFiles"]).replace("B","F").replace("Fytes","F"), \
+                            naturalSize(m["transferTxFiles"]).replace("B","F").replace("Fytes","f"), \
                             m["time_base"] )
                 else:
-                    line += " %10s %10s %9s %5s %5s %10s %8s" % ( "-", "-", "-", "-", "-", "-", "-" )
+                    line += "%10s %10s %9s %5s %5s %10s %8s " % ( "-", "-", "-", "-", "-", "-", "-" )
                     if self.options.displayFull:
-                        line += " %8s %7s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s" % \
+                        line += "%8s %7s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s" % \
                             ( "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-" )
 
                 if ('instance_pids' in self.states[c][cfg]) and (len(self.states[c][cfg]['instance_pids']) >= 0) and ('resource_usage' in self.states[c][cfg]):
@@ -2641,16 +2648,16 @@ class sr_GlobalState:
 
                     
                     if self.options.displayFull:
-                        line += " %10s %10s %10s " % (\
+                        line += "%10s %10s %10s " % (\
                              naturalSize( ru['uss'] ), naturalSize( ru['rss'] ), naturalSize( ru['vms'] )  \
                              )
-                        line += " %10.2f %10.2f" % (\
+                        line += "%10.2f %10.2f " % (\
                              ru['user_cpu'], ru['system_cpu'] \
                              )
                 else:
-                    line += " %10s %10s %10s" % ( "-", "-", "-" )
+                    line += "%10s %10s %10s" % ( "-", "-", "-" )
                     if self.options.displayFull:
-                        line += " %10s %10s" % ( "-", "-" )
+                        line += "%10s %10s" % ( "-", "-" )
                 try:
                      print(line)
                 except:
@@ -2680,9 +2687,9 @@ class sr_GlobalState:
                     self.cumulative_stats['rxMessageQueued'], self.cumulative_stats['rxMessageRetry'], self.cumulative_stats['lagMean']
                 ))
             print( '\t      Data Received: %s/s (%s/s), Sent: %s/s (%s/s) ' % (
-                   naturalSize(self.cumulative_stats['rxFileRate']).replace("B","F").replace("Fytes","F") ,
+                   naturalSize(self.cumulative_stats['rxFileRate']).replace("B","F").replace("Fytes","f") ,
                    naturalSize(self.cumulative_stats['rxDataRate']).replace("Bytes","B"),
-                   naturalSize( self.cumulative_stats['txFileRate']).replace("B","F").replace("Fytes","F"),
+                   naturalSize( self.cumulative_stats['txFileRate']).replace("B","F").replace("Fytes","f"),
                    naturalSize(self.cumulative_stats['txDataRate']).replace("Bytes","B") ) )
 
             # FIXME: does not seem to find any stray exchange (with no bindings...) hmm...

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2609,26 +2609,26 @@ class sr_GlobalState:
                     line += " %5d %3d%% %3d%% %6d %7.2fs %7.2fs %-5s %4.1f%% %8s/s %8s/s %8s/s %8s/s" % ( \
                             m['retry'], m['connectPercent'], m['byteConnectPercent'], m['messagesQueued'], m['lagMax'], m['lagMean'], \
                             m['latestTransfer'], m['rejectPercent'],\
-                            naturalSize(m['byteRate']), \
-                            naturalSize(m['msgRate']).replace("B","m").replace("mytes","msgs"), \
-                            naturalSize(m['transferRxByteRate']), \
-                            naturalSize(m['transferTxByteRate']) 
+                            naturalSize(m['byteRate']).replace("Bytes","B"), \
+                            naturalSize(m['msgRate']).replace("B","m").replace("mytes","m"), \
+                            naturalSize(m['transferRxByteRate']).replace("Bytes","B"), \
+                            naturalSize(m['transferTxByteRate']).replace("Bytes","B") 
                             )
 
                     if self.options.displayFull :
                         line += " %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %7.2fs" % ( \
                             naturalSize(m['msgRateCpu']).replace("B","m").replace("mytes","msgs"), \
-                            naturalSize(m['rxByteCount']), \
-                            naturalSize(m['rxGoodCount']).replace("B","m").replace("myte","msg"), \
-                            naturalSize(m["rejectCount"]).replace("B","m").replace("myte","msg"), \
-                            naturalSize(m["rxBadCount"]).replace("B","m").replace("myte","msg"), \
-                            naturalSize(m['txByteCount']), 
-                            naturalSize(m['txGoodCount']).replace("B","m").replace("myte","msg"), \
-                            naturalSize(m["txBadCount"]).replace("B","m").replace("myte","msg"), \
-                            naturalSize(m["transferRxBytes"]), \
-                            naturalSize(m["transferRxFiles"]).replace("B","F").replace("Fyte","File"), \
-                            naturalSize(m["transferTxBytes"]), \
-                            naturalSize(m["transferTxFiles"]).replace("B","F").replace("Fyte","File"), \
+                            naturalSize(m['rxByteCount']).replace("Bytes","B"), \
+                            naturalSize(m['rxGoodCount']).replace("B","m").replace("mytes","m"), \
+                            naturalSize(m["rejectCount"]).replace("B","m").replace("mytes","m"), \
+                            naturalSize(m["rxBadCount"]).replace("B","m").replace("mytes","m"), \
+                            naturalSize(m['txByteCount']).replace("Bytes","B"), 
+                            naturalSize(m['txGoodCount']).replace("B","m").replace("mytes","m"), \
+                            naturalSize(m["txBadCount"]).replace("B","m").replace("mytes","m"), \
+                            naturalSize(m["transferRxBytes"]).replace("Bytes","B"), \
+                            naturalSize(m["transferRxFiles"]).replace("B","F").replace("Fytes","F"), \
+                            naturalSize(m["transferTxBytes"]).replace("Bytes","B"), \
+                            naturalSize(m["transferTxFiles"]).replace("B","F").replace("Fytes","F"), \
                             m["time_base"] )
                 else:
                     line += " %10s %10s %9s %5s %5s %10s %8s" % ( "-", "-", "-", "-", "-", "-", "-" )
@@ -2673,17 +2673,17 @@ class sr_GlobalState:
                   ))
 
             print( '\t   Pub/Sub Received: %s/s (%s/s), Sent:  %s/s (%s/s) Queued: %d Retry: %d, Mean lag: %02.2fs' % ( 
-                    naturalSize(self.cumulative_stats['rxMessageRate']).replace("B","m").replace("myte","msg"), \
-                    naturalSize(self.cumulative_stats['rxMessageByteRate']),\
-                    naturalSize(self.cumulative_stats['txMessageRate']).replace("B","m").replace("myte","msg"),\
-                    naturalSize(self.cumulative_stats['txMessageByteRate']),
+                    naturalSize(self.cumulative_stats['rxMessageRate']).replace("B","m").replace("mytes","m"), \
+                    naturalSize(self.cumulative_stats['rxMessageByteRate']).replace("Bytes","B"),\
+                    naturalSize(self.cumulative_stats['txMessageRate']).replace("B","m").replace("mytes","m"),\
+                    naturalSize(self.cumulative_stats['txMessageByteRate']).replace("Bytes","B"),
                     self.cumulative_stats['rxMessageQueued'], self.cumulative_stats['rxMessageRetry'], self.cumulative_stats['lagMean']
                 ))
             print( '\t      Data Received: %s/s (%s/s), Sent: %s/s (%s/s) ' % (
-                   naturalSize(self.cumulative_stats['rxFileRate']).replace("B","F").replace("Fyte","File") ,
-                   naturalSize(self.cumulative_stats['rxDataRate']),
-                   naturalSize( self.cumulative_stats['txFileRate']).replace("B","F").replace("Fyte","File"),
-                   naturalSize(self.cumulative_stats['txDataRate']) ) )
+                   naturalSize(self.cumulative_stats['rxFileRate']).replace("B","F").replace("Fytes","F") ,
+                   naturalSize(self.cumulative_stats['rxDataRate']).replace("Bytes","B"),
+                   naturalSize( self.cumulative_stats['txFileRate']).replace("B","F").replace("Fytes","F"),
+                   naturalSize(self.cumulative_stats['txDataRate']).replace("Bytes","B") ) )
 
             # FIXME: does not seem to find any stray exchange (with no bindings...) hmm...
             for h in self.brokers:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2512,8 +2512,22 @@ class sr_GlobalState:
         """ v3 Printing prettier statuses for each component/configs found
         """
 
+        flowNameWidth=0
+        for c in sorted(self.configs):
+            for cfg in sorted(self.configs[c]):
+                f = c + os.sep + cfg
+                if f not in self.filtered_configurations:
+                    continue
+                if self.configs[c][cfg]['status'] == 'include':
+                    continue
 
-        line = "%-40s %-11s %7s %10s %19s %14s %38s " % ("Component/Config", "Processes", "Connection", "Lag", "", "Rates", "" )
+                if not (c in self.states and cfg in self.states[c]):
+                    continue
+                if len(f) > flowNameWidth:
+                    flowNameWidth = len(f)
+
+        lfmt = f"%-{flowNameWidth}s %-11s %7s %10s %19s %14s %38s "
+        line = lfmt % ("Component/Config", "Processes", "Connection", "Lag", "", "Rates", "" )
 
         if self.options.displayFull:
             line += "%10s %-40s %17s %33s %40s" % ("", "Counters (per housekeeping)", "", "Data Counters", "" )
@@ -2525,8 +2539,9 @@ class sr_GlobalState:
         try:
             print(line)
 
-            line      = "%-40s %-5s %5s %5s %4s %4s %8s %7s %5s %5s %5s %10s %-10s %-10s %-10s " % ("", "State", "Run", "Retry", "msg", "data", "Queued", "LagMax", "LagAvg", "Last", "%rej", "pubsub", "messages", "RxData", "TxData" )
-            underline = "%-40s %-5s %5s %5s %4s %4s %8s %7s %5s %5s %5s %10s %-10s %-10s %-10s " % ("", "-----", "---", "-----", "---", "----", "------", "------", "------", "----", "----", "------", "--------", "------", "------" )
+            lfmt      = f"%-{flowNameWidth}s %-5s %5s %5s %4s %4s %8s %7s %5s %5s %5s %10s %-10s %-10s %-10s " 
+            line      =  lfmt % ("", "State", "Run", "Retry", "msg", "data", "Queued", "LagMax", "LagAvg", "Last", "%rej", "pubsub", "messages", "RxData", "TxData" )
+            underline =  lfmt % ("", "-----", "---", "-----", "---", "----", "------", "------", "------", "----", "----", "------", "--------", "------", "------" )
 
             if self.options.displayFull:
                 line      += "%10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %8s" % \
@@ -2549,6 +2564,7 @@ class sr_GlobalState:
         configs_running = 0
         now = time.time()
 
+                
         for c in sorted(self.configs):
             for cfg in sorted(self.configs[c]):
                 f = c + os.sep + cfg
@@ -2585,7 +2601,8 @@ class sr_GlobalState:
                     cfg_status = 'wVip'
 
                 process_status = "%d/%d" % ( running, expected ) 
-                line= "%-40s %-5s %5s" % (f, cfg_status, process_status ) 
+                lfmt      = f"%-{flowNameWidth}s %-5s %5s "
+                line= lfmt % (f, cfg_status, process_status ) 
 
                 if 'metrics' in self.states[c][cfg]:
                     m=self.states[c][cfg]['metrics']

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -989,16 +989,24 @@ class sr_GlobalState:
                         m['latestTransfer'] = "n/a"
                         if "transferLast" in m and m['transferLast'] > 0:
                             v=now - m['transferLast']
-                            if v > 100:
+                            if v > 10000:
+                                m['latestTransfer'] = f">9999"
+                            elif v > 100:
                                 m['latestTransfer'] = f"{round(v):4d}s"
-                            else:
+                            elif v >  10:
                                 m['latestTransfer'] = f"{v:4.1f}s"
+                            else:
+                                m['latestTransfer'] = f"{v:4.2f}s"
                         elif "messageLast" in m:
                             v=now - m['messageLast']
-                            if v > 100:
+                            if v > 10000:
+                                m['latestTransfer'] = f">9999"
+                            elif v > 100:
                                 m['latestTransfer'] = f"{round(v):4d}s"
-                            else:
+                            elif v >  10:
                                 m['latestTransfer'] = f"{v:4.1f}s"
+                            else:
+                                m['latestTransfer'] = f"{v:4.2f}s"
 
                         
                         if len(m['latestTransfer']) > self.cumulative_stats['latestTransferWidth']:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2543,10 +2543,10 @@ class sr_GlobalState:
         if self.options.displayFull:
             line += "%10s %10s " % ( " ", "CPU Time" )
 
-        if True: #try:
+        try:
             print(line)
 
-            lfmt      = f"%-{flowNameWidth}s %-5s %5s %5s %4s %4s %5s %8s %8s %{latestTransferWidth}s %5s %10s %-10s %-10s %-10s " 
+            lfmt      = f"%-{flowNameWidth}s %-5s %5s %5s %4s %4s %5s %8s %8s %{latestTransferWidth}s %5s %10s %10s %10s %10s " 
             line      =  lfmt % ("", "State", "Run", "Retry", "msg", "data", "Que", "LagMax", "LagAvg", "Last", "%rej", "pubsub", "messages", "RxData", "TxData" )
             underline =  lfmt % ("", "-----", "---", "-----", "---", "----", "---", "------", "------", "----", "----", "------", "--------", "------", "------" )
 
@@ -2565,7 +2565,7 @@ class sr_GlobalState:
 
             print(line)
             print(underline)
-        else: #except:
+        except:
             return
 
         configs_running = 0

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -891,7 +891,7 @@ class sr_GlobalState:
         # comparing states and configs to find missing instances, and correct state.
         self.resources={ 'uss': 0, 'rss': 0, 'vms':0, 'user_cpu': 0, 'system_cpu':0 }
         self.cumulative_stats={ 
-                'flowNameWidth': 0, 'latestTransferWidth': 0, 
+                'flowNameWidth': 20, 'latestTransferWidth': 4, 
                 'rxLagTime':0, 'rxLagCount':0, 
                 'rxMessageQueued':0, 'rxMessageRetry':0, 
                 'txMessageQueued':0, 'txMessageRetry':0, 


### PR DESCRIPTION
make it have consistent columns in max situations:
* establish with of name field by finding the longest flow name.
* lastTransmit display adjusted:  >9999 if that big, and no decimals if over 100. so it fits in 5 spaces in all 
* change all the units to be shorter: Bytes->B, Msgs->m, Files->f.

```

host% sr3 status
status:
Component/Config         Processes   Connection        Lag                              Rates
                         State   Run Retry  msg data   Que   LagMax   LagAvg  Last  %rej     pubsub   messages     RxData     TxData
                         -----   --- -----  --- ----   ---   ------   ------  ----  ----     ------   --------     ------     ------
cpost/pelle_dd1_f04      stop    0/0     0   0%   0%     0    0.00s    0.00s     0  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
cpost/pelle_dd2_f05      stop    0/0     0   0%   0%     0    0.00s    0.00s     0  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
cpost/veille_f34         idle    1/1     0 100%   0%     0    0.00s    0.00s   n/a  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
cpump/xvan_f14           idle    1/1     0 100%   0%     0    0.00s    0.00s   n/a  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
cpump/xvan_f15           idle    1/1     0 100%   0%     0    0.00s    0.00s   n/a  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
poll/sftp_f62            idle    1/1     0 100%   0%     0    0.00s    0.00s   n/a  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
poll/sftp_f63            wVip    1/1     0 100%   0%     0    0.00s    0.00s   n/a  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
post/shim_f63            stop    0/0          -          -         -     -     -          -        -          -          -          -
post/t_dd1_f00           stop    0/0     0 100%   0%     0   12.53s    6.98s 23.4s  0.0% 12.0 KiB/s      0 m/s      0 B/s      0 B/s
post/t_dd2_f00           stop    0/0     0 100%   0%     0   12.80s    7.10s 23.1s  0.0% 12.2 KiB/s      0 m/s      0 B/s      0 B/s
post/test2_f61           stop    0/0     0 100%   0%     0    0.58s    0.55s 6.77s  0.0%  1.7 KiB/s      0 m/s      0 B/s      0 B/s
report/tsarra_f20        idle    1/1     0 100%   0%     0    0.00s    0.00s   n/a  0.0%      0 B/s      0 m/s      0 B/s      0 B/s
sarra/download_f20       run     1/1     0 100%  87%     0   23.02s   14.33s 13.1s 50.0% 47.7 KiB/s     75 m/s 44.1 KiB/s      0 B/s
sender/tsource2send_f50  run     1/1     0 100%  85%     0    8.44s    4.33s 2.46s  0.0% 109.7 KiB/s     37 m/s      0 B/s 44.0 KiB/s
shovel/rabbitmqtt_f22    run     1/1     0 100%   0%     0    3.92s    2.50s 8.25s  0.0% 109.7 KiB/s     37 m/s      0 B/s      0 B/s
subscribe/amqp_f30       run     1/1     0 100%  82%     0   23.10s   14.58s 12.9s  0.0% 15.5 KiB/s     37 m/s 44.0 KiB/s      0 B/s
subscribe/cdnld_f21      run     1/1     0 100%  82%   145   13.48s    8.48s 23.3s  0.1% 16.5 KiB/s     46 m/s 44.1 KiB/s      0 B/s
subscribe/cfile_f44      run     1/1     0 100%  84%     1    1.81s    0.87s 21.8s  0.0% 15.9 KiB/s     40 m/s 43.9 KiB/s      0 B/s
subscribe/cp_f61         run     1/1     0 100%  57%     0    9.46s    5.82s 4.76s  0.0% 39.0 KiB/s     33 m/s 16.1 KiB/s      0 B/s
subscribe/ftp_f70        run     1/1     0 100%  53%     0    6.89s    3.61s 6.28s  0.0%  7.3 KiB/s     14 m/s 11.3 KiB/s      0 B/s
subscribe/mirror_f80     run     1/1     0 100%  65%     0    2.64s    1.40s 1.58s  0.0% 15.9 KiB/s     40 m/s 26.3 KiB/s      0 B/s
subscribe/q_f71          cpuS    5/5     0 100%  13%     0    3.74s    1.95s 1.54s  0.0%  3.3 KiB/s      8 m/s 10.3 KiB/s      0 B/s
subscribe/rabbitmqtt_f31 run     1/1     0 100%  47%     0    4.19s    2.90s 11.7s  0.0% 31.6 KiB/s     31 m/s 16.1 KiB/s      0 B/s
subscribe/u_sftp_f60     run     1/1     0 100%  59%     0    9.48s    5.85s 3.71s  0.0% 41.5 KiB/s     34 m/s 16.1 KiB/s      0 B/s
watch/f40                run     1/1     0 100%   0%     0    1.53s    0.45s 8.68s  0.0% 55.5 KiB/s      0 m/s      0 B/s      0 B/s
      Total Running Configs:  19 ( Processes: 23 missing: 0 stray: 0 )
                     Memory: uss:865.7 MiB rss:1.2 GiB vms:3.0 GiB
                   CPU Time: User:65.70s System:12.13s
           Pub/Sub Received: 461 m/s (543.3 KiB/s), Sent:  212 m/s (205.8 KiB/s) Queued: 146 Retry: 0, Mean lag: 5.53s
              Data Received: 274 f/s (309.0 KiB/s), Sent: 37 f/s (44.0 KiB/s)
host%

```