### PR TITLE
Issue1155 AMQP ack refactor

### DIFF
--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -48,20 +48,7 @@ class Message(FlowCB):
 
         for m in mlist:
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
-            if 'ack_id' not in m:
-                # don't bother attempting to ack a message with no ack_id. 
-                # If you did try to ack it, the Moth class is supposed to return True anyways.
-                continue
-            elif self.consumer.ack(m):
-                # ack was successful, don't need the ack_id anymore
-                del m['ack_id']
-                m['_deleteOnPost'].remove('ack_id')
-            else:
-                # FIXME when consuming from multiple brokers, maybe we shouldn't delete the ack_id?
-                # we might need to try acking on all brokers and only delete the ack_id once if acking fails 
-                # with all possible brokers?
-                del m['ack_id']
-                m['_deleteOnPost'].remove('ack_id')
+            self.consumer.ack(m)
 
     def metricsReport(self) -> dict:
         if hasattr(self,'consumer') and hasattr(self.consumer,'metricsReport'):

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -48,7 +48,20 @@ class Message(FlowCB):
 
         for m in mlist:
             # messages being re-downloaded should not be re-acked, but they won't have an ack_id (see issue #466)
-            self.consumer.ack(m)
+            if 'ack_id' not in m:
+                # don't bother attempting to ack a message with no ack_id. 
+                # If you did try to ack it, the Moth class is supposed to return True anyways.
+                continue
+            elif self.consumer.ack(m):
+                # ack was successful, don't need the ack_id anymore
+                del m['ack_id']
+                m['_deleteOnPost'].remove('ack_id')
+            else:
+                # FIXME when consuming from multiple brokers, maybe we shouldn't delete the ack_id?
+                # we might need to try acking on all brokers and only delete the ack_id once if acking fails 
+                # with all possible brokers?
+                del m['ack_id']
+                m['_deleteOnPost'].remove('ack_id')
 
     def metricsReport(self) -> dict:
         if hasattr(self,'consumer') and hasattr(self.consumer,'metricsReport'):

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -308,11 +308,12 @@ class Moth():
         logging.basicConfig(format=self.o['logFormat'],
                             level=getattr(logging, self.o['logLevel'].upper()))
 
-    def ack(self, message: sarracenia.Message ) -> None:
+    def ack(self, message: sarracenia.Message ) -> bool:
         """
           tell broker that a given message has been received.
 
           ack uses the 'ack_id' property to send an acknowledgement back to the broker.
+          If there's no 'ack_id' in the message, you should return True.
         """
         logger.error("ack unimplemented")
 

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -667,13 +667,14 @@ class MQTT(Moth):
         else:
             return None
 
-    def ack(self, m: sarracenia.Message ) -> None:
+    def ack(self, m: sarracenia.Message ) -> bool:
 
         if 'ack_id' in m:
             logger.info('mid=%d' % m['ack_id'])
             self.client.ack( m['ack_id'], m['qos'] )
-            del m['ack_id']
-            m['_deleteOnPost'].remove('ack_id')
+        # return True if successful. when there's no ack_id, acking doesn't fail,
+        # there's just nothing to ack so still return True
+        return True
 
     def putNewMessage(self,
                       message: sarracenia.Message,

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -667,13 +667,13 @@ class MQTT(Moth):
         else:
             return None
 
-    def ack(self, m: sarracenia.Message ) -> bool:
+    def ack(self, m: sarracenia.Message ) -> None:
 
         if 'ack_id' in m:
             logger.info('mid=%d' % m['ack_id'])
             self.client.ack( m['ack_id'], m['qos'] )
-        # return True if successful. when there's no ack_id, acking doesn't fail,
-        # there's just nothing to ack so still return True
+            del m['ack_id']
+            m['_deleteOnPost'].remove('ack_id')
         return True
 
     def putNewMessage(self,


### PR DESCRIPTION
 AMQP: refuse to attempt to ack a message if it was received on a different channel, connection or broker (preventing unnecessary
connection tear down and re-establish)

AMQP: when ack is attempted and fails because the connection to the broker is broken, cleanup (close) the broken connection and don't bother attempting to retry the ack

Also changed the ack method to return a boolean, which wasn't needed but could possibly be useful someday if we want to change how we handle a failed ack.