### PR TITLE
Paho mqtt v2 support

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -2063,7 +2063,7 @@ class Config:
         # FIXME: confused about this...  commenting out for now...
         for f,l,u in self.undeclared:
             if u not in alloptions:
-                logger.error( f"{component}/{config} {f}:{l} undeclared option: {u}")
+                logger.error( f"{f}:{l} undeclared option: {u}")
             elif u in flag_options:
                 if type( getattr(self,u) ) is not bool:
                     setattr(self,u,isTrue(getattr(self,u)))
@@ -2092,7 +2092,7 @@ class Config:
              if not hasattr(self,u):
                 no_defaults.add( u )
 
-        logger.debug("{component}/{config} missing defaults: %s" % no_defaults)
+        logger.debug("missing defaults: %s" % no_defaults)
 
     """
       2020/05/26 FIXME here begins sheer terror.

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -125,8 +125,6 @@ default_options = {
     'sourceFromExchange': False,
     'sourceFromMessage': False,
     'sundew_compat_regex_first_match_is_zero': False,
-    'sourceFromExchange': False,
-    'sourceFromMessage': False,
     'topicCopy': False,
     'v2compatRenameDoublePost': False,
     'varTimeOffset': 0,
@@ -1982,7 +1980,7 @@ class Config:
 
         valid_inlineEncodings = [ 'guess', 'text', 'binary' ]
         if hasattr(self, 'inlineEncoding') and self.inlineEncoding not in valid_inlineEncodings:
-            logger.error( f"invalid inlineEncoding: {self.inlineEncoding} must be one of: {','.join(valid_inlineEncodings)}" )
+            logger.error( f"{component}/{config} invalid inlineEncoding: {self.inlineEncoding} must be one of: {','.join(valid_inlineEncodings)}" )
 
         if hasattr(self, 'no'):
             if self.statehost:
@@ -2004,7 +2002,7 @@ class Config:
                 path = os.path.realpath(path)
 
             if sys.platform == 'win32' and words0.find('\\'):
-                logger.warning("%s %s" % (words0, words1))
+                logger.warning("{component}/{config} %s %s" % (words0, words1))
                 logger.warning(
                     "use of backslash ( \\ ) is an escape character. For a path separator use forward slash ( / )."
                 )
@@ -2017,7 +2015,7 @@ class Config:
 
         if hasattr(self, 'pollUrl'):
             if not hasattr(self,'post_baseUrl') or not self.post_baseUrl :
-                logger.debug( f"defaulting post_baseUrl to match pollURl, since it isn't specified." )
+                logger.debug( f"{component}/{config} defaulting post_baseUrl to match pollURl, since it isn't specified." )
                 self.post_baseUrl = self.pollUrl
             
         # verify post_baseDir
@@ -2036,13 +2034,13 @@ class Config:
                 self.post_baseDir = u.path
             elif self.baseDir is not None:
                 self.post_baseDir = os.path.expanduser(self.baseDir)
-                logger.debug("defaulting post_baseDir to same as baseDir")
+                logger.debug("{component}/{config} defaulting post_baseDir to same as baseDir")
 
 
         if self.messageCountMax > 0:
             if self.batch > self.messageCountMax:
                 self.batch = self.messageCountMax
-                logger.info( f'overriding batch for consistency with messageCountMax: {self.batch}' )
+                logger.info( f'{component}/{config} overriding batch for consistency with messageCountMax: {self.batch}' )
 
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
@@ -2053,10 +2051,10 @@ class Config:
                     self.sleep=1
 
         if self.runStateThreshold_hung < self.housekeeping:
-            logger.warning( f"runStateThreshold_hung {self.runStateThreshold_hung} set lower than housekeeping {self.housekeeping}. sr3 sanity might think this flow is hung kill it too quickly.")
+            logger.warning( f"{component}/{config} runStateThreshold_hung {self.runStateThreshold_hung} set lower than housekeeping {self.housekeeping}. sr3 sanity might think this flow is hung kill it too quickly.")
 
         if self.vip and not features['vip']['present']:
-            logger.critical( f"vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )
+            logger.critical( f"{component}/{config} vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )
             sys.exit(1)
 
     def check_undeclared_options(self):
@@ -2065,7 +2063,7 @@ class Config:
         # FIXME: confused about this...  commenting out for now...
         for f,l,u in self.undeclared:
             if u not in alloptions:
-                logger.error( f"{f}:{l} undeclared option: {u}")
+                logger.error( f"{component}/{config} {f}:{l} undeclared option: {u}")
             elif u in flag_options:
                 if type( getattr(self,u) ) is not bool:
                     setattr(self,u,isTrue(getattr(self,u)))
@@ -2094,7 +2092,7 @@ class Config:
              if not hasattr(self,u):
                 no_defaults.add( u )
 
-        logger.debug("missing defaults: %s" % no_defaults)
+        logger.debug("{component}/{config} missing defaults: %s" % no_defaults)
 
     """
       2020/05/26 FIXME here begins sheer terror.

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -70,7 +70,7 @@ features = {
            'lament': 'humans will have to read larger, uglier numbers',
            'rejoice': 'humans numbers that are easier to read.' },
    'mqtt' : { 'modules_needed': ['paho.mqtt.client'], 'present': False, 
-           'lament': 'cannot connect to mqtt brokers' ,
+           'lament': 'cannot connect to mqtt brokers (need >= 2.1.0)' ,
            'rejoice': 'can connect to mqtt brokers' },
    'process' : { 'modules_needed': ['psutil'], 'present': False,
         'lament': 'cannot monitor running processes, sr3 CLI basically does not work.',

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -131,3 +131,10 @@ if features['filetypes']['present']:
         features['filetypes']['present'] = False
         logger.debug( f'redhat magic bindings not supported.')
 
+if features['mqtt']['present']:
+    import paho.mqtt
+    if not paho.mqtt.__version__ >= '2.1.0' :
+        features['mqtt']['present'] = False
+        logger.debug( f'paho-mqtt minimum version needed is 2.1.0')
+
+

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -606,7 +606,8 @@ class Flow:
                     and self.metrics['retry']['msgs_in_post_retry'] > 0):
                     logger.debug("Not exiting because there are still messages in the post retry queue.")
                     # Sleep for a while. Messages can't be retried before housekeeping has run...
