### PR TITLE
Fix #1173: problems stopping instances

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -461,7 +461,7 @@ class Flow:
         m.setReport(code, reason)
 
     def please_stop(self) -> None:
-        logger.info( f'ok, telling {len(self.plugins["please_stop"])} callbacks about it.')
+        logger.info(f'stop requested')
         self._stop_requested = True
         self.metrics["flow"]['stop_requested'] = True
 
@@ -562,8 +562,10 @@ class Flow:
                     self.close()
                     break
                 else:
-                    logger.debug( 'starting last pass (without gather) through loop for cleanup.')
+                    logger.debug('starting last pass (without gather) through loop for cleanup.')
                     stopping = True
+                    logger.info(f'telling {len(self.plugins["please_stop"])} callbacks to please_stop.')
+                    self.runCallbacksTime('please_stop')
 
             self._run_vip_update()
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -613,7 +613,9 @@ class Flow:
             run_time = now - start_time
             total_messages += last_gather_len
 
+            # trigger shutdown when messageCountMax is reached
             if (self.o.messageCountMax > 0) and (total_messages > self.o.messageCountMax):
+                logger.info(f'{total_messages} messages processed > messageCountMax {self.o.messageCountMax}')
                 self.runCallbacksTime('please_stop')
 
             current_rate = total_messages / run_time
@@ -622,6 +624,7 @@ class Flow:
             self.metrics['flow']['msgRate'] = current_rate
             self.metrics['flow']['msgRateCpu'] = total_messages / (self.metrics['flow']['cpuTime']+self.metrics['flow']['last_housekeeping_cpuTime'] )
 
+            # trigger shutdown once gather is finished, where sleep < 0 (e.g. a post)
             if (last_gather_len == 0) and (self.o.sleep < 0):
                 if (self.o.retryEmptyBeforeExit and "retry" in self.metrics
                     and self.metrics['retry']['msgs_in_post_retry'] > 0):

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1008,7 +1008,7 @@ class Flow:
 
                 if self.o.fileAgeMin > 0 and age < self.o.fileAgeMin:
                     logger.warning( f"file too young: queueing for retry.")
-                    self.worklist.failed.append(msg)
+                    self.worklist.failed.append(m)
                     continue
 
             if 'fileOp' in m and 'rename' in m['fileOp']:

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -74,3 +74,10 @@ class Message(FlowCB):
         if hasattr(self,'consumer') and hasattr(self.consumer, 'close'):
             self.consumer.close()
         logger.info('closing')
+
+    def please_stop(self) -> None:
+        """ pass stop request along to consumer Moth instance(s)
+        """
+        super().please_stop()
+        if hasattr(self,'consumer') and self.consumer:
+            self.consumer.please_stop()

--- a/sarracenia/flowcb/gather/message.py
+++ b/sarracenia/flowcb/gather/message.py
@@ -80,4 +80,5 @@ class Message(FlowCB):
         """
         super().please_stop()
         if hasattr(self,'consumer') and self.consumer:
+            logger.debug("asking Moth consumer to please_stop")
             self.consumer.please_stop()

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -69,3 +69,10 @@ class Message(FlowCB):
         if hasattr(self,'poster') and self.poster:
             self.poster.close()
         logger.debug('closing')
+    
+    def please_stop(self) -> None:
+        """ pass stop request along to publisher Moth instance(s)
+        """
+        super().please_stop()
+        if hasattr(self, 'poster') and self.poster:
+            self.poster.please_stop()

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -75,4 +75,5 @@ class Message(FlowCB):
         """
         super().please_stop()
         if hasattr(self, 'poster') and self.poster:
+            logger.debug("asking Moth publisher to please_stop")
             self.poster.please_stop()

--- a/sarracenia/flowcb/report.py
+++ b/sarracenia/flowcb/report.py
@@ -166,3 +166,9 @@ class Report(FlowCB):
             self.poster.close()
         logger.info('closing')
 
+    def please_stop(self) -> None:
+        """ pass stop request along to publisher Moth instance(s)
+        """
+        super().please_stop()
+        if hasattr(self, 'poster') and self.poster:
+            self.poster.please_stop()

