### PR TITLE
Fix logging for default poll

### DIFF
--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -254,7 +254,7 @@ class Poll(FlowCB):
 
     """
 
-    def __init__(self, options,class_logger=None):
+    def __init__(self, options,class_logger=logger):
 
         super().__init__(options,class_logger)
 


### PR DESCRIPTION
When running the default poll code (i.e. no poll plugin), debug log messages would not show up from the Poll class when logLevel was set to debug. This fixes that by setting class_logger to logger. 

`logger` is what used to be passed to the parent class before this change:
https://github.com/MetPX/sarracenia/commit/9c8d4639324d62993979edca3be7901fae619007

Now a subclass can still pass in it's own logger, but the normal Poll class will also work. 