### PR TITLE
Issue339 part2 queue names

### DIFF
--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -1360,7 +1360,7 @@ class Config:
                 subtopic = subtopic_string.split('/')
             
         if hasattr(self, 'exchange') and hasattr(self, 'topicPrefix'):
-            self.bindings.append((self.exchange, self.topicPrefix, subtopic))
+            self.bindings.append((self.broker, self.exchange, self.topicPrefix, subtopic))
 
     def _parse_v2plugin(self, entryPoint, value):
         """
@@ -1998,7 +1998,7 @@ class Config:
 
 
         if (self.bindings == [] and hasattr(self, 'exchange')):
-            self.bindings = [(self.exchange, self.topicPrefix, [ '#' ])]
+            self.bindings = [(self.broker, self.exchange, self.topicPrefix, [ '#' ])]
 
         if hasattr(self, 'documentRoot') and (self.documentRoot is not None):
             path = os.path.expanduser(os.path.abspath(self.documentRoot))
@@ -2433,7 +2433,7 @@ class Config:
                    topicPrefix = namespace.topicPrefix.split('/')
 
             namespace.bindings.append(
-                (namespace.exchange, topicPrefix, values))
+                (namespace.broker, namespace.exchange, topicPrefix, values))
 
     def parse_args(self, isPost=False):
         """

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -110,6 +110,7 @@ default_options = {
     'post_baseDir': None,
     'post_baseUrl': None,
     'post_format': 'v03',
+    'qos': 1,
     'realpathPost': False,
     'recursive' : True,
     'runStateThreshold_reject': 80,
@@ -133,7 +134,7 @@ default_options = {
 
 count_options = [
     'batch', 'count', 'exchangeSplit', 'instances', 'logRotateCount', 'no', 
-    'post_exchangeSplit', 'prefetch', 'messageCountMax', 'runStateThreshold_cpuSlow', 
+    'post_exchangeSplit', 'prefetch', 'qos', 'messageCountMax', 'runStateThreshold_cpuSlow', 
     'runStateThreshold_reject', 'runStateThreshold_retry', 'runStateThreshold_slow', 
 ]
 
@@ -1361,7 +1362,7 @@ class Config:
             
         if hasattr(self, 'exchange') and hasattr(self, 'topicPrefix'):
             new_binding={}
-            for i in [ 'broker', 'exchange', 'topicPrefix' ]:
+            for i in [ 'auto_delete', 'broker', 'durable', 'exchange', 'expire', 'message_ttl', 'prefetch', 'qos', 'queueBind', 'queueDeclare', 'topicPrefix' ]:
                 new_binding[i] = getattr(self,i)
 
             new_binding['subtopic'] = subtopic

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -104,25 +104,10 @@ class Credential:
         self.azure_credentials = None
         self.implicit_ftps = False
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns attributes of the Credential object as a readable string.
         """
-
-        s = ''
-        if False:
-            s += self.url.geturl()
-        else:
-            s += self.url.scheme + '://'
-            if self.url.username:
-                s += self.url.username
-            #if self.url.password:
-            #   s += ':' + self.url.password
-            if self.url.hostname:
-                s += '@' + self.url.hostname
-            if self.url.port:
-                s += ':' + str(self.url.port)
-            if self.url.path:
-                s += self.url.path
+        s = self.geturl()
 
         s += " %s" % self.ssh_keyfile
         s += " %s" % self.passive
@@ -137,6 +122,24 @@ class Credential:
         s += " %s" % 'Yes' if self.azure_credentials != None else 'No'
         s += " %s" % self.implicit_ftps
 
+        return s
+
+    def geturl(self) -> str:
+        if not hasattr(self,'url'):
+            return ''
+
+        s=''
+        s += self.url.scheme + '://'
+        if self.url.username:
+            s += self.url.username
+        #if self.url.password:
+        #   s += ':' + self.url.password
+        if self.url.hostname:
+            s += '@' + self.url.hostname
+        if self.url.port:
+            s += ':' + str(self.url.port)
+        if self.url.path:
+            s += self.url.path
         return s
 
 
@@ -241,6 +244,8 @@ class CredentialDB:
         else:
             k=urlstr
         return False, self.credentials[k]
+
+
 
     def has(self, urlstr):
         """Return ``True`` if the Credential matching the urlstr is already in the CredentialDB.

--- a/sarracenia/examples/flow_api_consumer.py
+++ b/sarracenia/examples/flow_api_consumer.py
@@ -12,9 +12,10 @@ cfg.topicPrefix = ['v02', 'post']
 cfg.component = 'subscribe'
 cfg.config = 'flow_demo'
 cfg.action = 'hoho'
-cfg.bindings = [('xpublic', ['v02', 'post'],
+cfg.bindings = [( 'xpublic', ['v02', 'post'],
                  ['*', 'WXO-DD', 'observations', 'swob-ml', '#'])]
 cfg.queueName = 'q_anonymous.subscriber_test2'
+cfg.debug = True
 cfg.download = True
 cfg.batch = 1
 cfg.messageCountMax = 5

--- a/sarracenia/examples/flow_api_consumer.py
+++ b/sarracenia/examples/flow_api_consumer.py
@@ -15,7 +15,7 @@ cfg.action = 'hoho'
 cfg.bindings = [( 'xpublic', ['v02', 'post'],
                  ['*', 'WXO-DD', 'observations', 'swob-ml', '#'])]
 cfg.queueName = 'q_anonymous.subscriber_test2'
-cfg.debug = True
+#cfg.debug = True
 cfg.download = True
 cfg.batch = 1
 cfg.messageCountMax = 5

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -983,7 +983,6 @@ class Flow:
 
         now = nowflt()
         for m in self.worklist.incoming:
-            logger.critical( f"{type(m)} {m=}" )
             then = sarracenia.timestr2flt(m['pubTime'])
             lag = now - then
             if self.o.messageAgeMax != 0 and lag > self.o.messageAgeMax:
@@ -1264,6 +1263,7 @@ class Flow:
 
             # assume dir always exist... should check on startup, not here.
             # if os.path.isdir(os.path.dirname(self.o.metricsFilename)):
+            logger.critical( f"{self.metrics}" )
             metrics=json.dumps(self.metrics)
             with open(self.o.metricsFilename, 'w') as mfn:
                  mfn.write(metrics+"\n")

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1263,7 +1263,6 @@ class Flow:
 
             # assume dir always exist... should check on startup, not here.
             # if os.path.isdir(os.path.dirname(self.o.metricsFilename)):
-            logger.critical( f"{self.metrics}" )
             metrics=json.dumps(self.metrics)
             with open(self.o.metricsFilename, 'w') as mfn:
                  mfn.write(metrics+"\n")

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -983,6 +983,7 @@ class Flow:
 
         now = nowflt()
         for m in self.worklist.incoming:
+            logger.critical( f"{type(m)} {m=}" )
             then = sarracenia.timestr2flt(m['pubTime'])
             lag = now - then
             if self.o.messageAgeMax != 0 and lag > self.o.messageAgeMax:

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -68,7 +68,10 @@ class Message(FlowCB):
 
         for m in mlist:
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
-            self.consumers[m['broker']].ack(m)
+            if 'broker' in m:
+                 self.consumers[m['broker']].ack(m)
+            else:
+                logger.error( f"cannot ack, missing broker in {m}" )
 
     def metricsReport(self) -> dict:
 
@@ -88,10 +91,11 @@ class Message(FlowCB):
 
         m = self.metricsReport()
         for broker in self.brokers:
-            average = (m[broker.geturl()]['rxByteCount'] /
-                   m[broker.geturl()]['rxGoodCount'] if m[broker.geturl()]['rxGoodCount'] != 0 else 0)
-            logger.info( f"{broker.url} messages: good: {m[broker]['rxGoodCount']} bad: {m[broker]['rxBadCount']} " +\
-               f"bytes: {naturalSize(m[broker]['rxByteCount'])} " +\
+            burl=broker.geturl()
+            average = (m[burl]['rxByteCount'] /
+                   m[burl]['rxGoodCount'] if m[burl]['rxGoodCount'] != 0 else 0)
+            logger.info( f"{burl} messages: good: {m[burl]['rxGoodCount']} bad: {m[burl]['rxBadCount']} " +\
+               f"bytes: {naturalSize(m[burl]['rxByteCount'])} " +\
                f"average: {naturalSize(average)}" )
             self.consumers[broker].metricsReset()
 

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -67,11 +67,19 @@ class Message(FlowCB):
             return
 
         for m in mlist:
+            if not 'broker' in m:
+                logger.error( f"cannot ack, missing broker in {m}" )
+                continue
+
+            if not m['broker'] in self.consumers:
+                logger.error( f"cannot ack, no consumer for {m['broker'].geturl()}" )
+                continue
+
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
-            if 'broker' in m:
+            if hasattr(self.consumers[m['broker']],'ack'):
                  self.consumers[m['broker']].ack(m)
             else:
-                logger.error( f"cannot ack, missing broker in {m}" )
+                logger.error( f"cannot ack" )
 
     def metricsReport(self) -> dict:
 

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -33,8 +33,8 @@ class Message(FlowCB):
 
         self.brokers=[]
         for binding in self.o.bindings:
-            if len(binding) >= 4 and binding[0] not in self.brokers:
-               self.brokers.append(binding[0])
+            if type(binding) is dict:
+               self.brokers.append(binding['broker'])
 
         if len(self.brokers) == 0:
             self.brokers=[ self.o.broker ]

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -33,8 +33,11 @@ class Message(FlowCB):
 
         self.brokers=[]
         for binding in self.o.bindings:
-            if binding[0] not in self.brokers:
+            if len(binding) >= 4 and binding[0] not in self.brokers:
                self.brokers.append(binding[0])
+
+        if len(self.brokers) == 0:
+            self.brokers=[ self.o.broker ]
 
         self.consumers={}
         for broker in self.brokers:

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -63,7 +63,7 @@ class Message(FlowCB):
 
     def ack(self, mlist) -> None:
 
-        if not hasattr(self,'consumer'):
+        if not hasattr(self,'consumers'):
             return
 
         for m in mlist:
@@ -72,24 +72,24 @@ class Message(FlowCB):
 
     def metricsReport(self) -> dict:
 
-        if not hasattr(self,'consumer'):
+        if not hasattr(self,'consumers'):
            return {}
 
         metrics={}
         for broker in self.brokers:
            if hasattr(self.consumers[broker],'metricsReport'):
-               metrics[broker] = self.consumers[broker].metricsReport()
+               metrics[broker.geturl()] = self.consumers[broker].metricsReport()
         return metrics 
 
     def on_housekeeping(self) -> None:
 
-        if not hasattr(self,'consumer'):
+        if not hasattr(self,'consumers'):
             return
 
         m = self.metricsReport()
         for broker in self.brokers:
-            average = (m[broker]['rxByteCount'] /
-                   m[broker]['rxGoodCount'] if m[broker]['rxGoodCount'] != 0 else 0)
+            average = (m[broker.geturl()]['rxByteCount'] /
+                   m[broker.geturl()]['rxGoodCount'] if m[broker.geturl()]['rxGoodCount'] != 0 else 0)
             logger.info( f"{broker.url} messages: good: {m[broker]['rxGoodCount']} bad: {m[broker]['rxBadCount']} " +\
                f"bytes: {naturalSize(m[broker]['rxByteCount'])} " +\
                f"average: {naturalSize(average)}" )

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -358,7 +358,14 @@ class AMQP(Moth):
 
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
-                        broker, exchange, prefix, subtopic = tup
+                        if len(tup) == 4:
+                            broker, exchange, prefix, subtopic = tup
+                        elif len(tup) == 3:
+                            exchange, prefix, subtopic = tup
+                            broker = self.o['broker']
+                        else:
+                            logger.critical( f"binding \"{tup}\" should be a list of tuples ( broker, exchange, prefix, subtopic )" )
+                            continue
                         logger.critical( f"{broker=} {self.o['broker']=} ")
                         if broker != self.o['broker']:
                             continue

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -359,7 +359,7 @@ class AMQP(Moth):
 
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
-                        exchange, prefix, subtopic = tup
+                        broker, exchange, prefix, subtopic = tup
                         topic = '.'.join(prefix + subtopic)
                         if self.o['dry_run']:
                             logger.info('binding (dry run) %s with %s to %s (as: %s)' % \

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -334,7 +334,8 @@ class AMQP(Moth):
                     pass
                 elif type(binding) is tuple and len(binding) == 3:
                     new_binding = { 'exchange': binding[0], 'topicPrefix': binding[1], 'subtopic': binding[2] }
-                    for i in [ 'auto_delete', 'broker', 'durable', 'exchange', 'expire', 'message_ttl', 'prefetch', 'queueBind', 'queueDeclare', 'topicPrefix' ]:
+                    for i in [ 'auto_delete', 'broker', 'durable', 'exchange', 'expire', 'message_ttl', \
+                            'prefetch', 'queueBind', 'queueDeclare', 'queueName', 'topicPrefix' ]:
                         new_binding[i] = self.o[i]
                     binding=new_binding
                 else:
@@ -365,16 +366,16 @@ class AMQP(Moth):
                 
                 if msg_count == -2: continue
 
-                if binding['queueBind'] and self.o['queueName']:
+                if binding['queueBind'] and binding['queueName']:
                     topic = '.'.join(binding['topicPrefix'] + binding['subtopic'])
                     if self.o['dry_run']:
                         logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
-                            ( self.o['queueName'], topic, binding['exchange'], broker_str ) )
+                            ( binding['queueName'], topic, binding['exchange'], broker_str ) )
                     else:
                         logger.info('binding %s with %s to %s (as: %s)' % \
-                            ( self.o['queueName'], topic, binding['exchange'], broker_str ) )
+                            ( binding['queueName'], topic, binding['exchange'], broker_str ) )
                         if binding['exchange']:
-                            self.management_channel.queue_bind(self.o['queueName'], 
+                            self.management_channel.queue_bind(binding['queueName'], 
                                binding['exchange'], topic)
 
                 # Setup Successfully Complete!
@@ -384,7 +385,7 @@ class AMQP(Moth):
 
             except Exception as err:
                 logger.error(
-                    f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
+                    f'connecting to: {binding["queueName"]}, durable: {binding["durable"]}, expire: {binding["expire"]}, auto_delete={binding["auto_delete"]}'
                 )
                 logger.error("AMQP getSetup failed to {} with {}".format(
                     binding['broker'].url.hostname, err))

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -112,8 +112,6 @@ class AMQP(Moth):
                     logger.info('had no delivery info')
                 logger.info('raw message end')
 
-
-
             if type(body) is bytes:
                 try:
                     body = raw_msg.body.decode("utf8")
@@ -142,9 +140,10 @@ class AMQP(Moth):
             msg.deriveSource( self.o )
             msg.deriveTopics( self.o, topic )
 
+            msg['broker'] = self.o['broker']
             msg['ack_id'] = raw_msg.delivery_info['delivery_tag']
             msg['local_offset'] = 0
-            msg['_deleteOnPost'] |= set( ['ack_id', 'exchange', 'local_offset', 'subtopic'])
+            msg['_deleteOnPost'] |= set( ['ack_id', 'broker', 'exchange', 'local_offset', 'subtopic'])
             if not msg.validate():
                 if hasattr(self,'channel'):
                     self.channel.basic_ack(msg['ack_id'])
@@ -360,6 +359,9 @@ class AMQP(Moth):
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
                         broker, exchange, prefix, subtopic = tup
+                        logger.critical( f"{broker=} {self.o['broker']=} ")
+                        if broker != self.o['broker']:
+                            continue
                         topic = '.'.join(prefix + subtopic)
                         if self.o['dry_run']:
                             logger.info('binding (dry run) %s with %s to %s (as: %s)' % \

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -357,18 +357,22 @@ class AMQP(Moth):
                 if msg_count == -2: break
 
                 if self.o['queueBind'] and self.o['queueName']:
-                    for tup in self.o['bindings']:
-                        if len(tup) == 4:
-                            broker, exchange, prefix, subtopic = tup
-                        elif len(tup) == 3:
-                            exchange, prefix, subtopic = tup
+                    for binding in self.o['bindings']:
+                        if type(tup) is dict:
+                            broker = binding['broker']
+                            exchange = binding['exchange']
+                            prefix = binding['topicPrefix']
+                            subtopic = binding['subtopic']
+                        elif type(binding) is tuple and len(binding) == 3:
+                            exchange, prefix, subtopic = binding
                             broker = self.o['broker']
                         else:
-                            logger.critical( f"binding \"{tup}\" should be a list of tuples ( broker, exchange, prefix, subtopic )" )
+                            logger.critical( f"binding \"{tup}\" should be a list of dictionaries ( broker, exchange, prefix, subtopic )" )
                             continue
-                        logger.critical( f"{broker=} {self.o['broker']=} ")
+                        #logger.critical( f"{broker=} {self.o['broker']=} ")
                         if broker != self.o['broker']:
                             continue
+
                         topic = '.'.join(prefix + subtopic)
                         if self.o['dry_run']:
                             logger.info('binding (dry run) %s with %s to %s (as: %s)' % \

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -213,8 +213,8 @@ class MQTT(Moth):
             if 'topic' in userdata.o:
                 subj=userdata.o['topic']
             else:
-                exchange, prefix, subtopic = binding_tuple
-                logger.info( f"tuple: {exchange} {prefix} {subtopic}")
+                broker, exchange, prefix, subtopic = binding_tuple
+                logger.info( f"tuple: {broker} {exchange} {prefix} {subtopic}")
 
                 subj = '/'.join(['$share', userdata.o['queueName'], exchange] +
                                 prefix + subtopic)

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -208,20 +208,26 @@ class MQTT(Moth):
         # FIXME: enhancement could subscribe accepts multiple (subj, qos) tuples so, could do this in one RTT.
         userdata.connected=True
         userdata.subscribe_mutex.acquire()
-        for binding_tuple in userdata.o['bindings']:
+        for binding in userdata.o['bindings']:
 
             if 'topic' in userdata.o:
                 subj=userdata.o['topic']
             else:
-                if len(binding_tuple) == 4:
-                    broker, exchange, prefix, subtopic = binding_tuple
-                elif len(binding_tuple) == 3:
-                    exchange, prefix, subtopic = binding_tuple
+                if type(binding) is dict:
+                    broker=binding['broker']
+                    exchange = binding['exchange']
+                    prefix = binding['topicPrefix']
+                    subtopic = binding['subtopic']
+                elif type(binding) is tuple and len(binding) == 3: # old API.
+                    exchange, prefix, subtopic = binding
                     broker = userdata.o['broker']
                 else:
-                    logger.critical( f"invalid binding: \"{binding_tuple}\" should be a tuple containing ( broker, exchange, topicPrefix, subtopic )" )
+                    logger.critical( f"invalid binding: \"{binding}\" should be a dictionary containing ( broker, exchange, topicPrefix, subtopic )" )
                     continue
  
+                if broker != userdata.o['broker']:
+                    continue
+
                 logger.info( f"tuple: {broker} {exchange} {prefix} {subtopic}")
 
                 subj = '/'.join(['$share', userdata.o['queueName'], exchange] +

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -590,10 +590,11 @@ class MQTT(Moth):
         message.deriveSource( self.o )
         message.deriveTopics( self.o, topic=mqttMessage.topic, separator='/' )
 
+        message['broker'] = self.o['broker']
         message['ack_id'] = mqttMessage.mid
         message['qos'] = mqttMessage.qos
         message['local_offset'] = 0
-        message['_deleteOnPost'] |= set( ['exchange', 'local_offset', 'ack_id', 'qos' ])
+        message['_deleteOnPost'] |= set( ['ack_id', 'broker', 'exchange', 'local_offset', 'qos' ])
 
         self.metrics['rxLast'] = sarracenia.nowstr()
         if message.validate():

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -213,7 +213,15 @@ class MQTT(Moth):
             if 'topic' in userdata.o:
                 subj=userdata.o['topic']
             else:
-                broker, exchange, prefix, subtopic = binding_tuple
+                if len(binding_tuple) == 4:
+                    broker, exchange, prefix, subtopic = binding_tuple
+                elif len(binding_tuple) == 3:
+                    exchange, prefix, subtopic = binding_tuple
+                    broker = userdata.o['broker']
+                else:
+                    logger.critical( f"invalid binding: \"{binding_tuple}\" should be a tuple containing ( broker, exchange, topicPrefix, subtopic )" )
+                    continue
+ 
                 logger.info( f"tuple: {broker} {exchange} {prefix} {subtopic}")
 
                 subj = '/'.join(['$share', userdata.o['queueName'], exchange] +


### PR DESCRIPTION
This is the second phase of work in issue339, being able to gather messages from multiple sources.  It adds all of the queue settings into the binding structure.

Bindings used to have three elements: exchange, topicPrefix, subtopic, but now they need:
broker, queueName, and all the settings related to declaring and binding a queue... so: expiry, durable, queueBind, queueDeclare, auto_delete, prefetch....

All of those settings become binding/consumer specific.

so that is too much to keep track of in a tuple, so changed the binding into a dictionary.

This is mean to be merged after part1 is merged... the patches in part1 break flow tests, so they need to be collapsed into a single patch.  In contrast, these patches all preserve full flow_test compatibility, so a merge is fine (desirable actually to have smaller patches to work on bisection.)


The feature still isn't finished though... need to replace .qname files with .binding files, and figure out how to read them in.... there will beed to be a part 3.
