### PR TITLE
AM adaptation for U18.04 servers

### DIFF
--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -159,7 +159,7 @@ class Am(FlowCB):
                         os.set_inheritable(conn.fileno(), True)
                         time.sleep(1)
 
-                    except TimeoutError:
+                    except (TimeoutError,socket.timeout):
                         n = n * 2 
                         if n > 64: n = 64
                         logger.info(f"No new connections. Waiting {n} seconds.")
@@ -168,6 +168,7 @@ class Am(FlowCB):
 
                     except Exception as e:
                         logger.error(f"Stopping accept. Exiting. Error message: {e}")
+                        logger.critical("Exception details", exc_info=True)
                         sys.exit(0)   
 
                     # Instance forks


### PR DESCRIPTION
See https://docs.python.org/3/library/socket.html#socket.timeout 

`socket.timeout` is only an alias of `TimeoutError` since python3.10. So Ubuntu18.04 (python3.6) doesn't have this accomodation set in place. 

I commited from edcm-dirt18-1.. this is why @reidsunderland is set as the commiter. I was too lazy to change that so credit to Reid for the change :smile: