### PR TITLE
Issue33 - default queue name change.

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -658,7 +658,7 @@ Creating the Queue
 Once connected to an AMQP broker, the user needs to create a queue.
 Common settings for the queue on broker :
 
-- **queueShare <strin>         (default: ${USER}_${HOSTNAM})**
+- **queueShare <strin>         (default: ${USER}_${HOSTNAME}_${RAND8})**
 - **expire        <duration>      (default: 5m  == five minutes. RECOMMEND OVERRIDING)**
 - **message_ttl   <duration>      (default: None)**
 - **prefetch      <N>            (default: 1)**
@@ -670,8 +670,8 @@ may need to override the defaults.  The queue is where the notifications
 are held on the server for each subscriber.
 
 
-queueShare <str> (default: ${USER}_${HOSTNAME} )
-------------------------------------------------
+queueShare <str> (default: ${USER}_${HOSTNAME}_${RAND8} )
+---------------------------------------------------------
 
 A suffix included to queue names to allow defining the sharing scope of a queue.
 When multiple hosts are participating in the same queue, use this setting

--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -658,7 +658,7 @@ Creating the Queue
 Once connected to an AMQP broker, the user needs to create a queue.
 Common settings for the queue on broker :
 
-- **queue         <name>         (default: q_<brokerUser>.<programName>.<configName>)**
+- **queueShare <strin>         (default: ${USER}_${HOSTNAM})**
 - **expire        <duration>      (default: 5m  == five minutes. RECOMMEND OVERRIDING)**
 - **message_ttl   <duration>      (default: None)**
 - **prefetch      <N>            (default: 1)**
@@ -669,36 +669,23 @@ and users do not need to set them.  For less usual cases, the user
 may need to override the defaults.  The queue is where the notifications
 are held on the server for each subscriber.
 
-[ queue|queue_name|qn <name>]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, components create a queue name that should be unique. The 
-default queue_name components create follows the following convention: 
+queueShare <str> (default: ${USER}_${HOSTNAME} )
+------------------------------------------------
 
-   **q_<brokerUser>.<programName>.<configName>.<random>.<random>** 
+A suffix included to queue names to allow defining the sharing scope of a queue.
+When multiple hosts are participating in the same queue, use this setting
+to have instances pick the same queue::
 
-Where:
+    queueShare my_share_group
 
-* *brokerUser* is the username used to connect to the broker (often: *anonymous* )
+to get a private queue, for example, one could specify::
 
-* *programName* is the component using the queue (e.g. *sr_subscribe* ),
+    queueShare ${RAND8}
 
-* *configName* is the configuration file used to tune component behaviour.
-
-* *random* is just a series of characters chosen to avoid clashes from multiple
-  people using the same configurations
-
-Users can override the default provided that it starts with **q_<brokerUser>**.
-
-When multiple instances are used, they will all use the same queue, for trivial
-multi-tasking. If multiple computers have a shared home file system, then the
-queue_name is written to: 
-
- ~/.cache/sarra/<programName>/<configName>/<programName>_<configName>_<brokerUser>.qname
-
-Instances started on any node with access to the same shared file will use the
-same queue. Some may want use the *queue_name* option as a more explicit method
-of sharing work across multiple nodes.
+will result in a random 8 digit number being appended to the queue name.
+All the instances within the configuration with access to the same state directory
+will use the queue name thus defined.
 
 
 AMQP QUEUE BINDINGS

--- a/docs/source/Explanation/DeploymentConsiderations.rst
+++ b/docs/source/Explanation/DeploymentConsiderations.rst
@@ -130,7 +130,9 @@ based on the **queueShare** setting including **${HOSTNAME}**.
 Each node will have its own queue, only shared by the node instances.
 
 To get a shared queue, the user must set **queueShare** to the same
-value on all participating nodes.
+value on all participating nodes. e.g.:
+
+   queueShare cluster_name
 
 
 Often there is internal traffic of data acquired before it is finally published.

