### PR TITLE
fix #1166 improved download decision criteria

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1457,7 +1457,7 @@ class Flow:
             method='unknown'
         
         # if no method given, then assume binary comparison is good.
-        if method in ['sha512', 'md5', 'unknown']: 
+        if method in sarracenia.identity.binary_methods: 
             if 'size' in msg:
                 end = msg['size']
                 # compare sizes... if (sr_subscribe is downloading partitions into taget file) and (target_file isn't fully done)

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1451,7 +1451,7 @@ class Flow:
         #   part of partitioning deferral.
         #end   = self.local_offset + self.length
         # if using a true binary checksum, the size check is enough.
-        if 'identidy' in msg and 'method' in msg['identity']:
+        if 'identity' in msg and 'method' in msg['identity']:
             method=msg['identity']['method']
         else:
             method='unknown'

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1451,8 +1451,8 @@ class Flow:
         #   part of partitioning deferral.
         #end   = self.local_offset + self.length
         # if using a true binary checksum, the size check is enough.
-        if 'identify' in msg and 'method' in msg['identity']:
-            method=msg['identity']
+        if 'identidy' in msg and 'method' in msg['identity']:
+            method=msg['identity']['method']
         else:
             method='unknown'
         

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1450,58 +1450,62 @@ class Flow:
         # FIXME... local_offset... offset within the local file... partitioned... who knows?
         #   part of partitioning deferral.
         #end   = self.local_offset + self.length
-        if 'size' in msg:
-            end = msg['size']
-            # compare sizes... if (sr_subscribe is downloading partitions into taget file) and (target_file isn't fully done)
-            # This check prevents random halting of subscriber (inplace on) if the messages come in non-sequential order
-            # target_file is the same as new_file unless the file is partitioned.
-            # FIXME If the file is partitioned, then it is the new_file with a partition suffix.
-            #if ('self.target_file == msg['new_file'] ) and ( fsiz != msg['size'] ):
-            if (fsiz != msg['size']):
-                logger.debug("%s file size different, so cannot be the same" %
-                             (msg['new_path']))
-                return True
+        # if using a true binary checksum, the size check is enough.
+        if 'identify' in msg and 'method' in msg['identity']:
+            method=msg['identity']
         else:
-            end = 0
+            method='unknown'
+        
+        # if no method given, then assume binary comparison is good.
+        if method in ['sha512', 'md5', 'unknown']: 
+            if 'size' in msg:
+                end = msg['size']
+                # compare sizes... if (sr_subscribe is downloading partitions into taget file) and (target_file isn't fully done)
+                # This check prevents random halting of subscriber (inplace on) if the messages come in non-sequential order
+                # target_file is the same as new_file unless the file is partitioned.
+                # FIXME If the file is partitioned, then it is the new_file with a partition suffix.
+                #if ('self.target_file == msg['new_file'] ) and ( fsiz != msg['size'] ):
+                if (fsiz != msg['size']):
+                    logger.debug("%s file size different, so cannot be the same" %
+                             (msg['new_path']))
+                    return True
 
-        # compare dates...
-
-        if 'mtime' in msg:
-            new_mtime = sarracenia.timestr2flt(msg['mtime'])
-            old_mtime = 0.0
-
-            if self.o.timeCopy:
-                old_mtime = lstat.st_mtime
-            elif sarracenia.filemetadata.supports_extended_attributes:
-                try:
-                    x = sarracenia.filemetadata.FileMetadata(msg['new_path'])
-                    old_mtime = sarracenia.timestr2flt(x.get('mtime'))
-                except:
-                    pass
-
-            if new_mtime <= old_mtime:
-                self.reject(msg, 304,
-                            "mtime not newer %s " % (msg['new_path']))
-                return False
             else:
-                logger.debug(
-                    "{} new version is {} newer (new: {} vs old: {} )".format(
+                end = 0
+
+            # compare dates...
+
+            if 'mtime' in msg:
+                new_mtime = sarracenia.timestr2flt(msg['mtime'])
+                old_mtime = 0.0
+
+                if self.o.timeCopy:
+                    old_mtime = lstat.st_mtime
+                elif sarracenia.filemetadata.supports_extended_attributes:
+                    try:
+                        x = sarracenia.filemetadata.FileMetadata(msg['new_path'])
+                        old_mtime = sarracenia.timestr2flt(x.get('mtime'))
+                    except:
+                        pass
+    
+                if new_mtime <= old_mtime:
+                    self.reject(msg, 304,
+                            "mtime not newer %s " % (msg['new_path']))
+                    return False
+                else:
+                    logger.debug(
+                        "{} new version is {} newer (new: {} vs old: {} )".format(
                         msg['new_path'], new_mtime - old_mtime, new_mtime,
                         old_mtime))
 
-        if 'identity' in msg and msg['identity']['method'] in ['random', 'cod']:
-            logger.debug("content_match %s sum 0/z never matches" %
+        elif method in ['random', 'cod']:
+            logger.debug("content_match %s sum random/zero/cod never matches" %
                          (msg['new_path']))
-            return True
-
-        if end > fsiz:
-            logger.debug(
-                "new file not big enough... considered different")
             return True
 
         if not 'identity' in msg: 
             # FIXME... should there be a setting to assume them the same? use cases may vary.
-            logger.debug( "no checksum available, assuming different" )
+            logger.debug( "size different and no checksum available, assuming different" )
             return True
 
         try:

--- a/sarracenia/identity/__init__.py
+++ b/sarracenia/identity/__init__.py
@@ -84,6 +84,12 @@ import sarracenia.identity.md5
 import sarracenia.identity.random
 import sarracenia.identity.sha512
 
+# the 'unknown' method is created to accomodate cases where a identity field 
+# missing, or the corresponding class is not known to this instance.
+
+# methods where size checks makes sense. updated when new methods added.
+binary_methods = [ 'sha512', 'md5', 'unknown' ]
+
 known_methods = []
 for sc in Identity.__subclasses__():
     known_methods.append(sc.__name__.lower())


### PR DESCRIPTION

re-organized the file_should_be_download routine a bit, now only check size and mtime if using an unknown or binary checksum where those characteristics would be definitive.

so now it will not check size for arbitrary, or other checksums where it is irrelevant....
When adding methods to identity, can update the binary_methods list.