--- a/sarracenia/flowcb/report.py
+++ b/sarracenia/flowcb/report.py
@@ -171,4 +171,5 @@ class Report(FlowCB):
         """
         super().please_stop()
         if hasattr(self, 'poster') and self.poster:
+            logger.debug("asking Moth publisher to please_stop")
             self.poster.please_stop()

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -62,7 +62,7 @@ class instance:
                     if line:
                         code.append("  %s" % (line.strip()))
             logging.debug('\n'.join(code))
-        self.running_instance.please_stop()
+        self.running_instance.stop_request()
 
     def start(self):
         """

--- a/sarracenia/interruptible_sleep.py
+++ b/sarracenia/interruptible_sleep.py
@@ -1,0 +1,32 @@
+"""
+Long running sleeps prevent Sarracenia from being shutdown cleanly in a
+reasonable amount of time.
+
+This implements a reusable sleep function that can be called from other parts
+of the code to sleep for a long time, but can still be interrupted.
+"""
+
+import time
+
+def interruptible_sleep(sleep_time:float, obj: object, stop_flag_name: str='_stop_requested', nap_time: float=5.0) -> bool:
+    """ Sleep for sleep_time, divided up into shorter nap_time intervals.
+        Pass a reference to an object that contains a boolean attribute named stop_flag_name. 
+        Between each nap_time, the function will check if obj.stop_flag_name has become True.
+        If the flag is False, it will continue sleeping, if True, it will abort the sleep.
+
+         Args:
+            sleep_time (float): total amount of time to sleep, if not interrupted
+            obj (object): the object containing the boolean attribute named stop_flag_name
+            stop_flag_name (str): the name of the boolean attribute in obj
+            nap_time (float): default = 5.0, sleep in intervals of nap_time
+
+        Returns:
+            bool: ``True`` if the sleep **was** interrupted, ``False`` if it slept for the entire ``sleep_time`` 
+                    time without interruption.
+    """
+    interrupted = False
+    while sleep_time > 0 and not interrupted:
+        time.sleep(min(nap_time, sleep_time))
+        sleep_time -= nap_time
+        interrupted = (hasattr(obj, stop_flag_name) and getattr(obj, stop_flag_name))
+    return interrupted

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -280,7 +280,7 @@ class Moth():
 
         self.is_subscriber = is_subscriber
         self.connected=False
-        self.please_stop = False
+        self.self._stop_requested = False
         self.metrics = { 'connected': False }
         self.metricsReset()
 
@@ -349,6 +349,13 @@ class Moth():
         """
         logger.error("NewMessages unimplemented")
         return []
+    
+    def please_stop(self) -> None:
+        """ register a request to cleanly stop. Any long running processes should check for _stop_requested and 
+            stop if it becomes True.
+        """
+        logger.info("asked to stop")
+        self._stop_requested = True
 
     def putNewMessage(self, message:sarracenia.Message, content_type: str ='application/json', exchange: str = None) -> bool:
         """

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -280,7 +280,7 @@ class Moth():
 
         self.is_subscriber = is_subscriber
         self.connected=False
-        self.self._stop_requested = False
+        self._stop_requested = False
         self.metrics = { 'connected': False }
         self.metricsReset()
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -34,6 +34,7 @@ import re
 import sarracenia
 from sarracenia.postformat import PostFormat
 from sarracenia.moth import Moth
+from sarracenia.interruptible_sleep import interruptible_sleep
 import os
 
 import time
@@ -391,7 +392,7 @@ class AMQP(Moth):
             if ebo < 60: ebo *= 2
 
             logger.info("Sleeping {} seconds ...".format(ebo))
-            time.sleep(ebo)
+            interruptible_sleep(ebo, obj=self)
 
     def putSetup(self) -> None:
 
@@ -456,7 +457,7 @@ class AMQP(Moth):
 
             self.close()
             logger.info("Sleeping {} seconds ...".format(ebo))