--- a/docs/source/Explanation/DeploymentConsiderations.rst
+++ b/docs/source/Explanation/DeploymentConsiderations.rst
@@ -125,11 +125,13 @@ single broker for a pool of transfer engines. So each transfer engine's view of
 the file space is local, but the queues are global to the pump.  
 
 Note: On such clusters, all nodes that run a component with the
-same config file created by default have an identical **queue_name**. Targetting the
-same broker, it forces the queue to be shared. If it should be avoided,
-the user can just overwrite the default **queue_name** inserting **${HOSTNAME}**.
+same config file created by default have an different **queueName**, 
+based on the **queueShare** setting including **${HOSTNAME}**. 
 Each node will have its own queue, only shared by the node instances.
-ex.: queue_name q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME} )
+
+To get a shared queue, the user must set **queueShare** to the same
+value on all participating nodes.
+
 
 Often there is internal traffic of data acquired before it is finally published.
 As a means of scaling, often transfer engines will also have brokers to handle

--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -45,6 +45,27 @@ git
 *CHANGE*: *sr3 sanity* only restarts missing instances, not stopped ones.
 this is considered more in accordance with analyst expectations (POLA)
 
+*CHANGE*: new *queueShare* setting should be used wherever, in prior versions
+ *queueName* was used. Should result in fewer configuration settings
+ and the queueShare settings used should also be shorter than former queueName
+ ones.
+
+*CHANGE*: default queue names changed from randomized value to one based
+on user name and host name. 
+
+Existing configurations without explicit queueName settings will continue
+to use old queues if they are already in use. as *cleanup* commands are 
+executed, or in newly deployed configurations, the new naming will gradually
+take effect.  The new *queueShare* setting can be used to customize that.
+
+Please review all configurations that:
+* do not have explicit queueName settings AND
+* run on multiple hosts 
+
+To understand whether they need queueShare in order 
+to keep the same sharing as previously obtained by default.
+
+
 3.0.53
 ------
 

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1476,7 +1476,7 @@ Where:
 
 * *configName* is the configuration file used to tune component behaviour.
 
-* *queueShare* defaults to ${USER}_${HOSTNAME} but should be overridden with the 
+* *queueShare* defaults to ${USER}_${HOSTNAME}_${RAND8} but should be overridden with the 
   *queueShare* configuration option.
 
 Users can override the default provided that it starts with **q_<brokerUser>**.
@@ -1492,8 +1492,8 @@ same queue. Some may want use the *queueName* option as a more explicit method
 of sharing work across multiple nodes.
 
 
-queueShare <str> (default: ${USER}_${HOSTNAME} )
-------------------------------------------------
+queueShare <str> ( default: ${USER}_${HOSTNAME}_${RAND8} )
+----------------------------------------------------------
 
 A suffix included to queue names to allow defining the sharing scope of a queue.
 When multiple hosts are participating in the same queue, use this setting 

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1497,7 +1497,9 @@ queueShare <str> (default: ${USER}_${HOSTNAME} )
 
 A suffix included to queue names to allow defining the sharing scope of a queue.
 When multiple hosts are participating in the same queue, use this setting 
-to have instances pick the same queue.
+to have instances pick the same queue::
+
+    queueShare my_share_group
 
 to get a private queue, for example, one could specify:: 
 

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -44,6 +44,26 @@ git
 *CHANGEMENT* : *sr3 sanity* redémarre uniquement les instances manquantes, pas celles arrêtées.
 cela est considéré comme plus conforme aux attentes des analystes. 
 
+*CHANGEMENT* : le nouveau paramètre *queueShare* peut être utilisé partout où, dans les versions précédentes,
+ *queueName* a servi. Cela devrait entraîner moins de paramètres de configuration
+ et les valeurs paramètres *queueShare* utilisés seront également plus courts que ceux de *queueName*.
+
+*CHANGEMENT* : les noms de files d'attente par défaut sont passés d'une valeur aléatoire à une valeur basée
+sur le nom d'utilisateur et le nom d'hôte.
+
+Les configurations existantes sans paramètres de queueName explicites continueront
+d'utiliser les anciennes files d'attente si elles sont déjà utilisées. Quand les commandes *cleanup*
+seront exécutés, ou dans des configurations nouvellement déployées, la nouvelle dénomination prendra effet
+progressivement. Le nouveau paramètre *queueShare* peut être utilisé pour personnaliser cela.
+
+Veuillez examiner toutes les configurations qui:
+
+* n'ont pas de paramètres de queueName explicites
+* sont exécutés sur plusieurs hôtes 
+
+pour comprendre s'ils ont besoin de queueShare pour
+pour conserver le même partage que précédemment obtenu par défaut.
+
 3.0.53
 ------
 

