### PR TITLE
Authentication plugin refactor

### DIFF
--- a/sarracenia/examples/subscribe/get_copernicus.conf
+++ b/sarracenia/examples/subscribe/get_copernicus.conf
@@ -1,7 +1,7 @@
 broker amqp://COPERNICUS@localhost/
 exchange xs_COPERNICUS
 
-callback accept.auth_copernicus
+callback authenticate.copernicus
 
 directory /tmp/copernicus
 accept .*L2__O3.*

--- a/sarracenia/flowcb/authenticate/__init__.py
+++ b/sarracenia/flowcb/authenticate/__init__.py
@@ -2,8 +2,11 @@
 sarracenia.flowcb.authenticate plugins deal with implementing custom authentication
 for various data sources.
 
-This currently supports various ways of dynamically generating and using 
-bearer tokens, for authenticating with HTTP(S) sources.
+This module currently provides a class to deal with bearer token authentication
+for HTTP(S) data sources.
+
+More classes could be added later, if we find other common authentication methods
+that we need to implement.
 
 Work in progress. See https://github.com/MetPX/sarracenia/issues/565
 """
@@ -22,11 +25,10 @@ class BearerToken(sarracenia.flowcb.FlowCB):
 
     The get_token() method should return the bearer token as a string,
     or None in case it failed to get a token.
-
     """
 
-    def __init__(self, options):
-        super().__init__(options, logger)
+    def __init__(self, options, class_logger=logger):
+        super().__init__(options, class_logger)
 
     def after_accept(self, worklist):
         """ Adds a bearer token to Sarracenia's in memory credentials DB for the message's baseUrl. This will allow

--- a/sarracenia/flowcb/authenticate/__init__.py
+++ b/sarracenia/flowcb/authenticate/__init__.py
@@ -1,7 +1,64 @@
 """
-Authentication plugins.
+sarracenia.flowcb.authenticate plugins deal with implementing custom authentication
+for various data sources.
+
+This currently supports various ways of dynamically generating and using 
+bearer tokens, for authenticating with HTTP(S) sources.
 
 Work in progress. See https://github.com/MetPX/sarracenia/issues/565
 """
+import sarracenia
+import logging
 
-pass
+logger = logging.getLogger(__name__)
+
+class BearerToken(sarracenia.flowcb.FlowCB):
+    """ BearerToken class implements an after_accept method that is common
+    to authentication plugins that provide bearer tokens. 
+
+    A plugin author just needs to create a subclass of BearerToken and
+    implement the get_token() method. The after_accept method defined here
+    will handle loading the token into Sarracenia's credentials database.
+
+    The get_token() method should return the bearer token as a string,
+    or None in case it failed to get a token.
+
+    """
+
+    def __init__(self, options):
+        super().__init__(options, logger)
+
+    def after_accept(self, worklist):
+        """ Adds a bearer token to Sarracenia's in memory credentials DB for the message's baseUrl. This will allow
+            the file to be downloaded with Sarracenia's default HTTPS transfer class using the bearer token.
+        """
+        for msg in worklist.incoming:
+            token = self.get_token()
+            
+            if not token:
+                logger.error("Failed to get token!")
+                continue
+
+            # If the credential already exists and the bearer_token matches, don't need to do anything
+            ok, details = self.o.credentials.get(msg['baseUrl'])
+            token_already_in_creds = False
+            try: 
+                token_already_in_creds = (ok and details.bearer_token == token)
+                if token_already_in_creds:
+                    logger.debug(f"Token for {msg['baseUrl']} already in credentials database")
+            except:
+                token_already_in_creds = False
+
+            if not token_already_in_creds:
+                logger.info(f"Token for {msg['baseUrl']} not in credentials database. Adding it!")
+                # Add the new bearer token to the internal credentials db. If the credential is already in the db, it will
+                # be replaced which is desirable.
+                cred = sarracenia.credentials.Credential(urlstr=msg['baseUrl'])
+                cred.bearer_token = token
+                self.o.credentials.add(msg['baseUrl'], details=cred)
+    
+    def get_token(self):
+        """ To be implemented by plugin authors.
+        """
+        logger.error("BearerToken class get_token not implemented.")
+        return None

--- a/sarracenia/flowcb/authenticate/copernicus.py
+++ b/sarracenia/flowcb/authenticate/copernicus.py
@@ -61,7 +61,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-class Auth_copernicus(BearerToken):
+class Copernicus(BearerToken):
     def __init__(self, options):
         super().__init__(options, logger)
         


### PR DESCRIPTION
Adds a BearerToken class, with a standardized after_accept method that calls get_token (to be implemented by subclasses) and inserts the token into the in memory credentials DB.  This eliminates duplicated code that I had in my bearer token authentication plugins, and makes it easier for other people to write new authentication plugins. (Part of #565)

Refactored the NASA, Copernicus and Eumetsat auth plugins to use this BearerToken class as their parent class.

Also fixes #1133 (in a different way than #1134, sorry @andreleblanc11 😄 I was worried about string comparisons for dates not being reliable, especially with the MM/DD/YYYY format ).

I'm okay with waiting until after we release a stable version of 3.00.54 to merge this (i.e. only include it in 3.00.55).