### PR TITLE
Issue1189 SFTP FSETATTTR fix + timeout 0 support

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -2035,11 +2035,12 @@ a topicPrefix, followed by subtopics derived from the *relPath* field of the mes
 Some networks may choose to use different topic conventions, external to sarracenia.
 
 
-timeout <interval> (default: 0)
+timeout <interval> (default: 300)
 -------------------------------
 
 The **timeout** option, sets the number of seconds to wait before aborting a
 connection or download transfer (applied per buffer during transfer).
+Setting to zero disables timeouts.
 
 
 timezone <string> (default: UTC)

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1240,6 +1240,18 @@ off and output with *post_exchangeSplit*, which route notification with the same
 the same member of a **second layer of subscribers (winnow) whose duplicate suppression caches 
 are active.**
 
+nofsetstat <off|on> (default: off)
+----------------------------------
+
+Error messages such as this::
+
+    [ERROR] sarracenia.flow send could not send /source/filename to inflight=None sftp://user@example.com/ /destination/filename: FSETSTAT unsupported
+
+Some SFTP servers will restrict permissions in ways which limit functionality. Cannot set modification times, or 
+truncate files (when new file is shorter than earlier version.), cannot set mode/permission bits.
+To avoid warnings or errors being generated about FSETSTAT, one can accept the limited functionality
+by setting **nofsetstat on**
+
 
 outlet post|json|url (default: post)
 ------------------------------------

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1221,6 +1221,19 @@ utiliser *post_exchangeSplit* pour la sortie. Cela achemine les publications en 
 une **deuxième couche d’abonnés (winnow) dont les caches de suppression des doublons sont actives.**
 
 
+nofsetstat on|off (défaut: faux)
+--------------------------------
+
+Certains serveurs limitent le permissions aux répertoires::
+
+   [ERROR] sarracenia.flow send could not send /source/filename to inflight=None sftp://user@example.com/ /destination/filename: FSETSTAT unsupported
+
+Les autorisations restreintes sur le serveur signifient des fonctionnalités limitées. Impossible de corriger les 
+heures de modification ou de tronquer les fichiers (lorsque le nouveau fichier est plus court que la version 
+précédente), impossible de définir les bits de mode/autorisation. On allume cette option pour supprimer
+des avertissements pour vous informer de tels difficultés.
+
+
 outlet post|json|url (défaut: post)
 -----------------------------------
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -2007,11 +2007,12 @@ source et la destination sont comparés.
 
 Lorsqu’il est défini dans un composant de publication, les en-têtes *atime* et *mtime* des messages d'annonce sont éliminés.
 
-timeout <intervalle> (défaut: 0)
+timeout <intervalle> (défaut: 300)
 --------------------------------
 
 L’option **timeout** définit le nombre de secondes à attendre avant d’interrompre un
 transfert de connexion ou de téléchargement (appliqué pendant le transfert).