--- a/docs/source/fr/Explication/ConsiderationsDeployments.rst
+++ b/docs/source/fr/Explication/ConsiderationsDeployments.rst
@@ -138,26 +138,27 @@ façon.
 Commutateurs/Routage
 ~~~~~~~~~~~~~~~~~~~~
 
-Dans la configuration de commutation/routage, il y a une paire de machines
-qui font tourner un seul courtier pour un pool de moteurs de transfert. Ainsi,
-chaque transfert engine´s vue de l'espace fichier est local, mais les files
-d'attente sont les suivantes globale à la pompe.
+Dans une configuration de commutation/routage, plusieurs noeuds utilisent un
+courtier principal pour implanter une grappe (où pompe) de moteurs de transfert. Ainsi, la vue 
+de chaque moteur de transfert sur l'espace fichier est local, mais les files 
+d'attente sont globales pour la pompe.
 
-Note : Sur de tels clusters, tous les nœuds qui exécutent un composant avec
-l'option le même fichier de configuration crée par défaut un ***queue**
-identique. Cibler les même courtier, il force la fil d'attente à être
-partagée. S'il faut l'éviter, l'utilisateur peut écraser la valeur par
-défaut **queue_name** en y rajoutant **${HOSTNAME}**.  Chaque nœud aura
-sa propre fil d'attente, qui ne sera partagée que par les instances du nœud.
-ex : nom_de_files d'attente q_${BROKER_USER}.${PROGRAM}.${CONFIG}.${HOSTNAME}. )
+Remarque : Sur de tels clusters, tous les nœuds qui exécutent un composant avec le
+le même fichier de configuration créé par défaut a un **queueName** différent,
+basé sur le paramètre **queueShare** incluant **${HOSTNAME}**.
+Chaque nœud aura sa propre file d'attente, partagée uniquement par les instances de nœud.
 
-Souvent, il y a un trafic interne de données acquises avant qu'elles ne
-soient finalement publiées.  En tant que moyen de mise à l'échelle, souvent
-les moteurs de transfert auront également des courtiers pour gérer le
-trafic local, et ne publient les produits finaux qu´au coutier princiapal.
-C'est ainsi que les systèmes *ddsr* sont généralement
-configurés.
+Pour obtenir une file d'attente partagée, l'utilisateur doit définir **queueShare** sur la même
+valeur sur tous les nœuds participants. par exemple::
 
+
+    queueShare  cluster_name
+
+
+Il existe souvent un trafic interne de données acquises avant leur publication définitive.
+Comme moyen d'évolutivité, les moteurs de transfert auront souvent également des courtiers à gérer
+trafic local et publiez uniquement les produits finaux au courtier principal. C'est ainsi
+Les systèmes *ddsr* sont généralement configurés.
 
 
 Considérations de sécurité

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -662,7 +662,7 @@ Une fois connecté à un courtier AMQP, l'utilisateur doit créer une fil d'atte
 
 Mise en fil d'attente sur broker :
 
-- **queueShare <chaine> (par défaut : ${USER}_${HOSTNAME})**
+- **queueShare <chaine> (par défaut : ${USER}_${HOSTNAME}_${RAND8})**
 - **expire <durée> (par défaut : 5m == cinq minutes. À OUTREPASSER)**
 - **message_ttl <durée> (par défaut : Aucun)**
 - **prefetch <N> (par défaut : 1)**
@@ -674,8 +674,8 @@ les cas moins habituels, l'utilisateur peut avoir besoin a remplacer les valeurs
 par défaut. La fil d'attente est l'endroit où les avis sont conservés
 sur le serveur pour chaque abonné.
 
