### PR TITLE
The Hearty eXpert Issue1138 - documenting messageAgeMax

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1120,7 +1120,7 @@ If **messageCountMax** is greater than zero, the flow will exit after processing
 number of messages.  This is normally used only for debugging.
 
 messageRateMax <float> (default: 0)
--------------------------------------
+-----------------------------------
 
 if **messageRateMax** is greater than zero, the flow attempts to respect this delivery
 speed in terms of messages per second. Note that the throttle is on messages obtained or generated
@@ -1128,14 +1128,14 @@ per second, prior to accept/reject filtering. the flow will sleep to limit the p
 
 
 messageRateMin <float> (default: 0)
--------------------------------------
+-----------------------------------
 
 if **messageRateMin** is greater than zero, and the flow detected is lower than this rate,
 a warning message will be produced:
 
 
 messageAgeMax <duration>  (default: 0)
------------------------------------------
+--------------------------------------
 
 The messageAgeMax option sets the maximum age of a message to not 
 be rejected when consuming. Messages older than Max value are discarded
@@ -1408,7 +1408,7 @@ When provided, this value overrides whatever can be deduced from the post_topicP
 
 
 post_messageAgeMax <duration>  (default: 0)
-----------------------------------------------
+-------------------------------------------
 
 The post_messageAgeMax (aka **message_ttl**) option is used when publishing a message,
 as advice to the broker. Brokers discard messages which have exceeded their intended lifespan

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1134,11 +1134,13 @@ if **messageRateMin** is greater than zero, and the flow detected is lower than 
 a warning message will be produced:
 
 
-message_ttl <duration>  (default: None)
----------------------------------------
+messageAgeMax <duration>  (default: 0)
+-----------------------------------------
 
-The  **message_ttl**  option set the time a message can live in the queue.
-Past that time, the message is taken out of the queue by the broker.
+The messageAgeMax option sets the maximum age of a message to not 
+be rejected when consuming. Messages older than Max value are discarded
+by the subscriber. (0 means no maximum age)
+
 
 mirror <flag> (default: off)
 ----------------------------
@@ -1403,6 +1405,14 @@ Sets the message format for posted messages. the currently included values are:
 * wis ... a experimental geoJSON format in flux for the World Meteorological Organization
 
 When provided, this value overrides whatever can be deduced from the post_topicPrefix.
+
+
+post_messageAgeMax <duration>  (default: 0)
+----------------------------------------------
+
+The post_messageAgeMax (aka **message_ttl**) option is used when publishing a message,
+as advice to the broker. Brokers discard messages which have exceeded their intended lifespan
+without delivering them. (0 means no maximum lifespan is given.)
 
 
 post_on_start

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1139,7 +1139,7 @@ messageAgeMax <duration>  (default: 0)
 
 The messageAgeMax option sets the maximum age of a message to not 
 be rejected when consuming. Messages older than Max value are discarded
-by the subscriber. (0 means no maximum age)
+by the subscriber. (0 means no maximum age) 
 
 
 mirror <flag> (default: off)
@@ -1413,6 +1413,8 @@ post_messageAgeMax <duration>  (default: 0)
 The post_messageAgeMax (aka **message_ttl**) option is used when publishing a message,
 as advice to the broker. Brokers discard messages which have exceeded their intended lifespan
 without delivering them. (0 means no maximum lifespan is given.)
+When posting to AMQP, this option sets the *x-message-ttl* property (but the latter is in milliseconds.)
+When posting to MQTT, this option sets the *MessageExpiryInterval* property. 
 
 
 post_on_start

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1116,11 +1116,12 @@ messageRateMin <float> (défaut: 0)
 Si **messageRateMin** est supérieur à zéro et que le flux détecté est inférieur à ce taux,
 un message d´annonce sera produit :
 
-message_ttl <duration>  (défaut: None)
---------------------------------------
+messageAgeMax <duration>  (défaut: None)
+----------------------------------------
 
-L’option **message_ttl** définit un temps pour lequel un message d´annonce peut vivre dans la fil d’attente.
-Après ce temps, le message d´annonce est retiré de la fil d’attente par le courtier.
+L’option **AgeMax** définit un temps pour lequel un message d´annonce peut attendres du
+côté consommateur. Après ce temps, le message d´annonce est rejeté par le flot.
+(0 indique un age infini sera accepté.)
 
 mirror <flag> (défaut: off)
 ---------------------------
@@ -1389,6 +1390,13 @@ Définit le format de message pour les messages publiés. les valeurs actuelleme
 * wis ... un format expérimental geoJSON en flux pour l'Organisation météorologique mondiale
 
 Lorsqu'elle est fournie, cette valeur remplace tout ce qui peut être déduit de post_topicPrefix.