+On peut désactiver les **timeout** avec 0 comme intervalle.
 
 timezone <chaine> (défaut: UTC)
 --------------------------------

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -101,6 +101,7 @@ default_options = {
     'metrics_writeInterval': 5,
     'nodupe_driver': 'disk',
     'nodupe_ttl': 0,
+    'nofsetstat': True,
     'overwrite': True,
     'path': [],
     'permDefault' : octal_number(0),
@@ -142,7 +143,7 @@ count_options = [
 flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl_relPath', 'debug', \
     'delete', 'discard', 'download', 'dry_run', 'durable', 'exchangeDeclare', 'exchangeSplit', 'logReject', 'realpathFilter', \
     'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logMetrics', 'logStdout', 'logReject', 'restore', \
-    'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \
+    'messageDebugDump', 'mirror', 'timeCopy', 'nofsetstat', 'notify_only', 'overwrite', 'post_on_start', \
     'permCopy', 'persistent', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', \
     'reconnect', 'report', 'reset', 'retry_refilter', 'retryEmptyBeforeExit', 'save', 
     'sundew_compat_regex_first_match_is_zero', 'sourceFromExchange', 'sourceFromMessage', 'topicCopy', 

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -95,7 +95,6 @@ class Credential:
         self.ssh_keyfile = None
         self.passive = True
         self.binary = True
-        self.nofsetstat = False
         self.tls = False
         self.prot_p = False
         self.bearer_token = None
@@ -371,8 +370,6 @@ class CredentialDB:
                     details.binary = True
                 elif keyword == 'ascii':
                     details.binary = False
-                elif keyword == 'nofsetstat':
-                    details.nofsetstat = True
                 elif keyword == 'ssl':
                     details.tls = False
                 elif keyword == 'tls':

--- a/sarracenia/credentials.py
+++ b/sarracenia/credentials.py
@@ -95,6 +95,7 @@ class Credential:
         self.ssh_keyfile = None
         self.passive = True
         self.binary = True
+        self.nofsetstat = False
         self.tls = False
         self.prot_p = False
         self.bearer_token = None
@@ -370,6 +371,8 @@ class CredentialDB:
                     details.binary = True
                 elif keyword == 'ascii':
                     details.binary = False
+                elif keyword == 'nofsetstat':
+                    details.nofsetstat = True
                 elif keyword == 'ssl':
                     details.tls = False
                 elif keyword == 'tls':

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -141,6 +141,7 @@ class Transfer():
 
      uses options (on Sarracenia.config data structure passed to constructor/factory.)
      * credentials - used to authentication information.
+     * nofsetstat - used for SFTP to deal with limited server side permissions.
      * sendTo  - server to connect to.
      * batch   - how many files to transfer before a connection is torn down and re-established.
      * permDefault - what permissions to set on files transferred.

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -85,7 +85,7 @@ class Ftp(Transfer):
         self.ftp.cwd(self.originalDir)
         self.ftp.cwd(path)
         self.pwd = path
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     def cd_forced(self, perm, path):
         logger.debug("sr_ftp cd_forced %d %s" % (perm, path))
@@ -96,11 +96,11 @@ class Ftp(Transfer):
         self.ftp.cwd(self.originalDir)
         try:
             self.ftp.cwd(path)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             return
         except:
             pass
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
         # need to create subdir
 
@@ -113,7 +113,7 @@ class Ftp(Transfer):
             try:
                 alarm_set(self.o.timeout)
                 self.ftp.cwd(d)
-                alarm_cancel()
+                alarm_cancel(self.o.timeout)
                 continue
             except:
                 pass
@@ -121,17 +121,17 @@ class Ftp(Transfer):
             # create
             alarm_set(self.o.timeout)
             self.ftp.mkd(d)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
 
             # chmod
             alarm_set(self.o.timeout)
             self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + d)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
 
             # cd
             alarm_set(self.o.timeout)
             self.ftp.cwd(d)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
 
     # check_is_connected
 
@@ -164,7 +164,7 @@ class Ftp(Transfer):
         logger.debug("sr_ftp chmod %s %s" % (str(perm), path))
         alarm_set(self.o.timeout)
         self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + path)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # close
     def close(self):
@@ -179,7 +179,7 @@ class Ftp(Transfer):
             old_ftp.quit()
         except:
             pass
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # connect...
     def connect(self):
@@ -247,7 +247,7 @@ class Ftp(Transfer):
                          (self.host, self.user))
             logger.debug('Exception details: ', exc_info=True)
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return self.connected
 
     # credentials...