-queueShare <str> (default: ${USER}_${HOSTNAME} )
-------------------------------------------------
+queueShare <str> (default: ${USER}_${HOSTNAME}_${RAND8} )
+---------------------------------------------------------
 
 Un suffixe inclus dans les noms de files d'attente (queueName) pour permettre de spécifier 
 la portée de partage d'une file d'attente.

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -662,7 +662,7 @@ Une fois connecté à un courtier AMQP, l'utilisateur doit créer une fil d'atte
 
 Mise en fil d'attente sur broker :
 
-- **queue <nom> (par défaut : q_<brokerUser>.<programName>.<configName>.<configName>)**
+- **queueShare <chaine> (par défaut : ${USER}_${HOSTNAME})**
 - **expire <durée> (par défaut : 5m == cinq minutes. À OUTREPASSER)**
 - **message_ttl <durée> (par défaut : Aucun)**
 - **prefetch <N> (par défaut : 1)**
@@ -674,36 +674,25 @@ les cas moins habituels, l'utilisateur peut avoir besoin a remplacer les valeurs
 par défaut. La fil d'attente est l'endroit où les avis sont conservés
 sur le serveur pour chaque abonné.
 
-[ queue|queue_name|qn <name>]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+queueShare <str> (default: ${USER}_${HOSTNAME} )
+------------------------------------------------
 
-Par défaut, les composants créent un nom de fil d’attente qui doit être unique. Le
-queue_name par défaut créé par les composants et suit la convention suivante :
+Un suffixe inclus dans les noms de files d'attente (queueName) pour permettre de spécifier 
+la portée de partage d'une file d'attente.
+Lorsque plusieurs hôtes participent à la même file d'attente, utilisez ce paramètre
+pour que les instances choisissent la même file d'attente::
 
-   **q_<brokerUser>.<programName>.<configName>.<random>.<random>** 
+ queueShare my_share_group
 
-Ou:
+Par contre, pour obtenir une file d'attente privée, on pourrait spécifier ::
 
-* *brokerUser* est le nom d’utilisateur utilisé pour se connecter au courtier (souvent: *anonymous* )
+ queueShare ${RAND8}
 
-* *programName* est le composant qui utilise la fil d’attente (par exemple *sr_subscribe* )
+Ce entraînera l'ajout d'un nombre aléatoire à 8 chiffres au nom de la file d'attente.
+Toutes les instances de la configuration ayant accès au même répertoire d'état
+utilisera le nom de file d'attente ainsi défini.
 
-* *configName* est le fichier de configuration utilisé pour régler le comportement des composants
 
-* *random* n’est qu’une série de caractères choisis pour éviter les affrontements de plusieurs
-  personnes qui utilisent les mêmes configurations
-
-Les utilisateurs peuvent remplacer la valeur par défaut à condition qu’elle commence par **q_<brokerUser>**.
-
-Lorsque plusieurs instances sont utilisées, elles utilisent toutes la même fil d’attente, pour du multi-tasking simple.
-Si plusieurs ordinateurs disposent d’un système de fichiers domestique partagé, le
-queue_name est écrit à :
-
- ~/.cache/sarra/<programName>/<configName>/<programName>_<configName>_<brokerUser>.qname
-
-Les instances démarrées sur n’importe quel nœud ayant accès au même fichier partagé utiliseront la
-même fil d’attente. Certains voudront peut-être utiliser l’option *queue_name* comme méthode plus explicite
-de partager le travail sur plusieurs nœuds.
 
 AMQP QUEUE BINDINGS
 -------------------

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1457,7 +1457,7 @@ Ou:
 
 * *nomDeConfig* est le fichier de configuration utilisé pour régler le comportement des composants.
 
-*  *queueShare* est par défaut ${USER}_${HOSTNAME} mais doit être remplacé par le
+*  *queueShare* est par défaut ${USER}_${HOSTNAME}_${RAND8} mais doit être remplacé par le
  Option de configuration *queueShare*.
 
 Les utilisateurs peuvent remplacer le défaut à condition qu’il commence par **q_<utilisateurDeCourtier>**.
