### PR TITLE
Issue339 phase 1: adding broker to binding tuple.

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1360,7 +1360,7 @@ class Config:
                 subtopic = subtopic_string.split('/')
             
         if hasattr(self, 'exchange') and hasattr(self, 'topicPrefix'):
-            self.bindings.append((self.exchange, self.topicPrefix, subtopic))
+            self.bindings.append((self.broker, self.exchange, self.topicPrefix, subtopic))
 
     def _parse_v2plugin(self, entryPoint, value):
         """
@@ -1998,7 +1998,7 @@ class Config:
 
 
         if (self.bindings == [] and hasattr(self, 'exchange')):
-            self.bindings = [(self.exchange, self.topicPrefix, [ '#' ])]
+            self.bindings = [(self.broker, self.exchange, self.topicPrefix, [ '#' ])]
 
         if hasattr(self, 'documentRoot') and (self.documentRoot is not None):
             path = os.path.expanduser(os.path.abspath(self.documentRoot))
@@ -2433,7 +2433,7 @@ class Config:
                    topicPrefix = namespace.topicPrefix.split('/')
 
             namespace.bindings.append(
-                (namespace.exchange, topicPrefix, values))
+                (namespace.broker, namespace.exchange, topicPrefix, values))
 
     def parse_args(self, isPost=False):
         """

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -104,25 +104,10 @@ class Credential:
         self.azure_credentials = None
         self.implicit_ftps = False
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns attributes of the Credential object as a readable string.
         """
-
-        s = ''
-        if False:
-            s += self.url.geturl()
-        else:
-            s += self.url.scheme + '://'
-            if self.url.username:
-                s += self.url.username
-            #if self.url.password:
-            #   s += ':' + self.url.password
-            if self.url.hostname:
-                s += '@' + self.url.hostname
-            if self.url.port:
-                s += ':' + str(self.url.port)
-            if self.url.path:
-                s += self.url.path
+        s = self.geturl()
 
         s += " %s" % self.ssh_keyfile
         s += " %s" % self.passive
@@ -137,6 +122,24 @@ class Credential:
         s += " %s" % 'Yes' if self.azure_credentials != None else 'No'
         s += " %s" % self.implicit_ftps
 
+        return s
+
+    def geturl(self) -> str:
+        if not hasattr(self,'url'):
+            return ''
+
+        s=''
+        s += self.url.scheme + '://'
+        if self.url.username:
+            s += self.url.username
+        #if self.url.password:
+        #   s += ':' + self.url.password
+        if self.url.hostname:
+            s += '@' + self.url.hostname
+        if self.url.port:
+            s += ':' + str(self.url.port)
+        if self.url.path:
+            s += self.url.path
         return s
 
 
@@ -241,6 +244,8 @@ class CredentialDB:
         else:
             k=urlstr
         return False, self.credentials[k]
+
+
 
     def has(self, urlstr):
         """Return ``True`` if the Credential matching the urlstr is already in the CredentialDB.

--- a/sarracenia/examples/flow_api_consumer.py
+++ b/sarracenia/examples/flow_api_consumer.py
@@ -12,9 +12,10 @@ cfg.topicPrefix = ['v02', 'post']
 cfg.component = 'subscribe'
 cfg.config = 'flow_demo'
 cfg.action = 'hoho'
