### PR TITLE
Implement support for implicit FTPS on port 990

### DIFF
--- a/docs/source/Reference/sr3_credentials.7.rst
+++ b/docs/source/Reference/sr3_credentials.7.rst
@@ -47,6 +47,7 @@ passwords and settings needed by components.  The format is one entry per line. 
 
 - **ftps://user7:De%3Aize@host  passive,binary,tls**
 - **ftps://user8:%2fdot8@host:2121  active,ascii,tls,prot_p**
+- **ftp://user8:%2fdot8@host:990  implicit_ftps**
 - **https://ladsweb.modaps.eosdis.nasa.gov/ bearer_token=89APCBF0-FEBE-11EA-A705-B0QR41911BF4**
 
 
@@ -71,6 +72,7 @@ Supported details:
 - ``prot_p`` - (FTPS) Use a secure data connection for TLS connections (otherwise, clear text is used)
 - ``bearer_token=<token>`` (or ``bt=<token>``) - (HTTP) Bearer token for authentication
 - ``login_method=<PLAIN|AMQPLAIN|EXTERNAL|GSSAPI>`` - (AMQP) By default, the login method will be automatically determined. This can be overriden by explicity specifying a login method, which may be required if a broker supports multiple methods and an incorrect one is automatically selected.
+- ``implicit_ftps`` - (FTPS) Use implicit FTPS (otherwise, explicit FTPS is used). Setting this will also set ``tls`` to True.
 
 Note::
  SFTP credentials are optional, in that sarracenia will look in the .ssh directory

--- a/docs/source/fr/Reference/sr3_credentials.7.rst
+++ b/docs/source/fr/Reference/sr3_credentials.7.rst
@@ -46,6 +46,7 @@ ainsi que les paramètres nécessaires aux composants.  Le format est d'une entr
 
 - **ftps://user7:De%3Aize@host  passive,binary,tls**
 - **ftps://user8:%2fdot8@host:2121  active,ascii,tls,prot_p**
+- **ftp://user8:%2fdot8@host:990  implicit_ftps**
 - **https://ladsweb.modaps.eosdis.nasa.gov/ bearer_token=89APCBF0-FEBE-11EA-A705-B0QR41911BF4**
 
 Dans d’autres fichiers de configuration ou sur la ligne de commande, l’url n’a tout simplement pas le
@@ -71,6 +72,7 @@ Détails pris en charge :
 - ``prot_p`` - (FTPS) Utiliser une connexion de données sécurisée pour les connexions TLS (sinon, du texte clair est utilisé)
 - ``bearer_token=<token>`` (ou ``bt=<token>``) - (HTTP) Jeton Bearer pour l’authentification
 - ``login_method=<PLAIN|AMQPLAIN|EXTERNAL|GSSAPI>`` - (AMQP) Par défaut, la méthode de connexion sera automatiquement
+- ``implicit_ftps`` - (FTPS) Utilisez FTPS implicite (sinon, FTPS explicite est utilisé). Définir ceci définira également ``tls`` sur True.
 
 déterminée. Cela peut être remplacé en spécifiant une méthode Particulière de connexion, ce qui peut être
 nécessaire si un broker prend en charge plusieurs méthodes et qu’une méthode incorrecte est automatiquement

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -66,6 +66,7 @@ class Credential:
         bearer_token (str): bearer token for HTTP authentication
         login_method (str): force a specific login method for AMQP (PLAIN,
             AMQPLAIN, EXTERNAL or GSSAPI)
+        implicit_ftps (bool): use implicit FTPS, defaults to ``False`` (i.e. explicit FTPS)
 
     Usage:
 
@@ -101,6 +102,7 @@ class Credential:
         self.s3_endpoint = None
         self.s3_session_token = None
         self.azure_credentials = None