@@ -288,7 +288,7 @@ class Ftp(Transfer):
             self.ftp.delete(path)
         except:
             d = self.ftp.pwd()
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # get
     def get(self,
@@ -350,7 +350,7 @@ class Ftp(Transfer):
     def getcwd(self):
         alarm_set(self.o.timeout)
         pwd = self.ftp.pwd()
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return pwd
 
     # ls
@@ -359,7 +359,7 @@ class Ftp(Transfer):
         self.entries = {}
         alarm_set(self.o.timeout)
         self.ftp.retrlines('LIST', self.line_callback)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         logger.debug("sr_ftp ls = (size: %d) %s ..." % (len(self.entries), str(self.entries)[0:255]))
         return self.entries
 
@@ -400,12 +400,12 @@ class Ftp(Transfer):
         logger.debug("sr_ftp mkdir %s" % remote_dir)
         alarm_set(self.o.timeout)
         self.ftp.mkd(remote_dir)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         alarm_set(self.o.timeout)
         self.ftp.voidcmd('SITE CHMOD ' +
                          "{0:o}".format(self.o.permDirDefault) + ' ' +
                          remote_dir)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # put
     def put(self,
@@ -464,18 +464,18 @@ class Ftp(Transfer):
         logger.debug("sr_ftp rename %s %s" % (remote_old, remote_new))
         alarm_set(self.o.timeout)
         self.ftp.rename(remote_old, remote_new)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # rmdir
     def rmdir(self, path):
         logger.debug("sr_ftp rmdir %s" % path)
         alarm_set(self.o.timeout)
         self.ftp.rmd(path)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # umask
     def umask(self):
         logger.debug("sr_ftp umask")
         alarm_set(self.o.timeout)
         self.ftp.voidcmd('SITE UMASK 777')
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -239,7 +239,7 @@ class Https(Transfer):
             while True:
                 alarm_set(self.o.timeout)
                 chunk = self.http.read(self.o.bufsize)
-                alarm_cancel()
+                alarm_cancel(self.o.timeout)
                 if not chunk: break
                 if dbuf: dbuf += chunk
                 else: dbuf = chunk
@@ -339,7 +339,7 @@ class Https(Transfer):
 
             self.connected = True
 
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
 
             return True
 
@@ -348,21 +348,21 @@ class Https(Transfer):
             logger.error(
                 'Server couldn\'t fulfill the request. Error code: %s, %s' %
                 (e.code, e.reason))
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             self.connected = False
             raise
         except urllib.error.URLError as e:
             logger.error('Download failed 5 %s ' % self.urlstr)
             logger.error('Failed to reach server. Reason: %s' % e.reason)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             self.connected = False
             raise
         except:
             logger.warning("unable to open %s" % self.urlstr)
             logger.debug('Exception details: ', exc_info=True)
             self.connected = False
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             raise
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return False

--- a/sarracenia/transfer/s3.py
+++ b/sarracenia/transfer/s3.py
@@ -30,7 +30,6 @@ import stat
 import json
 
 from sarracenia.transfer import Transfer
-from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
 
 import boto3, botocore
 from boto3.s3.transfer import TransferConfig

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -86,7 +86,7 @@ class Sftp(Transfer):
         logger.debug("then cd to %s" % path)
         self.sftp.chdir(path)
         self.pwd = path
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # cd forced
     def cd_forced(self, perm, path):
@@ -98,11 +98,11 @@ class Sftp(Transfer):
         self.sftp.chdir(self.originalDir)
         try:
             self.sftp.chdir(path)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             return
         except:
             pass
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
         # need to create subdir
 
@@ -115,7 +115,7 @@ class Sftp(Transfer):
             try:
                 alarm_set(self.o.timeout)
                 self.sftp.chdir(d)
-                alarm_cancel()
+                alarm_cancel(self.o.timeout)
                 continue
             except:
                 pass
@@ -124,7 +124,7 @@ class Sftp(Transfer):
             alarm_set(self.o.timeout)
             self.sftp.mkdir(d, self.o.permDirDefault)
             self.sftp.chdir(d)
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
 
     def check_is_connected(self):
         logger.debug("sr_sftp check_is_connected")
@@ -151,7 +151,7 @@ class Sftp(Transfer):
             self.close()
             retval=False
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return retval
 
     # chmod
@@ -164,7 +164,7 @@ class Sftp(Transfer):
             except Exception as ex:
                 logger.warning( f"chmod {path} failed: {ex}")
                 logging.debug("Exception details:", exc_info=True)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # close
     def close(self):
@@ -184,7 +184,7 @@ class Sftp(Transfer):
             old_ssh.close()
         except:
             pass
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # connect...
     def connect(self):
@@ -231,7 +231,7 @@ class Sftp(Transfer):
             self.connected = True
             self.sftp = sftp
 
-            #alarm_cancel()
+            #alarm_cancel(self.o.timeout)
             return True
 
         except:
@@ -239,7 +239,7 @@ class Sftp(Transfer):
                          (self.host, self.user))
             logger.debug('Exception details: ', exc_info=True)
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return False
 
     # credentials...
@@ -306,7 +306,7 @@ class Sftp(Transfer):
         try:
             s = self.sftp.lstat(path)
         except:
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             return
 
         # proceed with file/link removal
@@ -319,13 +319,13 @@ class Sftp(Transfer):
             logger.debug("sr_sftp rmdir %s" % path)
             self.sftp.rmdir(path)
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     def readlink(self, link):
         logger.debug("%s" % (link))
         alarm_set(self.o.timeout)
         value = self.sftp.readlink(link)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return value
 
     # symlink
@@ -333,7 +333,7 @@ class Sftp(Transfer):
         logger.debug("(in %s), create this file %s as a link to: %s" % (self.getcwd(), path, link) )
         alarm_set(self.o.timeout)
         self.sftp.symlink(link, path)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # get
 
@@ -352,7 +352,7 @@ class Sftp(Transfer):
         rfp = self.sftp.file(remote_file, 'rb', self.o.bufsize)
         if remote_offset != 0: rfp.seek(remote_offset, 0)
         rfp.settimeout(1.0 * self.o.timeout)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
         # read from rfp and write to local_file
 
@@ -364,7 +364,7 @@ class Sftp(Transfer):
 
         alarm_set(self.o.timeout)
         rfp.close()
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
         return rw_length
 
@@ -391,7 +391,7 @@ class Sftp(Transfer):
     def getcwd(self):
         alarm_set(self.o.timeout)
         cwd = self.sftp.getcwd() if self.sftp else None
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         return cwd
 
     # ls
@@ -401,7 +401,7 @@ class Sftp(Transfer):
         # timeout is at least 30 secs, say we wait for max 5 mins
         alarm_set(self.o.timeout)
         dir_attr = self.sftp.listdir_attr()
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
         for index in range(len(dir_attr)):
             attr = dir_attr[index]
             line = attr.__str__()
@@ -439,16 +439,16 @@ class Sftp(Transfer):
             if S_ISDIR(s.st_mode):
                 return
             logger.error( f"cannot mkdir {path}, file exists" )
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             return
         except FileNotFoundError:
             pass
         except:
-            alarm_cancel()
+            alarm_cancel(self.o.timeout)
             return
 
         self.sftp.mkdir(remote_dir, self.o.permDirDefault)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # put
     def put(self,
@@ -482,7 +482,7 @@ class Sftp(Transfer):
             rfp.settimeout(1.0 * self.o.timeout)
             if remote_offset != 0: rfp.seek(remote_offset, 0)
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
         # read from local_file and write to rfp
 
@@ -500,7 +500,7 @@ class Sftp(Transfer):
                 logging.debug("Exception details:", exc_info=True)
 
         rfp.close()
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
         return rw_length
 
@@ -534,14 +534,14 @@ class Sftp(Transfer):
             pass
         alarm_set(self.o.timeout)
         self.sftp.rename(remote_old, remote_new)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # rmdir
     def rmdir(self, path):
         logger.debug("sr_sftp rmdir %s " % path)
         alarm_set(self.o.timeout)
         self.sftp.rmdir(path)
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)
 
     # utime
     def utime(self, path, tup):
@@ -555,4 +555,4 @@ class Sftp(Transfer):
                 logger.warning( f"utime {path} failed: {ex}")
                 logging.debug("Exception details:", exc_info=True)
 
-        alarm_cancel()
+        alarm_cancel(self.o.timeout)

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -56,7 +56,6 @@ class Sftp(Transfer):
         self.connected = False
         self.sftp = None
         self.ssh = None
-        self.fsetstat = True
         self.seek = True
 
         self.batch = 0
@@ -158,7 +157,7 @@ class Sftp(Transfer):
     def chmod(self, perm, path):
         logger.debug("sr_sftp chmod %s %s" % ("{0:o}".format(perm), path))
         alarm_set(self.o.timeout)
-        if self.fsetstat: 
+        if not self.o.nofsetstat: 
             try:
                 self.sftp.chmod(path, perm)
             except Exception as ex:
@@ -253,7 +252,6 @@ class Sftp(Transfer):
             self.host = url.hostname
             self.port = url.port
             self.user = url.username
-            self.fsetstat = not details.nofsetstat
             self.password = url.password
             self.ssh_keyfile = details.ssh_keyfile
 
@@ -492,7 +490,7 @@ class Sftp(Transfer):
 
         alarm_set(self.o.timeout)
         self.fpos = remote_offset + rw_length
-        if self.fsetstat and length != 0: 
+        if not self.o.nofsetstat and length != 0: 
             try:
                 rfp.truncate(self.fpos)
             except Exception as ex:
@@ -548,7 +546,7 @@ class Sftp(Transfer):
         logger.debug("sr_sftp utime %s %s " % (path, tup))
         alarm_set(self.o.timeout)
 
-        if self.fsetstat: 
+        if not self.o.nofsetstat: 
             try:
                 self.sftp.utime(path, tup)
             except Exception as ex:


### PR DESCRIPTION
close #1189 

These are changes that deal with sftp servers.
* wrap truncate/chmod/utime calls in sftp in try/excepts so that the transfers are not considered "failed" if one of those operations fails.
* report a warning about the call failing instead.
* add an nofsetstat option to the sr3_options configs, so that when we know that those operations won't work, don't even generate the warning message.   

passes flow tests, but No tested with a server that restricts the permissions.

@iMacadan  perhaps you can test this in sending to such a client.