-                    current_sleep = 60
+                    # how long to sleep is unclear... if there are a lot of retries, and a low batch... could take a long time.
+                    current_sleep = self.o.batch if self.o.batch < self.o.housekeeping else self.o.housekeeping // 2
                 else:
                     self.runCallbacksTime('please_stop')
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -604,7 +604,8 @@ class Flow:
             if (last_gather_len == 0) and (self.o.sleep < 0):
                 if (self.o.retryEmptyBeforeExit and "retry" in self.metrics
                     and self.metrics['retry']['msgs_in_post_retry'] > 0):
-                    logger.debug("Not exiting because there are still messages in the post retry queue.")
+                    logger.info( f"retryEmptyBeforeExit=True and there are still "
+                        f"{self.metrics['retry']['msgs_in_post_retry']} messages in the post retry queue.")
                     # Sleep for a while. Messages can't be retried before housekeeping has run...
                     # how long to sleep is unclear... if there are a lot of retries, and a low batch... could take a long time.
                     current_sleep = self.o.batch if self.o.batch < self.o.housekeeping else self.o.housekeeping // 2

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -271,6 +271,5 @@ def load_library(factory_path, options):
                 setattr(opt, s, options.settings[factory_path][s])
     else:
         opt = options
-
     plugin = class_(opt)
     return plugin

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -138,45 +138,9 @@ class AMQP(Moth):
             topic = raw_msg.delivery_info['routing_key'].replace(
                 '%23', '#').replace('%22', '*')
             msg['exchange'] = raw_msg.delivery_info['exchange']
-            source=None
-            if 'source' in self.o:
-                source = self.o['source']
-            elif 'sourceFromExchange' in self.o and self.o['sourceFromExchange']:
-                itisthere = re.match( "xs_([^_]+)_.*", msg['exchange'] )
-                if itisthere:
-                    source = itisthere[1]
-                else:
-                    itisthere = re.match( "xs_([^_]+)", msg['exchange'] )
-                    if itisthere:
-                        source = itisthere[1]
-            if 'source' in msg and 'sourceFromMessage' in self.o and self.o['sourceFromMessage']:
-                pass
-            elif source:
-                msg['source'] = source
-                msg['_deleteOnPost'] |= set(['source'])
 
-            msg_topic = topic.split('.')
-
-            # topic validation... deal with DMS topic scheme. https://github.com/MetPX/sarracenia/issues/1017
-            if 'topicCopy' in self.o and self.o['topicCopy']:
-                topicOverride=True
-            else:
-                topicOverride=False
-                if 'relPath' in msg:
-                    path_topic = self.o['topicPrefix'] + os.path.dirname(msg['relPath']).split('/')
-
-                    if msg_topic != path_topic:
-                        topicOverride=True
-                
-                # set subtopic if possible.
-                if msg_topic[0:len(self.o['topicPrefix'])] == self.o['topicPrefix']:
-                    msg['subtopic'] = msg_topic[len(self.o['topicPrefix']):]
-                else:
-                    topicOverride=True
-
-            if topicOverride:
-                msg['topic'] = topic
-                msg['_deleteOnPost'] |= set( ['topic'] )
+            msg.deriveSource( self.o )
+            msg.deriveTopics( self.o, topic )
 
             msg['ack_id'] = raw_msg.delivery_info['delivery_tag']
             msg['local_offset'] = 0

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -577,6 +577,10 @@ class MQTT(Moth):
             self.metrics['rxBadCount'] += 1
             return None
 