+
+post_messageAgeMax <duration> (défaut: 0)
+-----------------------------------------
+
+L'option post_messageAgeMax (alias **message_ttl**) est utilisée lors de la publication d'un message,
+comme conseil au courtier. ttl est un abbréviation de *time to live* (*durée de vie maximale*) Les courtiers 
+rejettent les messages qui ont dépassé leur durée de vie prévue sans les livrer. (0 signifie qu'aucune durée de vie maximale n'est donnée.)
 
 
 post_on_start

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1397,6 +1397,8 @@ post_messageAgeMax <duration> (défaut: 0)
 L'option post_messageAgeMax (alias **message_ttl**) est utilisée lors de la publication d'un message,
 comme conseil au courtier. ttl est un abbréviation de *time to live* (*durée de vie maximale*) Les courtiers 
 rejettent les messages qui ont dépassé leur durée de vie prévue sans les livrer. (0 signifie qu'aucune durée de vie maximale n'est donnée.)
+Lors de la publication avec AMQP, cette option définit la propriété *x-message-ttl* (mais cette dernière est en millisecondes).
+Lors de la publication avec MQTT, cette option définit la propriété *MessageExpiryInterval*.
 
 
 post_on_start

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -152,7 +152,8 @@ flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl
 float_options = [ 'messageRateMax', 'messageRateMin' ]
 
 duration_options = [
-    'expire', 'housekeeping', 'logRotateInterval', 'message_ttl', 'fileAgeMax', 'fileAgeMin', 'metrics_writeInterval', \
+    'expire', 'housekeeping', 'logRotateInterval', 'fileAgeMax', 'fileAgeMin', 
+    'messageAgeMax', 'post_messageAgeMax', 'metrics_writeInterval', \
     'runStateThreshold_idle', 'runStateThreshold_lag', 'retry_ttl', 'runStateThreshold_hung', 'sleep', 'timeout', 'varTimeOffset'
 ]
 
@@ -753,7 +754,8 @@ class Config:
         'logRotate': 'logRotateCount',
         'logRotate': 'logRotateCount',
         'logRotate_interval': 'logRotateInterval',
-        'message-ttl': 'message_ttl',
+        'message-ttl': 'post_messageAgeMax',
+        'message_ttl': 'post_messageAgeMax',
         'msg_replace_new_dir' : 'pathReplace',
         'msg_filter_wmo2msc_replace_dir': 'filter_wmo2msc_replace_dir',
         'msg_filter_wmo2msc_uniquify': 'filter_wmo2msc_uniquify',
@@ -876,6 +878,7 @@ class Config:
         self.mirror = False
         self.messageAgeMax = 0
         self.post_exchanges = []
+        self.post_messageAgeMax = 0
 	    #self.post_topicPrefix = None
         self.pstrip = False
         self.queueName = None

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -24,7 +24,7 @@ class Message(FlowCB):
             props.update(self.o.dictify())
 
             # adjust settings post_xxx to be xxx, as Moth does not use post_ ones.
-            for k in [ 'broker', 'exchange', 'topicPrefix', 'exchangeSplit', 'topic' ]:
+            for k in [ 'broker', 'exchange', 'topicPrefix', 'exchangeSplit', 'topic', 'messageAgeMax' ]:
                 post_one='post_'+k
                 if hasattr( self.o, post_one ): 
                     #props.update({ k: getattr(self.o,post_one) } )

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -269,8 +269,8 @@ class AMQP(Moth):
                 if self.o['expire']:
                     x = int(self.o['expire'] * 1000)
                     if x > 0: args['x-expires'] = x
-                if self.o['message_ttl']:
-                    x = int(self.o['message_ttl'] * 1000)
+                if self.o['messageAgeMax']:
+                    x = int(self.o['messageAgeMax'] * 1000)
                     if x > 0: args['x-message-ttl'] = x
 
                 #FIXME: conver expire, message_ttl to proper units.
@@ -672,7 +672,7 @@ class AMQP(Moth):
 
         if self.o['message_ttl']:
             ttl = "%d" * int(
-                sarracenia.durationToSeconds(self.o['message_ttl']) * 1000)
+                sarracenia.durationToSeconds(self.o['messageAgeMax']) * 1000)
         else:
             ttl = "0"
         

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -455,8 +455,8 @@ class MQTT(Moth):
                 self.unexpected_publishes = collections.deque()
 
                 props = Properties(PacketTypes.CONNECT)
-                if self.o['message_ttl'] > 0:
-                    props.MessageExpiryInterval = int(self.o['message_ttl'])
+                if self.o['messageAgeMax'] > 0:
+                    props.MessageExpiryInterval = int(self.o['messageAgeMax'])
 
                 self.transport = 'websockets' if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
                    (self.o['broker'].url.scheme[-1] == 'w' ) else 'tcp'


### PR DESCRIPTION

documentation done, and changed the name of message_ttl to post_messageAgeMax to be more obvious.  There was a lot of discussion about retry_ttl, nodupe_ttl, and expire.  I left them alone.

Thinking about it... those aren't message age entries, so much as cache entry ages ... which are pretty similar... but I dunno... I think people are used to those _ttl names.  Could do nodupe_messageAgeMax, or nodupe_ageMax, but I think ttl is ok.  In French I explained what ttl acronym means... didn't bother with that in English, should be familiar.

similarly *expire* was kept as-is, rather than changing to *queueExpire*. while the latter is clearer, the simple *expire* word is what is used in AMQP documentation, making the mapping easier.  Similarly, in the post_messageAgeMax settings, the documentation describes the message properties (ttl) which are affected by it.

p.s. I needed the PR title to start with THX to go with the issue number.