### PR TITLE
Fix #1151

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -425,9 +425,10 @@ class Message(dict):
                 if xattr.get('mtime') >= msg['mtime']:
                     logger.debug("mtime remembered by xattr")
                     fxainteg = xattr.get('identity')
-                    if fxainteg['method'] == o.identity_method: 
-                         msg['identity'] = fxainteg
-                         return
+                    if fxainteg != 'null':
+                        if fxainteg['method'] == o.identity_method: 
+                            msg['identity'] = fxainteg
+                            return
                     logger.debug("xattr different method than on disk")
                     calc_method = o.identity_method
                 else:

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -425,10 +425,9 @@ class Message(dict):
                 if xattr.get('mtime') >= msg['mtime']:
                     logger.debug("mtime remembered by xattr")
                     fxainteg = xattr.get('identity')
-                    if fxainteg != 'null':
-                        if fxainteg['method'] == o.identity_method: 
-                            msg['identity'] = fxainteg
-                            return
+                    if fxainteg['method'] == o.identity_method: 
+                        msg['identity'] = fxainteg
+                        return
                     logger.debug("xattr different method than on disk")
                     calc_method = o.identity_method
                 else:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2096,7 +2096,10 @@ class Flow:
             if self.o.identity_method.startswith('cod,'):
                 download_algo = self.o.identity_method[4:]
             elif 'identity' in msg:
-                download_algo = msg['identity']['method']
+                if msg['identity']['method'] == 'cod':
+                    download_algo = msg['identity']['value']
+                else:
+                    download_algo = msg['identity']['method']
             else:
                 download_algo = None
 


### PR DESCRIPTION
When `identity` is missing from `xattr` it returns a `null` string