### PR TITLE
Later pip needs convincing 

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server, partitioned_flow ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -4,6 +4,15 @@
 # Intended use case is a fresh sys (tested on ubuntu18.04desktop)
 # which can easily be run in a virtualbox VM.
 
+
+# later OS versions have later versions of pip that require convincing to actually install.
+. /etc/os-release
+if [ "${VERSION_ID}" \> "22.04" ]; then
+        pip_install="pip3 install --break-system-packages --user "
+else
+        pip_install="pip3 install "
+fi
+
 # Install and configure dependencies
 sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
@@ -14,8 +23,8 @@ sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
 
-pip3 install -U pip
-pip3 install pyftpdlib paramiko net-tools
+${pip_install} -U pip
+${pip_install} pyftpdlib paramiko net-tools
 
 # The dependencies that are installed using apt are only available to system default Python versions (e.g. Python 3.8 on Ubuntu 20.04)
 # If we are testing on a non-default Python version, we need to ensure these dependencies are still installed, so we use pip.
@@ -25,14 +34,14 @@ for PKG in amqp appdirs dateparser flufl.lock humanize jsonpickle netifaces paho
     if [ "$?" == "0" ] ; then
         echo "$PKG is already installed"
     else
-        pip3 install ${PKG}
+        ${pip_install} ${PKG}
     fi
 done
 
 # in case it was installed as a dependency.
 sudo apt -y remove metpx-sr3
 
-pip3 install .
+${pip_install} .
 
 # Setup basic configs
 mkdir -p ~/.config/sarra ~/.config/sr3


### PR DESCRIPTION
* flow tests were failing, in 24.04 because pip installs were failing.
* newer pip install requires "--break-system-packages --user" ... options.
* Added a test so on ubuntu >22.04 it supplies those arguments.

Did a flow test with the change and now ubuntu 24.04 passes it's flow tests (but 20.04 is still broken.)