+        message['exchange'] = mqttMessage.topic.split('/')[0]
+        message.deriveSource( self.o )
+        message.deriveTopics( self.o, topic=mqttMessage.topic, separator='/' )
+
         message['ack_id'] = mqttMessage.mid
         message['qos'] = mqttMessage.qos
         message['local_offset'] = 0

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -221,7 +221,7 @@ class MQTT(Moth):
 
             (res, mid) = client.subscribe(subj, qos=userdata.o['qos'])
             userdata.subscribe_in_progress += 1
-            logger.info( f"asked to subscribe to: {subj}, mid={mid}"
+            logger.info( f"asked to subscribe to: {subj}, mid={mid} "
                     f"qos={userdata.o['qos']} result: {paho.mqtt.client.error_string(res)}" )
         userdata.subscribe_mutex.release()
         userdata.metricsConnect()

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -313,7 +313,7 @@ class MQTT(Moth):
         client = paho.mqtt.client.Client( \
                     callback_api_version = paho.mqtt.client.CallbackAPIVersion.VERSION2, \
                     client_id=cid, userdata=self, protocol=paho.mqtt.client.MQTTv5, \
-                    transport = self.transport , manual_ack = self.manual_ack )
+                    transport = self.transport , manual_ack = True )
 
         # FIXME: transport = 'websockets', 'unix' 
 
@@ -346,7 +346,6 @@ class MQTT(Moth):
 
         something_broke = True
         self.connected=False
-        self.manual_ack = False
         while True:
 
             if self.please_stop:
@@ -372,17 +371,6 @@ class MQTT(Moth):
                 logger.info( f"is no around? {self.o['no']} " )
                 if ('no' in self.o) and self.o['no'] > 0: # instances 'started'
                     self.client = self.__clientSetup(cid)
-                    if hasattr(self, 'client') and hasattr(self.client, 'manual_ack_set'):  # FIXME breaking this...
-                        self.client.manual_ack_set(True)
-                        logger.debug(
-                            "Switching on manual_acks for higher reliability via explicit acknowledgements."
-                        )
-                        self.manual_ack = True
-                    else:
-                        logger.warning(
-                            "paho library automatically acknowledges receipt. may lose data every crash or restart."
-                        )
-    
                     self.client.connect( self.o['broker'].url.hostname, port=self.__sslClientSetup(), \
                            clean_start=False, properties=props )
                     self.client.enable_logger(logger)
@@ -667,7 +655,7 @@ class MQTT(Moth):
 
     def ack(self, m: sarracenia.Message ) -> None:
 
-        if self.manual_ack and ('ack_id' in m):
+        if 'ack_id' in m:
             logger.info('mid=%d' % m['ack_id'])
             self.client.ack( m['ack_id'], m['qos'] )
             del m['ack_id']

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -773,7 +773,7 @@ class MQTT(Moth):
 
             if hasattr(self, 'pending_publishes'):
                 ebo=0.1
-                while  (len(self.pending_publishes)+len(self.unexpected_publishes)) >0:
+                while  len(self.pending_publishes) >0:
                     logger.info( f'waiting {ebo} seconds for last {len(self.pending_publishes)} messages to publish')
                     if len(self.unexpected_publishes) < 10:
                         logger.info( f'messages acknowledged before publish?: {self.unexpected_publishes}')

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -138,7 +138,7 @@ class MQTT(Moth):
 
 
         me = "%s.%s" % (__class__.__module__, __class__.__name__)
-        logger.setLevel('WARNING')
+        #logger.setLevel('WARNING')
 
         if ('settings' in self.o) and (me in self.o['settings']):
             for s in self.o['settings'][me]:

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -559,7 +559,7 @@ class MQTT(Moth):
 
             if hasattr(mqttMessage, 'payload'): 
                 logger.info( f"payload: type: {type(mqttMessage.payload)}"
-                        f"(len: {len(mqttMessage.payload)%d} bytes) body:{mqttMessage.payload}" )
+                        f"(len: {len(mqttMessage.payload):d} bytes) body:{mqttMessage.payload}" )
 
             if hasattr(mqttMessage.properties, 'UserProperty'): 
                 logger.info( f"User Property: {mqttMessage.properties.UserProperty}")


### PR DESCRIPTION
This branch changes the mqtt driver to use version 2.1 of paho-mqtt python client... the current one (released in 2024.)
Previous versions have no way of passing the flakey_broker test, and will fail in other ways because there
it no application control of acknowledgements.  The patch I submitted to the paho-mqtt for application acknowledgements was only merged for v2.   V2 also brings many api changes, so it's not straight-forward.

The stack, as-is, passes more tests than the old mqtt support did on the old mqtt version, but not yet all tests.
It's still better than what is there, and will probably not come back to it for a while, so better not to have a long running parallel branch.

It will be a good basis for finishing the work later.

This is part of #693  ... it might actually solve flakey... but there might be some timing issues... (false positives, where the results seem ok,. but the test indicates a failure.)

