### PR TITLE
fix #1002 putAccellerated when file names have colons

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -496,7 +496,7 @@ class Sftp(Transfer):
             dest_baseUrl = dest_baseUrl[0:-1]
         arg2 = dest_baseUrl + ':' + msg['new_dir'] + os.sep + remote_file
         arg2 = arg2.replace(' ', '\\ ')
-        arg1 = local_file
+        arg1 = '.' + os.sep + local_file
 
         cmd = self.o.accelScpCommand.replace('%s', arg1)
         cmd = cmd.replace('%d', arg2).split()


### PR DESCRIPTION
close #1002
apply same fix to putAccellerated that was there for getAccellerated.
fix the problem senders have had with being unable to resolve dns for "grib:"