@@ -1474,8 +1474,8 @@ de partager le travail sur plusieurs nœuds. Il est pourtant recommandé d´util
 
 
 
-queueShare <str> (default: ${USER}_${HOSTNAME} )
-------------------------------------------------
+queueShare <str> (default: ${USER}_${HOSTNAME}_${RAND8} )
+---------------------------------------------------------
 
 Un suffixe inclus dans les noms de files d'attente pour permettre de définir la portée de partage d'une file d'attente.
 Lorsque plusieurs hôtes participent à la même file d'attente, utilisez ce paramètre

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -139,6 +139,7 @@ en utilisant la notation *${..} * :
 * CONFIG      - le nom du fichier de configuration en cours d'exécution.
 * HOSTNAME    - le hostname qui exécute le client.
 * RANDID      - Un ID aléatoire qui va être consistant pendant la duration d'une seule invocation.
+* RAND8 - un nombre aléatoire à 8 chiffres qui est généré chaque fois qu'il est évalué dans une chaîne de caractères.
 
 
 Les horodatages %Y%m%d et %H font référence à l’heure à laquelle les données sont traitées par
@@ -1422,42 +1423,10 @@ messages d'annonce à la fois.  Pour réduire le nombre de messages d'annonce pe
 partage de charge optimal, prefetch doit être réglée le plus bas possible.  Cependant, sur des long haul links (FIXME),
 il faut augmenter ce nombre pour masquer la latence d'aller-retour, donc un réglage de 10 ou plus est nécessaire.
 
-queueName|queue|queue_name|qn
------------------------------
-
-* queueName <nom>
-
-Par défaut, les composants créent un nom de fil d’attente qui doit être unique. Par défaut, le
-queue_name crée par les composants suit la convention suivante :
-
-   **q_<utilisateurDeCourtier>.<nomDuProgramme>.<nomDeConfig>.<aléatoire>.<aléatoire>**
-
-Ou:
-
-* *utilisateurDeCourtier* est le nom d’utilisateur utilisé pour se connecter au courtier (souvent: *anonymous* )
-
-* *nomDuProgramme* est le composant qui utilise la fil d’attente (par exemple *subscribe* ),
-
-* *nomDeConfig* est le fichier de configuration utilisé pour régler le comportement des composants.
-
-* *aléatoire* n’est qu’une série de caractères choisis pour éviter les affrontements quand plusieurs
-  personnes utilisent les mêmes configurations
-
-Les utilisateurs peuvent remplacer le défaut à condition qu’il commence par **q_<utilisateurDeCourtier>**.
-
-Lorsque plusieurs instances sont utilisées, elles utilisent toutes la même fil d’attente, pour faire plusieurs
-taches simples à la fois. Si plusieurs ordinateurs disposent d’un système de fichiers domestique partagé, le
-queue_name est écrit à :
-
- ~/.cache/sarra/<nomDuProgramme>/<nomDeConfig>/<nomDuProgramme>_<nomDeConfig>_<utilisateurDeCourtier>.qname
-
-Les instances démarrées sur n’importe quel nœud ayant accès au même fichier partagé utiliseront la
-même fil d’attente. Certains voudront peut-être utiliser l’option *queue_name* comme méthode plus explicite
-de partager le travail sur plusieurs nœuds.
-
 queueBind
 ---------
 
+Avec l´option queueBind à *True*, les liaisons (dans AMQP) sont demandées après la déclaration d'une file d'attente.
 Au démarrage, par défaut, Sarracenia redéclare les ressources et les liaisons pour s’assurer qu’elles sont à jour.
 Si la fil d’attente existe déjà, ces indicateurs peuvent être défini a False, afin qu’aucune tentative de déclaration
 ne soit effectuée pour fil d’attente ou pour ses liaisons. Ces options sont utiles sur les courtiers qui ne
@@ -1469,6 +1438,59 @@ queueDeclare <flag> (défaut: True)
 Avec l´option queueDeclare à *True*, un composant déclare un fil d´attente pour accumuler des messages d'annonce lors
 de chaque démarrage. Des fois les permissions sont restrictifs sur les courtiers, alors on ne peut pas
 faire de tels déclarations de ressources. Dans ce cas, il faut supprimer cette déclaration.