+        self.implicit_ftps = False
 
     def __str__(self):
         """Returns attributes of the Credential object as a readable string.
@@ -133,6 +135,7 @@ class Credential:
         #want to show they provided a session token, but not leak it (like passwords above)
         s += " %s" % 'Yes' if self.s3_session_token != None else 'No'
         s += " %s" % 'Yes' if self.azure_credentials != None else 'No'
+        s += " %s" % self.implicit_ftps
 
         return s
 
@@ -383,6 +386,9 @@ class CredentialDB:
                     details.s3_endpoint = parts[1].strip()
                 elif keyword == 'azure_storage_credentials':
                     details.azure_credentials = urllib.parse.unquote(parts[1].strip())
+                elif keyword == 'implicit_ftps':
+                    details.implicit_ftps = True
+                    details.tls = True
                 else:
                     logger.warning("bad credential option (%s)" % keyword)
 

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -20,7 +20,7 @@
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 #
 
-import ftplib, os, subprocess, sys, time
+import ftplib, os, subprocess, sys, time, ssl
 import logging
 from sarracenia.transfer import Transfer
 from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
@@ -28,6 +28,26 @@ from urllib.parse import unquote
 
 logger = logging.getLogger(__name__)
 
+class IMPLICIT_FTP_TLS(ftplib.FTP_TLS):
+    """ FTP_TLS subclass that automatically wraps sockets in SSL to support implicit FTPS.
+        Copied from https://stackoverflow.com/questions/12164470/python-ftp-implicit-tls-connection-issue
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sock = None
+
+    @property
+    def sock(self):
+        """Return the socket."""
+        return self._sock
+
+    @sock.setter
+    def sock(self, value):
+        """When modifying the socket, ensure that it is ssl wrapped."""
+        if value is not None and not isinstance(value, ssl.SSLSocket):
+            value = self.context.wrap_socket(value)
+        self._sock = value
 
 class Ftp(Transfer):
     """
@@ -176,13 +196,27 @@ class Ftp(Transfer):
         try:
             expire = -999
             if self.o.timeout: expire = self.o.timeout
-            if self.port == '' or self.port == None: self.port = 21
+            if self.port == '' or self.port == None: 
+                if self.implicit_ftps:
+                    self.port = 990
+                else:
+                    self.port = 21
 
+            # plain FTP with no encryption (usually port 21)
             if not self.tls:
                 ftp = ftplib.FTP()
                 ftp.encoding = 'utf-8'
                 ftp.connect(self.host, self.port, timeout=expire)
                 ftp.login(self.user, unquote(self.password))
+            # implicit FTPS (usually port 990)
+            elif self.tls and self.implicit_ftps:
+                ftp = IMPLICIT_FTP_TLS()
+                ftp.encoding = 'utf-8'
+                ftp.connect(host=self.host, port=self.port, timeout=expire)
+                ftp.login(user=self.user, passwd=unquote(self.password))
+                if self.prot_p:
+                    ftp.prot_p()
+            # explicit FTPS (port 21)
             else:
                 # ftplib supports FTPS with TLS
                 ftp = ftplib.FTP_TLS(self.host,
@@ -233,6 +267,7 @@ class Ftp(Transfer):
             self.binary = details.binary
             self.tls = details.tls
             self.prot_p = details.prot_p
+            self.implicit_ftps = details.implicit_ftps
 
             return True
 


### PR DESCRIPTION
Issue #1121. Adds another option to credentials, `implicit_ftps`. 

It works with the ESA SMOS server I've been trying to connect to.

With just `tls` enabled (not `implicit_ftps`):

```
2024-06-25 15:58:20,515 [DEBUG] 466708 sarracenia.transfer.ftp connect Exception details:
Traceback (most recent call last):
  File "/net/local/home/sunderlandr/sr3/sarracenia/transfer/ftp.py", line 222, in connect
    ftp = ftplib.FTP_TLS(self.host,
  File "/usr/lib/python3.10/ftplib.py", line 740, in __init__
    super().__init__(host, user, passwd, acct,
  File "/usr/lib/python3.10/ftplib.py", line 123, in __init__
    self.login(user, passwd, acct)
  File "/usr/lib/python3.10/ftplib.py", line 745, in login
    self.auth()
  File "/usr/lib/python3.10/ftplib.py", line 753, in auth
    resp = self.voidcmd('AUTH TLS')
  File "/usr/lib/python3.10/ftplib.py", line 286, in voidcmd
    return self.voidresp()
  File "/usr/lib/python3.10/ftplib.py", line 259, in voidresp
    resp = self.getresp()
  File "/usr/lib/python3.10/ftplib.py", line 254, in getresp
    raise error_perm(resp)
ftplib.error_perm: 530 Please login with USER and PASS.
```

Note: this error is only because this particular server allows connections on port 21, but does not allow us to login. This fix should also work on servers that don't allow connections on port 21 at all.

With `implicit_tls` enabled, it uses the new code and works:

```
2024-06-25 16:04:21,326 [DEBUG] 468379 sarracenia.transfer.ftp connect sr_ftp connect ftp://ssc.hpc-chp.spc@canada.ca@smos-diss.eo.esa.int/
2024-06-25 16:04:21,326 [DEBUG] 468379 sarracenia.transfer.ftp credentials sr_ftp credentials ftp://ssc.hpc-chp.spc@canada.ca@smos-diss.eo.esa.int/
2024-06-25 16:04:25,934 [DEBUG] 468379 sarracenia.transfer.ftp cd sr_ftp cd /SMOS/L1CS/MIR_SCSF1C/2024/06
2024-06-25 16:04:26,145 [DEBUG] 468379 sarracenia.transfer.ftp ls sr_ftp ls
2024-06-25 16:04:26,663 [DEBUG] 468379 sarracenia.transfer.ftp ls sr_ftp ls = (size: 25) {'01': 'dr-x------ 3 oads oads 0 Jun 2 05:45 01', '02': 'dr-x------ 3 oads oads 0 Jun 3 05:21 02', '03': 'dr-x------ 3 oads oads 0 Jun 4 06:03 03', '04': 'dr-x------ 3 oads oads 0 Jun 5 07:19 04', '05': 'dr-x------ 3 oads oads 0 Jun 6 06:29 05', '06': 'dr ...
2024-06-25 16:04:26,740 [DEBUG] 468379 sarracenia.transfer.ftp cd sr_ftp cd /SMOS/L1CS/MIR_SCSF1C/2024/06/01
```