-            time.sleep(ebo)
+            interruptible_sleep(ebo, obj=self)
 
     def putCleanUp(self) -> None:
 
@@ -612,7 +613,7 @@ class AMQP(Moth):
             if ebo < 60:
                 ebo *= 2
             logger.info("Sleeping {} seconds before re-trying ack...".format(ebo))
-            time.sleep(ebo)
+            interruptible_sleep(ebo, obj=self)
             # TODO maybe implement message strategy stubborn here and give up after retrying?
 
     def putNewMessage(self,

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -33,7 +33,6 @@ import paho.mqtt.client
 import sarracenia
 from sarracenia.postformat import PostFormat
 from sarracenia.moth import Moth
-import signal
 import os
 import ssl
 import threading
@@ -342,25 +341,17 @@ class MQTT(Moth):
                                unquote(self.o['broker'].url.password))
         return client
 
-    def _mqtt_setup_signal_handler(self, signum, stack):
-        logger.info("ok, asked to stop")
-        self.please_stop=True
-
     def getSetup(self):
         """
            Establish a connection to consume messages with.  
         """
         ebo = 1
-        original_sigint = signal.getsignal(signal.SIGINT)
-        original_sigterm = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, self._mqtt_setup_signal_handler)
-        signal.signal(signal.SIGTERM, self._mqtt_setup_signal_handler)
 
         something_broke = True
         self.connected=False
         while True:
 
-            if self.please_stop:
+            if self._stop_requested:
                 break
 
             try:
@@ -390,7 +381,7 @@ class MQTT(Moth):
                     while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
                          logger.info( f"waiting for subscription to be set up. (ebo={ebo})")
                          time.sleep(0.1*ebo)
-                         if self.please_stop:
+                         if self._stop_requested:
                               break
                          if ebo < 512 :
                             ebo *= 2
@@ -411,7 +402,7 @@ class MQTT(Moth):
                         while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
                             logger.info( f"waiting ({ebo} seconds) for broker to confirm subscription is set up.")
                             logger.info( f"for {icid} connect_in_progress={self.connect_in_progress} subscribe_in_progress={self.subscribe_in_progress}" )
-                            if self.please_stop:
+                            if self._stop_requested:
                                 break
                             if ebo < 60: ebo *= 2
                             decl_client.loop(ebo)
@@ -427,27 +418,16 @@ class MQTT(Moth):
             if ebo < 60: ebo *= 2
             time.sleep(ebo)
 
-        signal.signal(signal.SIGINT, original_sigint)
-        signal.signal(signal.SIGTERM, original_sigterm)
-        if self.please_stop:
-            os.kill(os.getpid(), signal.SIGINT)
-
-
-
     def putSetup(self):
         """
            establish a connection to allow publishing. 
         """
         ebo = 1
-        original_sigint = signal.getsignal(signal.SIGINT)
-        original_sigterm = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, self._mqtt_setup_signal_handler)
-        signal.signal(signal.SIGTERM, self._mqtt_setup_signal_handler)
 
         self.connected=False
         while True:
             
-            if self.please_stop:
+            if self._stop_requested:
                 break
 
             try:
@@ -489,7 +469,7 @@ class MQTT(Moth):
                 while self.connect_in_progress:
                      logger.info( f"waiting for connection to {self.o['broker']} ebo={ebo}")
                      time.sleep(0.1*ebo)
-                     if self.please_stop:
+                     if self._stop_requested:
                           break
                      if ebo < 512:
                           ebo *= 2
@@ -503,12 +483,6 @@ class MQTT(Moth):
 
             if ebo < 60: ebo *= 2
             time.sleep(ebo)