+
+queueName|queue|queue_name|qn
+-----------------------------
+
+* queueName <nom>
+
+Par défaut, les composants créent un nom de fil d’attente qui doit être unique. Par défaut, le
+queueName crée par les composants suit la convention suivante :
+
+   **q_<utilisateurDeCourtier>.<nomDuProgramme>.<nomDeConfig>.<queueShare>**
+
+Ou:
+
+* *utilisateurDeCourtier* est le nom d’utilisateur utilisé pour se connecter au courtier (souvent: *anonymous* )
+
+* *nomDuProgramme* est le composant qui utilise la fil d’attente (par exemple *subscribe* ),
+
+* *nomDeConfig* est le fichier de configuration utilisé pour régler le comportement des composants.
+
+*  *queueShare* est par défaut ${USER}_${HOSTNAME} mais doit être remplacé par le
+ Option de configuration *queueShare*.
+
+Les utilisateurs peuvent remplacer le défaut à condition qu’il commence par **q_<utilisateurDeCourtier>**.
+
+Lorsque plusieurs instances sont utilisées, elles utilisent toutes la même fil d’attente, pour faire plusieurs
+taches simples à la fois. Si plusieurs ordinateurs disposent d’un système de fichiers domestique partagé, le
+queueName est écrit à :
+
+ ~/.cache/sarra/<nomDuProgramme>/<nomDeConfig>/<nomDuProgramme>_<nomDeConfig>_<utilisateurDeCourtier>.qname
+
+Les instances démarrées sur n’importe quel nœud ayant accès au même fichier partagé utiliseront la
+même fil d’attente. Certains voudront peut-être utiliser l’option *queueName* comme méthode plus explicite
+de partager le travail sur plusieurs nœuds. Il est pourtant recommandé d´utiliser queueShare a cette fin.
+
+
+
+queueShare <str> (default: ${USER}_${HOSTNAME} )
+------------------------------------------------
+
+Un suffixe inclus dans les noms de files d'attente pour permettre de définir la portée de partage d'une file d'attente.
+Lorsque plusieurs hôtes participent à la même file d'attente, utilisez ce paramètre
+pour que les instances choisissent la même file d'attente::
+
+ queueShare my_share_group
+
+Par contre, pour obtenir une file d'attente privée, on pourrait spécifier ::
+
+ queueShare ${RAND8}
+
+Ce entraînera l'ajout d'un nombre aléatoire à 8 chiffres au nom de la file d'attente.
+Toutes les instances de la configuration ayant accès au même répertoire d'état
+utilisera le nom de file d'attente ainsi défini.
+
 
 randomize <flag>
 ----------------

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -879,7 +879,7 @@ class Config:
 	    #self.post_topicPrefix = None
         self.pstrip = False
         self.queueName = None
-        self.queueShare = "${USER}_${HOSTNAME}"
+        self.queueShare = "${USER}_${HOSTNAME}_${RAND8}"
         self.randomize = False
         self.rename = None
         self.randid = "%04x" % randint(0, 65536)

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -177,7 +177,7 @@ str_options = [
     'exchange_suffix', 'feeder', 'filename', 'flatten', 'flowMain', 'header', 
     'hostname', 'identity', 'inlineEncoding', 'logFormat', 'logLevel', 
     'pollUrl', 'post_baseUrl', 'post_baseDir', 'post_broker', 'post_exchange',
-    'post_exchangeSuffix', 'post_format', 'post_topic', 'queueName', 'sendTo', 'rename',
+    'post_exchangeSuffix', 'post_format', 'post_topic', 'queueName', 'queueShare', 'sendTo', 'rename',
     'report_exchange', 'source', 'strip', 'timezone', 'nodupe_ttl', 'nodupe_driver', 
     'nodupe_basis', 'tlsRigour', 'topic'
 ]
@@ -856,6 +856,10 @@ class Config:
         self.fixed_headers = {}
         self.flatten = '/'
         self.hostname = socket.getfqdn()