-cfg.bindings = [('xpublic', ['v02', 'post'],
+cfg.bindings = [( 'xpublic', ['v02', 'post'],
                  ['*', 'WXO-DD', 'observations', 'swob-ml', '#'])]
 cfg.queueName = 'q_anonymous.subscriber_test2'
+cfg.debug = True
 cfg.download = True
 cfg.batch = 1
 cfg.messageCountMax = 5

--- a/sarracenia/examples/flow_api_consumer.py
+++ b/sarracenia/examples/flow_api_consumer.py
@@ -15,7 +15,7 @@ cfg.action = 'hoho'
 cfg.bindings = [( 'xpublic', ['v02', 'post'],
                  ['*', 'WXO-DD', 'observations', 'swob-ml', '#'])]
 cfg.queueName = 'q_anonymous.subscriber_test2'
-cfg.debug = True
+#cfg.debug = True
 cfg.download = True
 cfg.batch = 1
 cfg.messageCountMax = 5

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -983,7 +983,6 @@ class Flow:
 
         now = nowflt()
         for m in self.worklist.incoming:
-            logger.critical( f"{type(m)} {m=}" )
             then = sarracenia.timestr2flt(m['pubTime'])
             lag = now - then
             if self.o.messageAgeMax != 0 and lag > self.o.messageAgeMax:
@@ -1264,6 +1263,7 @@ class Flow:
 
             # assume dir always exist... should check on startup, not here.
             # if os.path.isdir(os.path.dirname(self.o.metricsFilename)):
+            logger.critical( f"{self.metrics}" )
             metrics=json.dumps(self.metrics)
             with open(self.o.metricsFilename, 'w') as mfn:
                  mfn.write(metrics+"\n")

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1263,7 +1263,6 @@ class Flow:
 
             # assume dir always exist... should check on startup, not here.
             # if os.path.isdir(os.path.dirname(self.o.metricsFilename)):
-            logger.critical( f"{self.metrics}" )
             metrics=json.dumps(self.metrics)
             with open(self.o.metricsFilename, 'w') as mfn:
                  mfn.write(metrics+"\n")

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -983,6 +983,7 @@ class Flow:
 
         now = nowflt()
         for m in self.worklist.incoming:
+            logger.critical( f"{type(m)} {m=}" )
             then = sarracenia.timestr2flt(m['pubTime'])
             lag = now - then
             if self.o.messageAgeMax != 0 and lag > self.o.messageAgeMax:

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -68,7 +68,10 @@ class Message(FlowCB):
 
         for m in mlist:
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
-            self.consumers[m['broker']].ack(m)
+            if 'broker' in m:
+                 self.consumers[m['broker']].ack(m)
+            else:
+                logger.error( f"cannot ack, missing broker in {m}" )
 
     def metricsReport(self) -> dict:
 
@@ -88,10 +91,11 @@ class Message(FlowCB):
 
         m = self.metricsReport()
         for broker in self.brokers:
-            average = (m[broker.geturl()]['rxByteCount'] /
-                   m[broker.geturl()]['rxGoodCount'] if m[broker.geturl()]['rxGoodCount'] != 0 else 0)
-            logger.info( f"{broker.url} messages: good: {m[broker]['rxGoodCount']} bad: {m[broker]['rxBadCount']} " +\
-               f"bytes: {naturalSize(m[broker]['rxByteCount'])} " +\
+            burl=broker.geturl()
+            average = (m[burl]['rxByteCount'] /
+                   m[burl]['rxGoodCount'] if m[burl]['rxGoodCount'] != 0 else 0)
+            logger.info( f"{burl} messages: good: {m[burl]['rxGoodCount']} bad: {m[burl]['rxBadCount']} " +\
+               f"bytes: {naturalSize(m[burl]['rxByteCount'])} " +\
                f"average: {naturalSize(average)}" )
             self.consumers[broker].metricsReset()
 

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -67,11 +67,19 @@ class Message(FlowCB):
             return
 
         for m in mlist:
+            if not 'broker' in m:
+                logger.error( f"cannot ack, missing broker in {m}" )
+                continue
+
+            if not m['broker'] in self.consumers:
+                logger.error( f"cannot ack, no consumer for {m['broker'].geturl()}" )
+                continue
+
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
-            if 'broker' in m:
+            if hasattr(self.consumers[m['broker']],'ack'):
                  self.consumers[m['broker']].ack(m)
             else:
-                logger.error( f"cannot ack, missing broker in {m}" )
+                logger.error( f"cannot ack" )
 
     def metricsReport(self) -> dict:
 

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -33,8 +33,11 @@ class Message(FlowCB):
 
         self.brokers=[]
         for binding in self.o.bindings:
-            if binding[0] not in self.brokers:
+            if len(binding) >= 4 and binding[0] not in self.brokers:
                self.brokers.append(binding[0])
+
+        if len(self.brokers) == 0:
+            self.brokers=[ self.o.broker ]
 
         self.consumers={}
         for broker in self.brokers:

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -63,7 +63,7 @@ class Message(FlowCB):
 
     def ack(self, mlist) -> None:
 
-        if not hasattr(self,'consumer'):
+        if not hasattr(self,'consumers'):
             return
 
         for m in mlist:
@@ -72,24 +72,24 @@ class Message(FlowCB):
 
     def metricsReport(self) -> dict:
 
-        if not hasattr(self,'consumer'):
+        if not hasattr(self,'consumers'):
            return {}
 
         metrics={}
         for broker in self.brokers:
            if hasattr(self.consumers[broker],'metricsReport'):
-               metrics[broker] = self.consumers[broker].metricsReport()
+               metrics[broker.geturl()] = self.consumers[broker].metricsReport()
         return metrics 
 
     def on_housekeeping(self) -> None:
 
-        if not hasattr(self,'consumer'):
+        if not hasattr(self,'consumers'):
             return
 
         m = self.metricsReport()
         for broker in self.brokers:
-            average = (m[broker]['rxByteCount'] /
-                   m[broker]['rxGoodCount'] if m[broker]['rxGoodCount'] != 0 else 0)
+            average = (m[broker.geturl()]['rxByteCount'] /
+                   m[broker.geturl()]['rxGoodCount'] if m[broker.geturl()]['rxGoodCount'] != 0 else 0)
             logger.info( f"{broker.url} messages: good: {m[broker]['rxGoodCount']} bad: {m[broker]['rxBadCount']} " +\
                f"bytes: {naturalSize(m[broker]['rxByteCount'])} " +\
                f"average: {naturalSize(average)}" )

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -358,7 +358,14 @@ class AMQP(Moth):
 
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
-                        broker, exchange, prefix, subtopic = tup
+                        if len(tup) == 4:
+                            broker, exchange, prefix, subtopic = tup
+                        elif len(tup) == 3:
+                            exchange, prefix, subtopic = tup
+                            broker = self.o['broker']
+                        else:
+                            logger.critical( f"binding \"{tup}\" should be a list of tuples ( broker, exchange, prefix, subtopic )" )
+                            continue
                         logger.critical( f"{broker=} {self.o['broker']=} ")
                         if broker != self.o['broker']:
                             continue

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -359,7 +359,7 @@ class AMQP(Moth):
 
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
-                        exchange, prefix, subtopic = tup
+                        broker, exchange, prefix, subtopic = tup
                         topic = '.'.join(prefix + subtopic)
                         if self.o['dry_run']:
                             logger.info('binding (dry run) %s with %s to %s (as: %s)' % \

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -112,8 +112,6 @@ class AMQP(Moth):
                     logger.info('had no delivery info')
                 logger.info('raw message end')
 
-
-
             if type(body) is bytes:
                 try:
                     body = raw_msg.body.decode("utf8")
@@ -142,9 +140,10 @@ class AMQP(Moth):
             msg.deriveSource( self.o )
             msg.deriveTopics( self.o, topic )
 
+            msg['broker'] = self.o['broker']
             msg['ack_id'] = raw_msg.delivery_info['delivery_tag']
             msg['local_offset'] = 0
-            msg['_deleteOnPost'] |= set( ['ack_id', 'exchange', 'local_offset', 'subtopic'])
+            msg['_deleteOnPost'] |= set( ['ack_id', 'broker', 'exchange', 'local_offset', 'subtopic'])
             if not msg.validate():
                 if hasattr(self,'channel'):
                     self.channel.basic_ack(msg['ack_id'])
@@ -360,6 +359,9 @@ class AMQP(Moth):
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
                         broker, exchange, prefix, subtopic = tup
+                        logger.critical( f"{broker=} {self.o['broker']=} ")
+                        if broker != self.o['broker']:
+                            continue
                         topic = '.'.join(prefix + subtopic)
                         if self.o['dry_run']:
                             logger.info('binding (dry run) %s with %s to %s (as: %s)' % \

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -213,8 +213,8 @@ class MQTT(Moth):
             if 'topic' in userdata.o:
                 subj=userdata.o['topic']
             else:
-                exchange, prefix, subtopic = binding_tuple
-                logger.info( f"tuple: {exchange} {prefix} {subtopic}")
+                broker, exchange, prefix, subtopic = binding_tuple
+                logger.info( f"tuple: {broker} {exchange} {prefix} {subtopic}")
 
                 subj = '/'.join(['$share', userdata.o['queueName'], exchange] +
                                 prefix + subtopic)

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -590,10 +590,11 @@ class MQTT(Moth):
         message.deriveSource( self.o )
         message.deriveTopics( self.o, topic=mqttMessage.topic, separator='/' )
 
+        message['broker'] = self.o['broker']
         message['ack_id'] = mqttMessage.mid
         message['qos'] = mqttMessage.qos
         message['local_offset'] = 0
-        message['_deleteOnPost'] |= set( ['exchange', 'local_offset', 'ack_id', 'qos' ])
+        message['_deleteOnPost'] |= set( ['ack_id', 'broker', 'exchange', 'local_offset', 'qos' ])
 
         self.metrics['rxLast'] = sarracenia.nowstr()
         if message.validate():

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -213,7 +213,15 @@ class MQTT(Moth):
             if 'topic' in userdata.o:
                 subj=userdata.o['topic']
             else:
-                broker, exchange, prefix, subtopic = binding_tuple
+                if len(binding_tuple) == 4:
+                    broker, exchange, prefix, subtopic = binding_tuple
+                elif len(binding_tuple) == 3:
+                    exchange, prefix, subtopic = binding_tuple
+                    broker = userdata.o['broker']
+                else:
+                    logger.critical( f"invalid binding: \"{binding_tuple}\" should be a tuple containing ( broker, exchange, topicPrefix, subtopic )" )
+                    continue
+ 
                 logger.info( f"tuple: {broker} {exchange} {prefix} {subtopic}")
 
                 subj = '/'.join(['$share', userdata.o['queueName'], exchange] +


### PR DESCRIPTION
This first patch implements flows that can subscribe to multiple brokers and multiple exchanges at once. it's a first installment.

This group of patches should be squash into a single commit because only with all together will it pass all existing flow tests. commiting subsets will result in git bisection breakage.

These changes add the broker to the binding tuple, and work, provided the same queueName is legal/usable at all brokers.  (declares queues on all brokers, with the same queueName.)

Weaknesses, why it is just part1:

*  if using different usernames to subscribe on different brokers, then legal queuenames will likely differ.  Need for queueName to be a per broker thing. (part 2) 

*  if one broker fails, it will hang trying to connect to that broker, rather than continuing to listen to the brokers for other bindings, defeating the HA purpose of some use cases for multiple source collection. (part 3)

Doing one merge of all the patches in part1 should be a minimal set of changes to start using multiple upstream brokes in flows.

How does par1 work?

* add broker to the *bindings* tuple used to do... uh... bindings... exchange is already there... so no big deal.  Then modify things in moth/*.py/getSetup to apply the bindings using the correct broker.

* have flowcb/gather/message.py to have slightly pars bindings to understand multiple consumers (1 per broker) and:
   * call getSetup for each one.
   * ask for messages from each one.
   * do housekeeping on each one.
   * have close, close for each one.