-
-        signal.signal(signal.SIGINT, original_sigint)
-        signal.signal(signal.SIGTERM, original_sigterm)
-        if self.please_stop:
-            os.kill(os.getpid(), signal.SIGINT)
-
 
     def __sub_on_message(client, userdata, msg):
         """
@@ -544,7 +518,7 @@ class MQTT(Moth):
                    clean_start=False, properties=props )
                 while self.connect_in_progress:
                     myclient.loop(0.1)
-                    if self.please_stop:
+                    if self._stop_requested:
                        break
                 myclient.disconnect()
                 logger.info( f"instance deletion for {i:02d} done" )

--- a/tests/sarracenia/interruptible_sleep_test.py
+++ b/tests/sarracenia/interruptible_sleep_test.py
@@ -1,0 +1,68 @@
+import pytest
+from tests.conftest import *
+#from unittest.mock import Mock
+
+import datetime
+import os
+import signal
+import subprocess
+from sarracenia.interruptible_sleep import interruptible_sleep
+
+class SleepThing():
+    def __init__(self):
+        self._stop_requested = False
+        self.other_name = False
+        signal.signal(signal.SIGTERM, self.signal_handler)
+        signal.signal(signal.SIGINT, self.signal_handler)
+    
+    def signal_handler(self, signum, stack):
+        self._stop_requested = True
+        self.other_name = True
+
+def test_interruptible_sleep():
+    st = SleepThing()
+    stime = 10
+
+    # Test that sleep sleeps for the right amount of time when not interrupted
+    before_time = datetime.datetime.now()
+    result = interruptible_sleep(stime, st)
+    after_time = datetime.datetime.now()
+    assert (result == False)
+    assert ( (after_time - before_time).seconds == stime)
+
+    # Test that the sleep behaves correctly when interrupted
+    # send a SIGINT to this process after 5 seconds:
+    cmdline = f"""bash -c '/usr/bin/sleep 5; kill -SIGTERM {os.getpid()};' &"""
+    subprocess.run(cmdline, shell=True)
+    before_time = datetime.datetime.now()
+    result = interruptible_sleep(stime, st)
+    after_time = datetime.datetime.now()
+    assert result
+    assert ( (after_time - before_time).seconds == 5)
+
+    # Test using a different nap_time
+    st = SleepThing()
+    # send a SIGINT to this process after 5 seconds:
+    cmdline = f"""bash -c '/usr/bin/sleep 5; kill -SIGTERM {os.getpid()};' &"""
+    subprocess.run(cmdline, shell=True)
+    before_time = datetime.datetime.now()
+    result = interruptible_sleep(stime, st, nap_time=1)
+    after_time = datetime.datetime.now()
+    assert result
+    assert ( (after_time - before_time).seconds == 5)
+
+
+    # Test using a different attribute name
+    st = SleepThing()
+    # send a SIGINT to this process after 5 seconds:
+    cmdline = f"""bash -c '/usr/bin/sleep 5; kill -SIGTERM {os.getpid()};' &"""
+    subprocess.run(cmdline, shell=True)
+    before_time = datetime.datetime.now()
+    result = interruptible_sleep(stime, st, stop_flag_name = 'other_name')
+    after_time = datetime.datetime.now()
+    assert result
+    assert ( (after_time - before_time).seconds == 5)
+
+
+
+


### PR DESCRIPTION
This fixes multiple problems:

1. Multi-instance configs don't stop correctly. For unknown reasons, the signal handler in `flow/__init__.py` works in instance 1 and cleanly stops the instance, but the signal handler in `moth/amqp.py` takes over in instances >1. The one in `flow/__init__.py` never executes, so the instance never shuts itself down. This forces `sr3 stop` to always kill instances > 1.<br>
    Only one signal handler at a time can be used, so whichever one was registered last was being called. <br><br>
2. Because the signal handler in moth/amqp.py was not working for instance 1, when AMQP was stuck in a long sleep because it couldn't connect to the broker, it would not shut itself down and would eventually get killed.<br><br>
3. `please_stop` callbacks were not being called, except in two rare cases (when messageCountMax is enabled and the max. message count is reached; or in configs where sleep is <0) (regression from #1070). <br>
    Now please_stop callbacks are called when SIGTERM or SIGINT is received.<br><br>
4. Adds a reusable `interruptible_sleep` function, a sleep that can be interrupted a variable becoming True.<br>


I'm not 100% sure it actually fixed the problem, but I did multiple runs of flakey_broker and never saw any unacked messages... it could be a coincidence.