### PR TITLE
Issue1157 add stat so subscribe/citypage downloads just work.

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server, partitioned_flow ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -26,7 +26,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow ]
-       osver: [ "ubuntu-22.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
-       osver: [ "ubuntu-22.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,22 +1,18 @@
-metpx-sr3 (3.00.55rc1) unstable; urgency=medium
+metpx-sr3 (3.00.55rc1) UNRELEASED; urgency=medium
 
+  * fix #953 sr3 status queue size updates again.
   * fix #1151 calculate on download not working.
   * fix #1150 bc transport api refactor.
 
  -- SSC-5CD2310S60 <peter@bsqt.homeip.net>  Tue, 08 Aug 2024 11:24:36 -0400
 
-metpx-sr3 (3.00.54rc3) unstable; urgency=medium
+metpx-sr3 (3.00.54) unstable; urgency=medium
 
   * fix #1142 token authentication re-factor
   * fix #1141 subscribe crash with random checksum.
   * fix #1133 NASA token expiry
   * fix #1089 filAgeMax works more often.
   * improved release documentation.
-
- -- SSC-5CD2310S60 <peter@bsqt.homeip.net>  Tue, 06 Aug 2024 11:24:36 -0400
-
-metpx-sr3 (3.00.54rc2) unstable; urgency=medium
-
   * CHANGE #33 default queue name generated now includes ${USER}_${HOSTNAME}
   * for #33, use of *queueName* deprecated in favour of *queueShare*
   * NEW/fix #1122 support for implicit FTPS on post 990.
@@ -26,21 +22,14 @@ metpx-sr3 (3.00.54rc2) unstable; urgency=medium
   * enable tests of block transfers #1112
   * fix for #1115: stop won't start, or foreground won't
   * fix redis unit tests broken by inclusion of _name var.
-
-
- -- peter <peter@bsqt.homeip.net>  Fri, 21 Jun 2024 17:46:14 -0400
-
-metpx-sr3 (3.00.54rc1) unstable; urgency=medium
-
-  [ SSC-5CD2310S60 ]
-  * NEW #1084 add metadata fetch to scheduled http. 
+  * NEW #1084 add metadata fetch to scheduled http.
   * NEW #1104 (EXPERIMENTAL) restored block partitioned transfers.
   * fix #1104 add message per cpu second and cpuS state.
   * only run after_post when actually posted #1101
   * fix #1097 message rates < 1 were parsed as zero, now work correctly.
   * messages reviewed & consolidated: #1094, #1099 (log de-cluttering.)
   * fix crashes/problems with statehost #1076, #1087, #1096
-  * when plugins go bad, report better, recover better: #1085, #1091, 
+  * when plugins go bad, report better, recover better: #1085, #1091,
   * performance improvements #1083, #1086
   * fix #1079 watch posting events it should not.
   * fix #1076 bogus messages and mkdir crash on HPC ( #1087 )
@@ -48,20 +37,21 @@ metpx-sr3 (3.00.54rc1) unstable; urgency=medium
     * adds lag,rtry,slow,reje states to status display.
     * adds checks for running process to cleanup, fail if running.
     * adds cleanup to remove, don't remove if cleanup fails.
-    * adds progressive logs to transfers  (closing #966) 
+    * adds progressive logs to transfers  (closing #966)
   * several fixes for sender crashes ( #1091, #1095, #1099 )
   * add #1054 can now convert multiple configs, and overwrite (with --wololo)
   * fixed #1064 poll crash.
   * fixed #927 sanity not restarting crashed polls.
   * reduced processing overhead ( #1086 )
-  * misc bug fixes ( #1070, #1092, #1103, #1108, #1109 ) 
+  * misc bug fixes ( #1070, #1092, #1103, #1108, #1109 )
   * NEW added logFormat option.
   * bug fixes and unit tests for AM ( #1036, $1068, #1074, #1075, #1078, #1079 )
   * many unit tests added, improved coverage (though still poor.)
   * many other plugin improvements. (#1085, #1082, #1091 )
   * search function restored on web-site documentation. ( #1062, #1072)
 
- -- SSC-5CD2310S60 <peter@bsqt.homeip.net>  Fri, 17 May 2024 12:29:22 -0400
+ -- SSC-5CD2310S60 <andre.leblanc@ssc-spc.gc.ca>  Fri, 12 Aug 2024 12:29:22 -0400
+
 
 metpx-sr3 (3.00.53) unstable; urgency=medium
 

--- a/docs/source/Contribution/Release.rst
+++ b/docs/source/Contribution/Release.rst
@@ -55,12 +55,14 @@ To publish a pre-release one needs to:
   - find redhat 8 server.  build package::
    
          * git checkout development_py36
+         * git pull
          * python3 setup.py bdist_rpm*
          * run flow tests
 
-  - find redhat 9 server,  build package:: 
+  - find redhat 9 server,  build package::
 
          * git checkout development_py36
+         * git pull
          * python3 setup.py bdist_rpm*
          * run flow tests
 
@@ -77,12 +79,14 @@ To publish a pre-release one needs to:
 
      * git pull
      * git checkout development_py36
+     * git pull
      * git tag -a o3.xx.yyrcz -m "pre-release o3.xx.yy.rcz"
      * git pull 
      * git checkout pre_release_py36
      * git pull
      * git merge development_py36
      * git push
+     * git push origin o3.xx.yyrcz
 
      * git checkout development
      * git tag -a v3.xx.yy.rcZ -m "pre-release v3.xx.yy.rcz"
@@ -90,11 +94,9 @@ To publish a pre-release one needs to:
      * git pull
      * git merge development
      * git push
-
-- push the above.  
-
-     * git push origin o3.xx.yyrcz
      * git push origin v3.xx.yyrcz
+
+
 
 - pypi.org
 
@@ -102,6 +104,7 @@ To publish a pre-release one needs to:
   - use the python3.6 branch to release to pypi (because upward compatibility works, but not downward.)
 
     * git checkout pre_release_py36
+    * git pull
     * python3 setup.py bdist_wheel
 
   - upload the pre-release so that installation with pip succeeds.
@@ -131,15 +134,16 @@ To publish a pre-release one needs to:
 
   - find redhat 8 server. build package:: 
 
-        git checkout stable_py36
+        git checkout pre-release_py36
+        git pull
         python3 setup.py bdist_rpm 
 
     
   - find redhat 9 server, build package::
 
-        git checkout stable_py36
+        git checkout pre-release_py36
+        git pull
         python3 setup.py bdist_rpm 
-
 
 - on github: Draft a release.
 
@@ -163,8 +167,14 @@ the stable release does not require any explicit testing.
 
 * merge from pre-release to stable::
 
+    
+     git checkout pre-release
+     git pull
      git checkout stable
+     git pull
      git merge pre-release
+     git push
+
      # there will be conflicts here for debian/changelog and sarracenia/_version.py
      # for changelog:
      #   - merge all the rcX changelogs into a single stable one.
@@ -177,12 +187,30 @@ the stable release does not require any explicit testing.
 
 * merge from pre-release_py36 to stable_py36::
 
+     git checkout pre_release_py36
+     git pull
      git checkout stable_py36
+     git pull
      git merge pre_release_py36
+     git push
      # same editing required as above.
      git tag -a o3.xx.yy -m "o3.xx.yy"
      git push origin o3.xx.yy
 
+* pypi.org
+
+  - to ensure compatiblity with python3.6, update a python3.6 branch (for redhat 8 and/or ubuntu 18.)
+  - use the python3.6 branch to release to pypi (because upward compatibility works, but not downward.)
+
+    * git checkout stable_py36
+    * git pull
+    * python3 setup.py bdist_wheel
+
+  - upload the pre-release so that installation with pip succeeds.
+
+    * twine upload dist/the_wheel_produced_above.whl 
+
+  
 * go on Launchpad, 
 
    * stable branch ready.
@@ -197,6 +225,7 @@ the stable release does not require any explicit testing.
 * go on ubuntu 18.04, build bdist_wheel::
 
       git checkout stable_py36
+      git pull
       python3 setup.py bdist_wheel 
 
 note that *pip3 install wheel* is needed, because the one from
@@ -205,12 +234,18 @@ ubuntu 18 is not compatible with the current pypi.org.
 * go on redhat 8, build rpm::
 
       git checkout stable_py36
+      git pull
       python3 setup.py bdist_rpm 
+      ls dist/
+      mv rpm file to have rh8 in the name somewhere.
 
-* go on redhat 9, build rpm::
+* go on redhat 9, build rpm **NOTE: Broken!, for now use redhat 8 process** ::
 
       git checkout stable_py36
+      git pull
       rpmbuild --build-in-place -bb metpx-sr3.spec
+      ls dist/
+      mv rpm file to have rh8 in the name somewhere.
 
 
 * On github.com, create release.
@@ -219,8 +254,7 @@ ubuntu 18 is not compatible with the current pypi.org.
   * attach wheel build on ubuntu 18.
   * attach redhat 8 rpm
   * attach redhat 9 rpm 
-  * attach windows exe
-
+  * attach windows exe ... see: `Building a Windows Installer`_
 
 Details
 -------
@@ -246,11 +280,13 @@ prior to accepting a release, and barring known exceptions,
   tests: static, no_mirror, flakey_broker, restart_server, dynamic_flow::
 
        git checkout pre_release_py36
+       git pull
        python3 setup.py bdist_rpm
  
 * Redhat 9 rpms currently do not work... vm and run the flow test there to ensure that it works::
 
        git checkout pre_release_py36
+       git pull
        python3 setup.py bdist_rpm
          
 
@@ -655,13 +691,16 @@ by pynsist to build the executable, so look at::
     https://www.python.org/downloads/windows/
 
 Then go look on python.org, for the "right" version (for 3.10, it is 3.10.11 )
-Then, from the shell, run::
+It will contain *embed* in the file names. Once you find the correct version
+From the shell, run::
 
- sudo apt install nsis
- pip3 install pynsist wheel
- ./generate-win-installer.sh 3.10.11 2>&1 > log.txt
+   sudo apt install nsis
+   pip3 install pynsist wheel
+   ./generate-win-installer.sh 3.10.11 2>&1 > log.txt
 
-The final package will be generated into build/nsis directory.
+The final package will be generated into *build/nsis* directory. Sometimes editing of 
+the *generate-win-installer.sh* script is needed to add *--no-isolation* to the *python -m build* line.
+It's not clear when that is needed.
 
 
 github

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -475,16 +475,16 @@ lowered to 1.  For most usual situations the default is fine. For higher volume
 cases, one could raise it to reduce transfer overhead. It is only used for file
 transfer protocols, not HTTP ones at the moment.
 
-blocksize <size> default: 0 (auto)
+blockSize <size> default: 0 (auto)
 -----------------------------------
 
 NOTE: **EXPERIMENTAL** sr3, expected to return in future version**
-This **blocksize** option controls the partitioning strategy used to post files.
+This **blockSize** option controls the partitioning strategy used to post files.
 The value should be one of::
 
    0 - autocompute an appropriate partitioning strategy (default)
    1 - always send entire files in a single part.
-   <blocksize> - used a fixed partition size (example size: 1M )
+   <blockSize> - used a fixed partition size (example size: 1M )
 
 Files can be announced as multiple parts.  Each part has a separate checksum.
 The parts and their checksums are stored in the cache. Partitions can traverse
@@ -522,10 +522,10 @@ Once connected to an AMQP broker, the user needs to bind a queue
 to exchanges and topics to determine the notification messages of interest.
 
 
-bufsize <size> (default: 1MB)
+bufSize <size> (default: 1MB)
 -----------------------------
 
-Files will be copied in *bufsize*-byte blocks. for use by transfer protocols.
+Files will be copied in *bufSize*-byte blocks. for use by transfer protocols.
 
 
 byteRateMax <size> (default: 0)
@@ -1225,6 +1225,14 @@ fileAgeMin
 If files are newer than this setting (default: 0), then ignore them, they are too
 new to post. 0 deactivates the setting.
 
+fileSizeMax (size: default 0)
+-----------------------------
+
+The default value of *fileSizeMax* is 0, meaning there is no limit. However one may
+wish to prevent downloads of very large files in some situations. Setting a maximum
+file size with the *fileSizeMax* option can be used to prevent unintentional 
+downloading of large data files.
+
 nodupe_ttl <off|on|999[smhdw]> 
 ------------------------------
 
@@ -1532,7 +1540,7 @@ randomize <flag>
 
 Active if *-r|--randomize* appears in the command line... or *randomize* is set
 to True in the configuration file used. If there are several notification messages because the 
-file is posted by block (the *blocksize* option was set), the block notification messages 
+file is posted by block (the *blockSize* option was set), the block notification messages 
 are randomized meaning that they will not be posted
 
 realpathAdjust <count> (Experimental) (default: 0)

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -403,22 +403,39 @@ It's named  */this/20160123/pattern/RAW_MERGER_GRIB/directory* if the notificati
 acceptSizeWrong: <boolean> (default: False)
 -------------------------------------------
 
-When a file is downloaded and its size does not match the one advertised, it is
-normally rejected, as a failure. This option accepts the file even with the wrong
-size. helpful when file is changing frequently, and there is some queueing, so
-the file is changed by the time it is retrieved.
+When acceptSizeWrong is set to True, the download accepts the file even if it's size
+does not match what is in the notification message received. This is helpful when 
+resources are changing frequently, and there is some queueing, so the file is changed 
+by the time it is retrieved.
+
+In the default case (acceptSizeWrong set to False), size mismatch is
+considered a download failure. Sarracenia then checks if the 
+what was downloaded matches what is on the upstream server currently.  
+
+If the modification date on the upstream server is newer than in the message::
+
+  2024-08-11 00:00:47,978 [INFO] sarracenia.flow download upstream resource is newer, so message https://hpfx.collab.science.gc.ca //20240811/WXO-DD/citypage_weather/xml/NB/s0000653_e.xml is obsolete. Discarding.
+
+If it does match the upstream size, than no error has occurred on download, 
+it's just that the size of the message announcing the new resource does not 
+match what is currently available. There is no point retrying the download.
+In the both cases, the file downloaded and the corresponding message are both 
+discarded.
+
+If the check of the upstream server fails, or the retrieve itself has failed,
+then it puts the resource on the retry queue for later attempts.
 
 
 attempts <count> (default: 3)
 -----------------------------
 
 The **attempts** option indicates how many times to
-attempt downloading the data before giving up.  The default of 3 should be appropriate
-in most cases.  When the **retry** option is false, the file is then dropped immediately.
+attempt downloading the data before giving up. The default of 3 should be appropriate
+in most cases. When the **retry** option is false, the file is then dropped immediately.
 
 When The **retry** option is set (default), a failure to download after prescribed number
 of **attempts** (or send, in a sender) will cause the notification message to be added to a queue file
-for later retry.  When there are no notification messages ready to consume from the AMQP queue,
+for later retry. When there are no notification messages ready to consume from the AMQP queue,
 the retry queue will be queried.
 
 

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1137,7 +1137,7 @@ If **messageCountMax** is greater than zero, the flow will exit after processing
 number of messages.  This is normally used only for debugging.
 
 messageRateMax <float> (default: 0)
--------------------------------------
+-----------------------------------
 
 if **messageRateMax** is greater than zero, the flow attempts to respect this delivery
 speed in terms of messages per second. Note that the throttle is on messages obtained or generated
@@ -1145,17 +1145,19 @@ per second, prior to accept/reject filtering. the flow will sleep to limit the p
 
 
 messageRateMin <float> (default: 0)
--------------------------------------
+-----------------------------------
 
 if **messageRateMin** is greater than zero, and the flow detected is lower than this rate,
 a warning message will be produced:
 
 
-message_ttl <duration>  (default: None)
----------------------------------------
+messageAgeMax <duration>  (default: 0)
+--------------------------------------
 
-The  **message_ttl**  option set the time a message can live in the queue.
-Past that time, the message is taken out of the queue by the broker.
+The messageAgeMax option sets the maximum age of a message to not 
+be rejected when consuming. Messages older than Max value are discarded
+by the subscriber. (0 means no maximum age) 
+
 
 mirror <flag> (default: off)
 ----------------------------
@@ -1428,6 +1430,16 @@ Sets the message format for posted messages. the currently included values are:
 * wis ... a experimental geoJSON format in flux for the World Meteorological Organization
 
 When provided, this value overrides whatever can be deduced from the post_topicPrefix.
+
+
+post_messageAgeMax <duration>  (default: 0)
+-------------------------------------------
+
+The post_messageAgeMax (aka **message_ttl**) option is used when publishing a message,
+as advice to the broker. Brokers discard messages which have exceeded their intended lifespan
+without delivering them. (0 means no maximum lifespan is given.)
+When posting to AMQP, this option sets the *x-message-ttl* property (but the latter is in milliseconds.)
+When posting to MQTT, this option sets the *MessageExpiryInterval* property. 
 
 
 post_on_start

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -476,16 +476,16 @@ ajuster à 1.  Pour la plupart des situations, le défaut est bien. Pour un volu
 on pourrait l’augmenter pour réduire les frais généraux de transfert. Cette option est seulement utilisé pour les
 protocoles de transfert de fichiers, et non HTTP pour le moment.
 
-blocksize <size> défaut: 0 (auto)
+blockSize <size> défaut: 0 (auto)
 -----------------------------------
 
 REMARQUE: **EXPERIMENTAL pour sr3, devrait revenir dans la version future**
-Cette option **blocksize** contrôle la stratégie de partitionnement utilisée pour publier des fichiers.
+Cette option **blockSize** contrôle la stratégie de partitionnement utilisée pour publier des fichiers.
 La valeur doit être l’une des suivantes ::
 
    0 - calcul automatiquement une stratégie de partitionnement appropriée (défaut).
    1 - envoyez toujours des fichiers entiers en une seule partie.
-   <blocksize> - utiliser une taille de partition fixe (taille d’exemple : 1M ).
+   <blockSize> - utiliser une taille de partition fixe (taille d’exemple : 1M ).
 
 Les fichiers peuvent être annoncés en plusieurs parties.  Chaque partie à un somme de contrôle (checksum) distinct.
 Les parties et leurs somme de contrôle sont stockées dans la cache. Les partitions peuvent traverser
@@ -522,10 +522,10 @@ L’option broker indique à chaque composant quel courtier contacter.
 Une fois connecté à un courtier AMQP, l’utilisateur doit lier une fil d’attente
 aux échanges et aux thèmes pour déterminer le messages d'annonce en question.
 
-bufsize <size> (défaut: 1m)
+bufSize <size> (défaut: 1m)
 ---------------------------
 
-Les fichiers seront copiés en tranches de *bufsize* octets. Utilisé par les protocoles de transfert.
+Les fichiers seront copiés en tranches de *bufSize* octets. Utilisé par les protocoles de transfert.
 
 byteRateMax <size> (défaut: 0)
 ------------------------------
@@ -1217,6 +1217,16 @@ fileAgeMin
 Si les fichiers sont plus neuf que ce paramètre (défaut: 0 ... désactivé), ignorez-les, ils sont trop
 neufs pour qu'ils puissent être postés.
 
+
+fileSizeMax (size: default 0)
+-----------------------------
+
+La valeur par défaut de *fileSizeMax* est 0, ce qui signifie qu'il n'y a pas de limite. Cependant, on peut
+souhaiter empêcher le téléchargement de fichiers très volumineux dans certaines situations. La définition d'une
+taille de fichier maximale avec l'option *fileSizeMax* peut être utilisée pour empêcher le
+téléchargement involontaire de fichiers de données volumineux.
+
+
 nodupe_ttl <off|on|999[smhdw]>
 ------------------------------
 
@@ -1525,7 +1535,7 @@ randomize <flag>
 
 Actif si *-r|--randomize* apparaît dans la ligne de commande... ou *randomize* est défini
 à True dans le fichier de configuration utilisé. S’il y a plusieurs postes parce que
-le fichier est publié par bloc (l’option *blocksize* a été définie), les messages d'annonce de bloc
+le fichier est publié par bloc (l’option *blockSize* a été définie), les messages d'annonce de bloc
 sont randomisés, ce qui signifie qu’ils ne seront pas affichés.
 
 realpathAdjust <compte> (Experimental) (défaut: 0)

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1144,11 +1144,12 @@ messageRateMin <float> (défaut: 0)
 Si **messageRateMin** est supérieur à zéro et que le flux détecté est inférieur à ce taux,
 un message d´annonce sera produit :
 
-message_ttl <duration>  (défaut: None)
---------------------------------------
+messageAgeMax <duration>  (défaut: None)
+----------------------------------------
 
-L’option **message_ttl** définit un temps pour lequel un message d´annonce peut vivre dans la fil d’attente.
-Après ce temps, le message d´annonce est retiré de la fil d’attente par le courtier.
+L’option **AgeMax** définit un temps pour lequel un message d´annonce peut attendres du
+côté consommateur. Après ce temps, le message d´annonce est rejeté par le flot.
+(0 indique un age infini sera accepté.)
 
 mirror <flag> (défaut: off)
 ---------------------------
@@ -1427,6 +1428,15 @@ Définit le format de message pour les messages publiés. les valeurs actuelleme
 * wis ... un format expérimental geoJSON en flux pour l'Organisation météorologique mondiale
 
 Lorsqu'elle est fournie, cette valeur remplace tout ce qui peut être déduit de post_topicPrefix.
+
+post_messageAgeMax <duration> (défaut: 0)
+-----------------------------------------
+
+L'option post_messageAgeMax (alias **message_ttl**) est utilisée lors de la publication d'un message,
+comme conseil au courtier. ttl est un abbréviation de *time to live* (*durée de vie maximale*) Les courtiers 
+rejettent les messages qui ont dépassé leur durée de vie prévue sans les livrer. (0 signifie qu'aucune durée de vie maximale n'est donnée.)
+Lors de la publication avec AMQP, cette option définit la propriété *x-message-ttl* (mais cette dernière est en millisecondes).
+Lors de la publication avec MQTT, cette option définit la propriété *MessageExpiryInterval*.
 
 
 post_on_start

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -404,16 +404,44 @@ normalement rejeté, comme un échec. Cette option accepte le fichier même avec
 taille. Cela est utile lorsque le fichier change fréquemment, et qu’il passe en fil d’attente, donc
 le fichier est modifié au moment de sa récupération.
 
+Lorsque acceptSizeWrong est défini sur True, le téléchargement accepte le fichier même si sa taille
+ne correspond pas à celle du message de notification reçu. Cela est utile lorsque
+les ressources changent fréquemment et qu'il y a une file d'attente, de sorte que le fichier 
+est modifié au moment où il est récupéré.
+
+Dans le cas par défaut (acceptSizeWrong défini sur False), l'incompatibilité de taille est
+considérée comme un échec de téléchargement. Sarracenia vérifie ensuite si
+ce qui a été téléchargé correspond à ce qui se trouve actuellement sur le serveur en amont.
+
+Si la date de modification sur le serveur en amont est plus récente que dans le message::
+
++  2024-08-11 00:00:47,978 [INFO] sarracenia.flow download upstream resource is newer, so message https://hpfx.collab.science.gc.ca //20240811/WXO-DD/citypage_weather/xml/NB/s0000653_e.xml is obsolete. Discarding.
+
+traduction::
+
+   2024-08-11 00:00:47,978 [INFO] la ressource en amont est plus récente, donc le message https://hpfx.collab.science.gc.ca //20240811/WXO-DD/citypage_weather/xml/NB/s0000653_e.xml est obsolète. on abandonne le traitement du message.
+
+Si elle correspond à la taille en amont, alors aucune erreur ne s'est produite lors du téléchargement,
+c'est juste que la taille du message annonçant la nouvelle ressource ne
+correspond pas à ce qui est actuellement disponible. Il est inutile de réessayer le téléchargement.
+Dans les deux cas, le fichier téléchargé et le message correspondant sont tous deux
+rejetés.
+
+Si la vérification du serveur en amont échoue, ou si la récupération elle-même a échoué,
+alors la ressource est placée dans la file d'attente de nouvelles tentatives pour des tentatives ultérieures.
+
+
+
 attempts <count> (défaut: 3)
 -----------------------------
 
 L’option **attempts** indique combien de fois il faut tenter le téléchargement des données avant d’abandonner.
-Le défaut de 3 tentatives est approprié dans la plupart des cas.  Lorsque l’option **retry** a la valeur false,
+Le défaut de 3 tentatives est approprié dans la plupart des cas. Lorsque l’option **retry** a la valeur false,
 le fichier est immédiatement supprimé.
 
 Lorsque l’option **attempts** est utilisé, un échec de téléchargement après le numéro prescrit
 des **attempts** (ou d’envoi, pour un sender) va entrainer l’ajout du message d'annonce à un fichier de fil d’attente
-pour une nouvelle tentative plus tard.  Lorsque aucun message d'annonce n’est prêt à être consommé dans la fil d’attente AMQP,
+pour une nouvelle tentative plus tard. Lorsque aucun message d'annonce n’est prêt à être consommé dans la fil d’attente AMQP,
 les requêtes se feront avec la fil d’attente de "retry".
 
 baseDir <chemin> (défaut: /)

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -371,6 +371,7 @@ known_report_codes = {
     206: "Partial Content: received and inserted.",
     304: "Not modified (Checksum validated, unchanged, so no download resulted.)",
     307: "Insertion deferred (writing to temporary part file for the moment.)",
+    410: "Gone: server data different from notification message",
     417: "Expectation Failed: invalid notification message (corrupt headers)",
     422: "Unprocessable Content: could not determine path to transfer to",
     499: "Failure: Not Copied. SFTP/FTP/HTTP download problem",

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -784,11 +784,11 @@ class Message(dict):
         if 'baseUrl' in msg:
             s+=msg['baseUrl']+' '
         if 'relPath' in msg:
-            if s and s[-1] != '/':
+            if msg['relPath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+=msg['relPath']
         elif 'retrievePath' in msg:
-            if s and s[-1] != '/':
+            if msg['retrievePath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+= msg['retrievePath']
         else:

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -475,7 +475,7 @@ class Message(dict):
                         fp.seek( offset )
 
                     while i < offset+msg['size']:
-                        buf = fp.read(o.bufsize)
+                        buf = fp.read(o.bufSize)
                         if not buf: break
                         sumalgo.update(buf)
                         i += len(buf)
@@ -661,10 +661,10 @@ class Message(dict):
         elif hasattr(o, 'exchange'):
             msg['exchange'] = o.exchange
 
-        if hasattr(o, 'blocksize') and (o.blocksize > 1) and lstat and \
+        if hasattr(o, 'blockSize') and (o.blockSize > 1) and lstat and \
                 (os_stat.S_IFMT(lstat.st_mode) == os_stat.S_IFREG) and \
-                (lstat.st_size > o.blocksize):
-           msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blocksize, 'manifest': {}  }
+                (lstat.st_size > o.blockSize):
+           msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blockSize, 'manifest': {}  }
 
         msg['local_offset'] = 0
         msg['_deleteOnPost'] = set(['exchange', 'local_offset', 'subtopic', '_format'])
@@ -783,11 +783,13 @@ class Message(dict):
         s=""
         if 'baseUrl' in msg:
             s+=msg['baseUrl']+' '
-        if 'relPath' in msg:
+        else:
+            s+="baseUrl missing "
+        if 'relPath' in msg and len(msg['relPath']) > 0:
             if msg['relPath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+=msg['relPath']
-        elif 'retrievePath' in msg:
+        elif 'retrievePath' in msg and len(msg['retrievePath']) > 0 :
             if msg['retrievePath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+= msg['retrievePath']
@@ -1025,7 +1027,7 @@ class Message(dict):
         # ide
         #if isinstance(data, io.IOBase ):
         #    with open(opath, 'wb') as f:
-        #        while buf = data.read(self.o.bufsize) > 0 :
+        #        while buf = data.read(self.o.bufSize) > 0 :
         #            sz=f.write(buf)
 
         if 'content' in msg:

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -152,7 +152,8 @@ flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl
 float_options = [ 'messageRateMax', 'messageRateMin' ]
 
 duration_options = [
-    'expire', 'housekeeping', 'logRotateInterval', 'message_ttl', 'fileAgeMax', 'fileAgeMin', 'metrics_writeInterval', \
+    'expire', 'housekeeping', 'logRotateInterval', 'fileAgeMax', 'fileAgeMin', 
+    'messageAgeMax', 'post_messageAgeMax', 'metrics_writeInterval', \
     'runStateThreshold_idle', 'runStateThreshold_lag', 'retry_ttl', 'runStateThreshold_hung', 'sleep', 'timeout', 'varTimeOffset'
 ]
 
@@ -755,7 +756,8 @@ class Config:
         'logRotate': 'logRotateCount',
         'logRotate': 'logRotateCount',
         'logRotate_interval': 'logRotateInterval',
-        'message-ttl': 'message_ttl',
+        'message-ttl': 'post_messageAgeMax',
+        'message_ttl': 'post_messageAgeMax',
         'msg_replace_new_dir' : 'pathReplace',
         'msg_filter_wmo2msc_replace_dir': 'filter_wmo2msc_replace_dir',
         'msg_filter_wmo2msc_uniquify': 'filter_wmo2msc_uniquify',
@@ -879,6 +881,7 @@ class Config:
         self.mirror = False
         self.messageAgeMax = 0
         self.post_exchanges = []
+        self.post_messageAgeMax = 0
 	    #self.post_topicPrefix = None
         self.pstrip = False
         self.queueName = None

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -170,7 +170,7 @@ set_choices = {
  
 perm_options = [ 'permDefault', 'permDirDefault','permLog']
 
-size_options = ['accelThreshold', 'blocksize', 'bufsize', 'byteRateMax', 'inlineByteMax']
+size_options = ['accelThreshold', 'blockSize', 'bufSize', 'byteRateMax', 'fileSizeMax', 'inlineByteMax']
 
 str_options = [
     'action', 'admin', 'baseDir', 'broker', 'cluster', 'directory', 'exchange',
@@ -702,6 +702,8 @@ class Config:
         'base_dir': 'baseDir',
         'baseurl': 'baseUrl',
         'bind_queue': 'queueBind',
+        'blocksize': 'blockSize', 
+        'bufsize': 'bufSize',
         'cache': 'nodupe_ttl',
         'c': 'include',
         'cb': 'nodupe_basis',
@@ -830,7 +832,7 @@ class Config:
             for i in parent:
                 setattr(self, i, parent[i])
 
-        self.bufsize = 1024 * 1024
+        self.bufSize = 1024 * 1024
         self.byteRateMax = 0
 
         self.fileAgeMax = 0 # disabled.
@@ -852,6 +854,7 @@ class Config:
         self.plugins_late = []
         self.plugins_early = []
         self.exchange = None
+        self.fileSizeMax = 0
         self.filename = None
         self.fixed_headers = {}
         self.flatten = '/'
@@ -2498,7 +2501,7 @@ class Config:
                             nargs='?',
                             help='how many transfers per each connection')
         parser.add_argument(
-            '--blocksize',
+            '--blockSize',
             type=int,
             nargs='?',
             help=

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1452,14 +1452,13 @@ class Flow:
         #end   = self.local_offset + self.length
         if 'size' in msg:
             end = msg['size']
-            # compare sizes... if (sr_subscribe is downloading partitions into taget file) and (target_file isn't fully done)
+            # compare sizes... if (sr_subscribe is downloading partitions into target file) and (target_file isn't fully done)
             # This check prevents random halting of subscriber (inplace on) if the messages come in non-sequential order
             # target_file is the same as new_file unless the file is partitioned.
             # FIXME If the file is partitioned, then it is the new_file with a partition suffix.
             #if ('self.target_file == msg['new_file'] ) and ( fsiz != msg['size'] ):
             if (fsiz != msg['size']):
-                logger.debug("%s file size different, so cannot be the same" %
-                             (msg['new_path']))
+                logger.debug( f"{msg['new_path']} file size different, so cannot be the same" )
                 return True
         else:
             end = 0
@@ -1480,23 +1479,18 @@ class Flow:
                     pass
 
             if new_mtime <= old_mtime:
-                self.reject(msg, 304,
-                            "mtime not newer %s " % (msg['new_path']))
+                self.reject(msg, 304, f"mtime not newer {msg['new_path']}" )
                 return False
             else:
                 logger.debug(
-                    "{} new version is {} newer (new: {} vs old: {} )".format(
-                        msg['new_path'], new_mtime - old_mtime, new_mtime,
-                        old_mtime))
+                    f"{msg['new_path']} new version is {new_time-old_time} newer (new: {new_time} vs old: {old_time} )" )
 
         if 'identity' in msg and msg['identity']['method'] in ['random', 'cod']:
-            logger.debug("content_match %s sum 0/z never matches" %
-                         (msg['new_path']))
+            logger.debug( f"content_match {msg['new_path']} sum 0/z never matches" )
             return True
 
         if end > fsiz:
-            logger.debug(
-                "new file not big enough... considered different")
+            logger.debug( "new file not big enough... considered different")
             return True
 
         if not 'identity' in msg: 
@@ -1512,11 +1506,10 @@ class Flow:
             )
             return True
 
-        logger.debug("checksum in message: %s vs. local: %s" %
-                     (msg['identity'], msg['local_identity']))
+        logger.debug( f"checksum in message: {msg['identity']} vs. local: {msg['local_identity']}" )
 
         if msg['local_identity'] == msg['identity']:
-            self.reject(msg, 304, "same checksum %s " % (msg['new_path']))
+            self.reject(msg, 304, f"same checksum {msg['new_path']}" )
             return False
         else:
             return True

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -235,7 +235,7 @@ class Flow:
         self.metrics=self.new_metrics
 
         # removing old metrics files
-        logger.info( f"looking for old metrics for {self.o.metricsFilename}" )
+        #logger.debug( f"looking for old metrics for {self.o.metricsFilename}" )
         old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
         for o in old_metrics:
             logger.info( f"removing old metrics file: {o} " )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1483,7 +1483,7 @@ class Flow:
                 return False
             else:
                 logger.debug(
-                    f"{msg['new_path']} new version is {new_time-old_time} newer (new: {new_time} vs old: {old_time} )" )
+                    f"{msg['new_path']} new version is {new_mtime-old_mtime} newer (new: {new_mtime} vs old: {old_mtime} )" )
 
         if 'identity' in msg and msg['identity']['method'] in ['random', 'cod']:
             logger.debug( f"content_match {msg['new_path']} sum 0/z never matches" )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1873,7 +1873,7 @@ class Flow:
                     logger.warning("downloading again, attempt %d" % i)
 
                 ok = self.download(msg, self.o)
-                if ok==1:
+                if ok == 1:
                     logger.debug("downloaded ok: %s" % new_path)
                     msg.setReport(201, "Download successful" )
                     # if content is present, but downloaded anyways, then it is no good, and should not be forwarded.
@@ -1882,7 +1882,7 @@ class Flow:
                     self.worklist.ok.append(msg)
                     self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
                     break
-                elif ok==-1:
+                elif ok == -1:
                     logger.debug("download failed permanently, discarding transfer: %s" % new_path)
                     msg.setReport(410, "message received for content that is no longer available" )
                     self.worklist.rejected.append(msg)
@@ -2195,13 +2195,13 @@ class Flow:
                                 mtime = sarracenia.timestr2flt(msg['pubTime'])
 
                             if current_stat and current_stat.st_mtime > mtime:
-                                logger.error( f'upstream source has changed, message obsolete. ' )
+                                logger.info( f'upstream resource is newer, so message {msg.getIDStr()} is obsolete. Discarding.' )
                                 retval=-1
                             elif current_stat and current_stat.st_size == len_written:
-                                logger.warning( f'downloads ok, but upstream source not as announced. Perhaps AcceptSizeWrong? ' )
+                                logger.info( f'download matches upstream source, {msg.getIDStr()} but not announcement. Discarding.' )
                                 retval=-1 
                             else:
-                                logger.error( f"unexplained size discrepancy, will retry later" )
+                                logger.error( f"unexplained size discrepancy in {msg.getIDStr()}, will retry later" )
                         elif len_written > block_length:
                             logger.error( f'download more {len_written} than expected {block_length} bytes for {new_inflight_path}' )
                         else:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1782,6 +1782,12 @@ class Flow:
                         self.reject(msg, 500, "link %s failed" % msg['fileOp'])
                     continue
 
+            # all non-files taken care of above... rest of routine is normal file download.
+
+            if self.o.fileSizeMax > 0 and msg['size'] > self.o.fileSizeMax:
+                self.reject(msg, 413, f"Payload Too Large {msg.getIDStr()}")
+                continue
+
             # establish new_inflight_path which is the file to download into initially.
             if self.o.inflight == None or (
                 ('blocks' in msg) and (msg['blocks']['method'] == 'inplace')):

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1873,7 +1873,7 @@ class Flow:
                     logger.warning("downloading again, attempt %d" % i)
 
                 ok = self.download(msg, self.o)
-                if ok:
+                if ok==1:
                     logger.debug("downloaded ok: %s" % new_path)
                     msg.setReport(201, "Download successful" )
                     # if content is present, but downloaded anyways, then it is no good, and should not be forwarded.
@@ -1881,6 +1881,11 @@ class Flow:
                         del msg['content']
                     self.worklist.ok.append(msg)
                     self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                    break
+                elif ok==-1:
+                    logger.debug("download failed permanently, discarding transfer: %s" % new_path)
+                    msg.setReport(410, "message received for content that is no longer available" )
+                    self.worklist.rejected.append(msg)
                     break
                 else:
                     logger.info("attempt %d failed to download %s/%s to %s" \
@@ -1899,9 +1904,13 @@ class Flow:
     # v2 sr_util.py ... generic sr_transport imported here...
 
     # generalized download...
-    def download(self, msg, options) -> bool:
+    def download(self, msg, options) -> int:
         """
            download/transfer one file based on message, return True if successful, otherwise False.
+
+           return 0 -- failed, retry later.
+           return 1 -- OK download successful.
+           return -1 -- download failed permanently, retry not useful.
         """
 
         self.o = options
@@ -1990,8 +1999,8 @@ class Flow:
                     logger.error( f'flowCallback plugin {plugin} crashed: {ex}' )
                     logger.debug( "details:", exc_info=True )
 
-                if not ok: return False
-            return True
+                if not ok: return 0
+            return 1
 
         if self.o.dry_run:
             curdir = new_dir
@@ -2012,7 +2021,7 @@ class Flow:
             except Exception as ex:
                 logger.warning("making %s: %s" % (new_dir, ex))
                 logger.debug('Exception details:', exc_info=True)
-                return False
+                return 0
 
         try:
             options.sendTo = msg['baseUrl']
@@ -2034,7 +2043,7 @@ class Flow:
                     ok = self.proto[self.scheme].connect()
                     if not ok:
                         self.proto[self.scheme] = None
-                        return False
+                        return 0
 
                     self.metrics['flow']['transferConnected'] = True
                     self.metrics['flow']['transferConnectStart'] = time.time() 
@@ -2046,7 +2055,7 @@ class Flow:
 
             #if not hasattr(proto,'seek') and ('blocks' in msg) and ( msg['blocks']['method'] == 'inplace' ):
             #   logger.error("%s, inplace part file not supported" % self.scheme)
-            #   return False
+            #   return 0
 
             cwd = None
          
@@ -2063,7 +2072,7 @@ class Flow:
                          self.proto[self.scheme].cd(cdir)
                     except Exception as ex:
                          logger.error("chdir %s: %s" % (cdir, ex))
-                         return False
+                         return 0
 
             remote_offset = 0
             exactLength=False
@@ -2144,7 +2153,7 @@ class Flow:
                             msg['local_offset'], block_length, exactLength)
                 except Exception as ex:
                     logger.error( f"could not get {remote_file}: {ex}" )
-                    return False
+                    return 0
 
             else:
                 len_written = block_length
@@ -2160,7 +2169,7 @@ class Flow:
                 logger.error("failed to download %s" % new_file)
                 if (self.o.inflight != None) and os.path.isfile(new_inflight_path):
                     os.remove(new_inflight_path)
-                return False
+                return 0
             else:
                 if block_length == 0:
                     if self.o.acceptSizeWrong:
@@ -2173,17 +2182,34 @@ class Flow:
                             % (len_written, new_inflight_path))
                 else:
                     if self.o.acceptSizeWrong:
-                        logger.debug(
+                        logger.info(
                             'AcceptSizeWrong download size mismatch, received %d of expected %d bytes for %s'
                             % (len_written, block_length, new_inflight_path))
                     else:
-                        if len_written > block_length:
+                        retval=0
+                        if hasattr( self.proto[self.scheme],'stat'):
+                            current_stat = self.proto[self.scheme].stat( remote_file, msg )
+                            if 'mtime' in msg:
+                                mtime = sarracenia.timestr2flt(msg['mtime'])
+                            else:
+                                mtime = sarracenia.timestr2flt(msg['pubTime'])
+
+                            if current_stat and current_stat.st_mtime > mtime:
+                                logger.error( f'upstream source has changed, message obsolete. ' )
+                                retval=-1
+                            elif current_stat and current_stat.st_size == len_written:
+                                logger.warning( f'downloads ok, but upstream source not as announced. Perhaps AcceptSizeWrong? ' )
+                                retval=-1 
+                            else:
+                                logger.error( f"unexplained size discrepancy, will retry later" )
+                        elif len_written > block_length:
                             logger.error( f'download more {len_written} than expected {block_length} bytes for {new_inflight_path}' )
                         else:
                             logger.error( f'incomplete download only {len_written} of expected {block_length} bytes for {new_inflight_path}' )
+
                         if (self.o.inflight != None) and os.path.isfile(new_inflight_path):
                             os.remove(new_inflight_path)
-                        return False
+                        return retval 
                 # when len_written is different than block_length
                 msg['size'] = len_written
 
@@ -2229,10 +2255,10 @@ class Flow:
                     logger.debug('Exception details: ', exc_info=True)
 
             if (self.o.acceptSizeWrong or (block_length == 0)) and (len_written > 0):
-                return True
+                return 1
 
             if (len_written != block_length):
-                return False
+                return 0
 
         except Exception as ex:
             logger.debug('Exception details: ', exc_info=True)
@@ -2254,8 +2280,8 @@ class Flow:
         
             if (not self.o.dry_run) and os.path.isfile(new_inflight_path):
                 os.remove(new_inflight_path)
-            return False
-        return True
+            return 0
+        return 1
 
     # generalized send...
     def send(self, msg, options):

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1280,7 +1280,7 @@ class Flow:
                     mfn.write( f'\"{timestamp}\" : {metrics},\n')
 
             # removing old metrics files
-            logger.debug( f"looking for old metrics for {self.o.metricsFilename}" )
+            #logger.debug( f"looking for old metrics for {self.o.metricsFilename}" )
             old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
             for o in old_metrics:
                 logger.info( f"removing old metrics file: {o} " )

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 default_options = {
     'acceptUnmatched': True,
-    'blocksize': 1,
-    'bufsize': 1024 * 1024,
+    'blockSize': 1,
+    'bufSize': 1024 * 1024,
     'chmod': 0o400,
     'pollUrl': None,
     'follow_symlinks': False,

--- a/sarracenia/flow/post.py
+++ b/sarracenia/flow/post.py
@@ -5,8 +5,8 @@ logger = logging.getLogger(__name__)
 
 default_options = {
     'acceptUnmatched': True,
-    'blocksize': 1,
-    'bufsize': 1024 * 1024,
+    'blockSize': 1,
+    'bufSize': 1024 * 1024,
     'follow_symlinks': False,
     'force_polling': False,
     'inflight': None,

--- a/sarracenia/flow/watch.py
+++ b/sarracenia/flow/watch.py
@@ -5,8 +5,8 @@ logger = logging.getLogger(__name__)
 
 default_options = {
     'acceptUnmatched': True,
-    'blocksize': 1,
-    'bufsize': 1024 * 1024,
+    'blockSize': 1,
+    'bufSize': 1024 * 1024,
     'follow_symlinks': False,
     'force_polling': False,
     'inflight': None,

--- a/sarracenia/flowcb/block_reassembly.py
+++ b/sarracenia/flowcb/block_reassembly.py
@@ -56,7 +56,7 @@ class Block_reassembly(FlowCB):
        given the reassemble setting is on, and have received a block file,
        then:
 
-       * partition file is whose name ends in §block_<blokno>,<blocksize>_§
+       * partition file is whose name ends in §block_<blokno>,<blockSize>_§
        * determing the inflight_file name for the entire file.
        * lock the inflight_file.
        * place the block in the working file.
@@ -206,14 +206,14 @@ class Block_reassembly(FlowCB):
             rf.seek(offset)     
 
             # copy data from block partition file into final destination.
-            sz=self.o.bufsize if self.o.bufsize > byteCount else byteCount
+            sz=self.o.bufSize if self.o.bufSize > byteCount else byteCount
             bytesTransferred=0
             while bytesTransferred < byteCount: 
                 b = pf.read(sz)
                 rf.write(b)
                 bytesTransferred += len(b)
                 bytesLeft = byteCount - bytesTransferred
-                sz=self.o.bufsize if self.o.bufsize > bytesLeft else bytesLeft
+                sz=self.o.bufSize if self.o.bufSize > bytesLeft else bytesLeft
 
             rf.close()
             pf.close()

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -159,7 +159,7 @@ class Am(FlowCB):
                         os.set_inheritable(conn.fileno(), True)
                         time.sleep(1)
 
-                    except TimeoutError:
+                    except (TimeoutError,socket.timeout):
                         n = n * 2 
                         if n > 64: n = 64
                         logger.info(f"No new connections. Waiting {n} seconds.")
@@ -168,6 +168,7 @@ class Am(FlowCB):
 
                     except Exception as e:
                         logger.error(f"Stopping accept. Exiting. Error message: {e}")
+                        logger.critical("Exception details", exc_info=True)
                         sys.exit(0)   
 
                     # Instance forks

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -114,7 +114,7 @@ class File(FlowCB):
         self.new_events = OrderedDict()
         self.left_events = OrderedDict()
 
-        #self.o.blocksize = 200 * 1024 * 1024
+        #self.o.blockSize = 200 * 1024 * 1024
         self.o.create_modify = ('create' in self.o.fileEvents) or (
             'modify' in self.o.fileEvents)
 
@@ -144,10 +144,10 @@ class File(FlowCB):
     def post_file(self, path, lstat, key=None, value=None):
         #logger.debug("start  %s" % path)
 
-        # check the value of blocksize
+        # check the value of blockSize
 
         fsiz = lstat.st_size
-        blksz = self.set_blocksize(self.o.blocksize, fsiz)
+        blksz = self.set_blockSize(self.o.blockSize, fsiz)
 
         # if we should send the file in parts
 
@@ -210,10 +210,10 @@ class File(FlowCB):
         msg = sarracenia.Message.fromFileInfo(path, self.o, lstat)
 
         logger.debug( f"initial msg:{msg}" )
-        # check the value of blocksize
+        # check the value of blockSize
 
         fsiz = lstat.st_size
-        chunksize = self.set_blocksize(self.o.blocksize, fsiz)
+        chunksize = self.set_blockSize(self.o.blockSize, fsiz)
 
         # count blocks and remainder
 
@@ -482,11 +482,11 @@ class File(FlowCB):
             return (True, self.post1file(src, lstat))
         return (True, [])
 
-    def set_blocksize(self, bssetting, fsiz):
+    def set_blockSize(self, bssetting, fsiz):
 
         tfactor = 50 * 1024 * 1024
 
-        if bssetting == 0:  ## default blocksize
+        if bssetting == 0:  ## default blockSize
             return tfactor
 
         elif bssetting == 1:  ## send file as one piece.

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -24,7 +24,7 @@ class Message(FlowCB):
             props.update(self.o.dictify())
 
             # adjust settings post_xxx to be xxx, as Moth does not use post_ ones.
-            for k in [ 'broker', 'exchange', 'topicPrefix', 'exchangeSplit', 'topic' ]:
+            for k in [ 'broker', 'exchange', 'topicPrefix', 'exchangeSplit', 'topic', 'messageAgeMax' ]:
                 post_one='post_'+k
                 if hasattr( self.o, post_one ): 
                     #props.update({ k: getattr(self.o,post_one) } )

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -270,8 +270,8 @@ class AMQP(Moth):
                 if self.o['expire']:
                     x = int(self.o['expire'] * 1000)
                     if x > 0: args['x-expires'] = x
-                if self.o['message_ttl']:
-                    x = int(self.o['message_ttl'] * 1000)
+                if self.o['messageAgeMax']:
+                    x = int(self.o['messageAgeMax'] * 1000)
                     if x > 0: args['x-message-ttl'] = x
 
                 #FIXME: conver expire, message_ttl to proper units.
@@ -673,7 +673,7 @@ class AMQP(Moth):
 
         if self.o['message_ttl']:
             ttl = "%d" * int(
-                sarracenia.durationToSeconds(self.o['message_ttl']) * 1000)
+                sarracenia.durationToSeconds(self.o['messageAgeMax']) * 1000)
         else:
             ttl = "0"
         

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -455,8 +455,8 @@ class MQTT(Moth):
                 self.unexpected_publishes = collections.deque()
 
                 props = Properties(PacketTypes.CONNECT)
-                if self.o['message_ttl'] > 0:
-                    props.MessageExpiryInterval = int(self.o['message_ttl'])
+                if self.o['messageAgeMax'] > 0:
+                    props.MessageExpiryInterval = int(self.o['messageAgeMax'])
 
                 self.transport = 'websockets' if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
                    (self.o['broker'].url.scheme[-1] == 'w' ) else 'tcp'

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -370,7 +370,7 @@ class Transfer():
         # 2022/12/02 - pas should see a lot of these messages in HPC case from now on...
         
         if not self.o.acceptSizeWrong and length != 0 and rw_length != length:
-            logger.warning(
+            logger.debug(
                 "util/writelocal mismatched file length writing %s. Message said to expect %d bytes.  Got %d bytes."
                 % (local_file, length, rw_length))
 

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -139,7 +139,7 @@ class Transfer():
      * permDirDefault - what permission to set on directories created.
      * timeout  - how long to wait for operations to complete.
      * byteRateMax - maximum transfer rate (throttle to avoid exceeding)
-     * bufsize - size of buffers for file transfers.
+     * bufSize - size of buffers for file transfers.
 
     """
     @staticmethod
@@ -290,7 +290,7 @@ class Transfer():
         if length == 0:
             while True:
                 if self.o.timeout: alarm_set(self.o.timeout)
-                chunk = src.read(self.o.bufsize)
+                chunk = src.read(self.o.bufSize)
                 if chunk:
                     new_chunk = self.on_data(chunk)
                     rw_length += len(new_chunk)
@@ -304,15 +304,15 @@ class Transfer():
 
         # exact length to be transfered
 
-        nc = int(length / self.o.bufsize)
-        r = length % self.o.bufsize
+        nc = int(length / self.o.bufSize)
+        r = length % self.o.bufSize
 
-        # read/write bufsize "nc" times
+        # read/write bufSize "nc" times
 
         i = 0
         while i < nc:
             if self.o.timeout: alarm_set(self.o.timeout)
-            chunk = src.read(self.o.bufsize)
+            chunk = src.read(self.o.bufSize)
             if chunk:
                 new_chunk = self.on_data(chunk)
                 rw_length += len(new_chunk)

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 #           options.permDefault
 #           options.permDirDefault
 #     opt   options.byteRateMax
-#     opt   options.bufsize
+#     opt   options.bufSize
 
 
 class File(Transfer):
@@ -197,7 +197,7 @@ def file_insert(options, msg):
     fp = open(msg['relPath'], 'rb')
     if msg.partflg == 'i': fp.seek(msg['offset'], 0)
 
-    ok = file_write_length(fp, msg, options.bufsize, msg.filesize, options)
+    ok = file_write_length(fp, msg, options.bufSize, msg.filesize, options)
 
     fp.close()
 

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -163,8 +163,10 @@ class File(Transfer):
 
     def stat(self,path,message=None):
         spath = path if path[0] == '/' else self.path + '/' + path
-        return sarracenia.stat(spath)
-
+        try:
+             return sarracenia.stat(spath)
+        except:
+             return None
     # ls
     def ls(self):
         logger.debug("sr_file ls")

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -162,7 +162,7 @@ class File(Transfer):
         return self.cwd
 
     def stat(self,path,message=None):
-        spath = path if path[0] == '/' else self.cwd + '/' + path
+        spath = path if path[0] == '/' else self.path + '/' + path
         return sarracenia.stat(spath)
 
     # ls

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -161,6 +161,10 @@ class File(Transfer):
     def getcwd(self):
         return self.cwd
 
+    def stat(self,path,message=None):
+        spath = path if path[0] == '/' else self.cwd + '/' + path
+        return sarracenia.stat(spath)
+
     # ls
     def ls(self):
         logger.debug("sr_file ls")

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -313,7 +313,7 @@ class Ftp(Transfer):
         try:
             if self.binary:
                 self.ftp.retrbinary('RETR ' + remote_file, self.write_chunk,
-                                self.o.bufsize)
+                                self.o.bufSize)
             else:
                 self.ftp.retrlines('RETR ' + remote_file, self.write_chunk)
         except Exception as Ex:
@@ -424,7 +424,7 @@ class Ftp(Transfer):
         self.write_chunk_init(None)
         try:
             if self.binary:
-                self.ftp.storbinary("STOR " + remote_file, src, self.o.bufsize,
+                self.ftp.storbinary("STOR " + remote_file, src, self.o.bufSize,
                                 self.write_chunk)
             else:
                 self.ftp.storlines("STOR " + remote_file, src, self.write_chunk)

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -383,7 +383,7 @@ class Https(Transfer):
         url += path
 
         try:
-            resp = requests.head(url)
+            resp = requests.head(url, headers = {'Accept-Encoding': 'identity'} )
             resp.raise_for_status()
 
             # parse the HTTP header response into the stat object used by sr3

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -240,7 +240,7 @@ class Https(Transfer):
             dbuf = None
             while True:
                 alarm_set(self.o.timeout)
-                chunk = self.http.read(self.o.bufsize)
+                chunk = self.http.read(self.o.bufSize)
                 alarm_cancel()
                 if not chunk: break
                 if dbuf: dbuf += chunk

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -372,16 +372,15 @@ class Https(Transfer):
     def stat(self,path,msg) -> sarracenia.filemetadata.FmdStat:
         st = sarracenia.filemetadata.FmdStat()
 
+        #logger.debug( f" baseUrl:{msg['baseUrl']}, path:{self.path}, cwd:{self.cwd}, path:{path} " )
 
         url = msg['baseUrl']
-        if msg['baseUrl'][-1] != '/' and self.cwd[0] != '/' :
+        if msg['baseUrl'][-1] != '/' and self.path[0] != '/' :
             url += '/' 
-        url += self.cwd
-        logger.critical( f" 1 url={url}")
+        url += self.path
         if url[-1] != '/':
             url += '/' 
         url += path
-        logger.critical( f" 2 url={url}")
 
         try:
             resp = requests.head(url)

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -531,7 +531,10 @@ class Sftp(Transfer):
 
     #when sftp is active, paramiko is present... STFPAttributes is then the same as FmdStat.
     def stat(self, path, msg=None) -> sarracenia.filemetadata.FmdStat:
-        return self.sftp.stat(path)
+        try:
+            return self.sftp.stat(path)
+        except:
+            return None
 
     # utime
     def utime(self, path, tup):

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -341,7 +341,7 @@ class Sftp(Transfer):
             (remote_file, local_file, remote_offset, local_offset, length, exactLength))
 
         alarm_set(2 * self.o.timeout)
-        rfp = self.sftp.file(remote_file, 'rb', self.o.bufsize)
+        rfp = self.sftp.file(remote_file, 'rb', self.o.bufSize)
         if remote_offset != 0: rfp.seek(remote_offset, 0)
         rfp.settimeout(1.0 * self.o.timeout)
         alarm_cancel()
@@ -459,7 +459,7 @@ class Sftp(Transfer):
         alarm_set(2 * self.o.timeout)
 
         if length == 0:
-            rfp = self.sftp.file(remote_file, 'wb', self.o.bufsize)
+            rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
             rfp.settimeout(1.0 * self.o.timeout)
 
         # parts
@@ -467,10 +467,10 @@ class Sftp(Transfer):
             try:
                 self.sftp.stat(remote_file)
             except:
-                rfp = self.sftp.file(remote_file, 'wb', self.o.bufsize)
+                rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
                 rfp.close()
 
-            rfp = self.sftp.file(remote_file, 'r+b', self.o.bufsize)
+            rfp = self.sftp.file(remote_file, 'r+b', self.o.bufSize)
             rfp.settimeout(1.0 * self.o.timeout)
             if remote_offset != 0: rfp.seek(remote_offset, 0)
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -25,6 +25,7 @@ import logging, paramiko, os, subprocess, sys, time
 from paramiko import *
 from stat import *
 
+import sarracenia
 from sarracenia.transfer import Transfer
 from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
 from urllib.parse import unquote
@@ -527,6 +528,10 @@ class Sftp(Transfer):
         alarm_set(self.o.timeout)
         self.sftp.rmdir(path)
         alarm_cancel()
+
+    #when sftp is active, paramiko is present... STFPAttributes is then the same as FmdStat.
+    def stat(self, path, msg=None) -> sarracenia.filemetadata.FmdStat:
+        return self.sftp.stat(path)
 
     # utime
     def utime(self, path, tup):

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -9,13 +9,13 @@ sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt update
 sudo apt -y upgrade
-sudo apt -y install python3-setuptools python3-magic python-setuptools python3-requests
+sudo apt -y install python3-setuptools python3-magic python-setuptools 
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
 
 pip3 install -U pip
-pip3 install pyftpdlib paramiko net-tools
+pip3 install pyftpdlib paramiko net-tools requests
 
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -9,13 +9,13 @@ sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt update
 sudo apt -y upgrade
-sudo apt -y install python3-setuptools python3-magic python-setuptools 
+sudo apt -y install python3-setuptools python3-magic python-setuptools python3-openssl
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
 
 pip3 install -U pip
-pip3 install pyftpdlib paramiko net-tools requests
+pip3 install pyftpdlib paramiko net-tools
 
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -9,7 +9,7 @@ sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt update
 sudo apt -y upgrade
-sudo apt -y install python3-setuptools python3-magic python-setuptools
+sudo apt -y install python3-setuptools python3-magic python-setuptools python3-requests
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -4,6 +4,13 @@
 # Intended use case is a fresh sys (tested on ubuntu18.04desktop)
 # which can easily be run in a virtualbox VM.
 
+. /etc/os-release
+if [ ${VERSION} = "24.04" ]; 
+	pip_install="pip3 install --break-system-packages --user "
+else
+	pip_install="pip3 install "
+fi
+
 # Install and configure dependencies
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
@@ -14,8 +21,8 @@ sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
 
-pip3 install --break-system-packages --user -U pip
-pip3 install --break-system-packages --user pyftpdlib paramiko net-tools
+$pip_install -U pip
+$pip_install pyftpdlib paramiko net-tools
 
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
@@ -25,7 +32,7 @@ for PKG in amqp appdirs dateparser flufl.lock humanize jsonpickle netifaces paho
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"
     else
-        pip3 install --break-system-packages --user ${PKG}
+        $pip_install ${PKG}
     fi
 done
 

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -5,7 +5,7 @@
 # which can easily be run in a virtualbox VM.
 
 . /etc/os-release
-if [ ${VERSION} = "24.04" ]; then
+if [ "${VERSION_ID}" == "24.04" ]; then
 	pip_install="pip3 install --break-system-packages --user "
 else
 	pip_install="pip3 install "

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -5,7 +5,7 @@
 # which can easily be run in a virtualbox VM.
 
 . /etc/os-release
-if [ ${VERSION} = "24.04" ]; 
+if [ ${VERSION} = "24.04" ]; then
 	pip_install="pip3 install --break-system-packages --user "
 else
 	pip_install="pip3 install "

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -14,8 +14,8 @@ sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
 
-pip3 install -U pip
-pip3 install pyftpdlib paramiko net-tools
+pip3 install --break-system-packages --user -U pip
+pip3 install --break-system-packages --user pyftpdlib paramiko net-tools
 
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
@@ -25,14 +25,14 @@ for PKG in amqp appdirs dateparser flufl.lock humanize jsonpickle netifaces paho
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"
     else
-        pip3 install ${PKG}
+        pip3 install --break-system-packages --user ${PKG}
     fi
 done
 
 # in case it was installed as a dependency.
 sudo apt -y remove metpx-sr3
 
-pip3 install .
+pip3 install --break-system-packages --user .
 
 # Setup basic configs
 mkdir -p ~/.config/sarra ~/.config/sr3


### PR DESCRIPTION

progress on #1157 ...

* add a stat() entry point to the transfer protocols.
* implemented using @reidsunderland 's and @andreleblanc11 's logic to fetch headers for https.
* tested with subscribe/hpfx_amis

so before this change:

* when downloading citypages, typically at the top of the hour, a subscriber would download a citypage and find it didn't match what the message said it should be.
* so the downloaded file is discarded, and the message it placed on the retry queue.
* five minutes later It will again attempt to download.

in the case of citypages, the file has been changed before the subscriber attempted the first download:
*  so all retries will fail.... for three days (by default retries continue for three days.)

with the change:

* after a length mismatch on download, stat() the file on the server. to ask it what the size is on the server.

* if the date of the file is newer than on the message, discard the message rather than requeing... 
* If the size matches on the server... then downloading again, won't change anything. so better to discard.

in both cases, subsequent retries will never succeed.,,, so just throw it out.

* so there will be no error reported, the subscribe flow now understands what is going on and just prints and information message.
* nothing will be put on the retry queue for this understood phenomenon.  

So testing was done downloading subscribe/hpfx_citypage ... and with these changes, it is clean now, with no retries.