+
+        # oddness where final period is included in hostname...seems wrong. happens on windows a lot.
+        if self.hostname[-1] == '.':
+            self.hostname = self.hostname[0:-1]
         self.hostdir = socket.getfqdn().split('.')[0]
         self.log_flowcb_needed = False
         self.sleep = 0.1
@@ -875,6 +879,7 @@ class Config:
 	    #self.post_topicPrefix = None
         self.pstrip = False
         self.queueName = None
+        self.queueShare = "${USER}_${HOSTNAME}"
         self.randomize = False
         self.rename = None
         self.randid = "%04x" % randint(0, 65536)
@@ -1003,6 +1008,9 @@ class Config:
         if (('${POST_BROKER_USER}' in word) and hasattr(self, 'post_broker') and self.post_broker is not None and
                 self.post_broker.url is not None and hasattr(self.post_broker.url, 'username')):
             result = result.replace('${POST_BROKER_USER}', self.post_broker.url.username)
+
+        if ( '${RAND8}' in word ):
+            result = result.replace('${RAND8}', str(randint(0, 100000000)).zfill(8))
 
         if not '$' in result:
             return result
@@ -1804,12 +1812,9 @@ class Config:
             
             #if the queuefile is corrupt, then will need to guess anyways.
             if ( self.queueName is None ) or ( self.queueName == '' ):
-                queueName = 'q_' + self.broker.url.username + '_' + component + '.' + cfg
-                if hasattr(self, 'queue_suffix'):
-                    queueName += '.' + self.queue_suffix
-                queueName += '.' + str(randint(0, 100000000)).zfill(8)
-                queueName += '.' + str(randint(0, 100000000)).zfill(8)
-                self.queueName = queueName
+                queueShare = self._varsub(self.queueShare)
+                logger.info( f"varsubbed {queueShare=} {self.hostname=}" )
+                self.queueName = f"q_{self.broker.url.username}." + '.'.join([component,cfg,queueShare])
                 logger.debug( f'default guessed queueName  {self.queueName} ' )
     
             if self.action not in [ 'start', 'foreground', 'declare' ]:

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -182,7 +182,9 @@ class Retry(FlowCB):
         if self.o.retry_driver == 'redis':
             from sarracenia.redisqueue import RedisQueue
             self.download_retry = RedisQueue(self.o, 'work_retry')
+            self.download_retry_name = self.download_retry.getName()
             self.post_retry = RedisQueue(self.o, 'post_retry')
+            self.post_retry_name = self.post_retry.getName()
         else:
             from sarracenia.diskqueue import DiskQueue
             self.download_retry_name = 'work_retry_%02d' % self.o.no

--- a/sarracenia/redisqueue.py
+++ b/sarracenia/redisqueue.py
@@ -111,6 +111,8 @@ class RedisQueue():
 
         # initialize ages and message counts
 
+    def getName(self) -> str:
+        return self.key_name
 
     def __len__(self) -> int:
         """Returns the total number of messages in the RedisQueue.

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -354,7 +354,7 @@ def test_broker_finalize():
      assert( hasattr( options, 'queue_filename' )  )
      assert( hasattr( options, 'queueName' )  )
      assert( type(options.queueName) == str )
-     assert( options.queueName.startswith('q_bunnypeer_subscribe.ex1')  )
+     assert( options.queueName.startswith('q_bunnypeer.subscribe.ex1')  )
      assert( options.directory == os.path.expanduser( '~/ex1' ) )
      assert( len(options.bindings) == 1 )
      assert( options.exchange == 'xs_bunnypeer' )


### PR DESCRIPTION
fix #33 

* adds: *queueShare* setting, defaulting to ${USER}_${HOSTNAME}
* essentially *queueShare* should be used wherever one used to set *queueNames*... should be no more need for queueName, and more often than before, the default should be good enough so *queueName* setting can just be removed.
* changes default queue to end in *queueShare*, replacing the random-ids.
* add RAND8 variable for people to use queueShare to get the old behaviour back by putting *queueShare ${RAND8}_${RAND8}* in their configuration.
* documenting above.

