### PR TITLE
Implement HTTP(S) stat using urllib, and HTTPS transfer class minor refactor

### DIFF
--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -26,7 +26,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       osver: [ "ubuntu-20.04", "ubuntu-22.04" ]
+       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow ]
-       osver: [ "ubuntu-22.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
-       osver: [ "ubuntu-22.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -403,22 +403,39 @@ It's named  */this/20160123/pattern/RAW_MERGER_GRIB/directory* if the notificati
 acceptSizeWrong: <boolean> (default: False)
 -------------------------------------------
 
-When a file is downloaded and its size does not match the one advertised, it is
-normally rejected, as a failure. This option accepts the file even with the wrong
-size. helpful when file is changing frequently, and there is some queueing, so
-the file is changed by the time it is retrieved.
+When acceptSizeWrong is set to True, the download accepts the file even if it's size
+does not match what is in the notification message received. This is helpful when 
+resources are changing frequently, and there is some queueing, so the file is changed 
+by the time it is retrieved.
+
+In the default case (acceptSizeWrong set to False), size mismatch is
+considered a download failure. Sarracenia then checks if the 
+what was downloaded matches what is on the upstream server currently.  
+
+If the modification date on the upstream server is newer than in the message::
+
+  2024-08-11 00:00:47,978 [INFO] sarracenia.flow download upstream resource is newer, so message https://hpfx.collab.science.gc.ca //20240811/WXO-DD/citypage_weather/xml/NB/s0000653_e.xml is obsolete. Discarding.
+
+If it does match the upstream size, than no error has occurred on download, 
+it's just that the size of the message announcing the new resource does not 
+match what is currently available. There is no point retrying the download.
+In the both cases, the file downloaded and the corresponding message are both 
+discarded.
+
+If the check of the upstream server fails, or the retrieve itself has failed,
+then it puts the resource on the retry queue for later attempts.
 
 
 attempts <count> (default: 3)
 -----------------------------
 
 The **attempts** option indicates how many times to
-attempt downloading the data before giving up.  The default of 3 should be appropriate
-in most cases.  When the **retry** option is false, the file is then dropped immediately.
+attempt downloading the data before giving up. The default of 3 should be appropriate
+in most cases. When the **retry** option is false, the file is then dropped immediately.
 
 When The **retry** option is set (default), a failure to download after prescribed number
 of **attempts** (or send, in a sender) will cause the notification message to be added to a queue file
-for later retry.  When there are no notification messages ready to consume from the AMQP queue,
+for later retry. When there are no notification messages ready to consume from the AMQP queue,
 the retry queue will be queried.
 
 

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -475,16 +475,16 @@ lowered to 1.  For most usual situations the default is fine. For higher volume
 cases, one could raise it to reduce transfer overhead. It is only used for file
 transfer protocols, not HTTP ones at the moment.
 
-blocksize <size> default: 0 (auto)
+blockSize <size> default: 0 (auto)
 -----------------------------------
 
 NOTE: **EXPERIMENTAL** sr3, expected to return in future version**
-This **blocksize** option controls the partitioning strategy used to post files.
+This **blockSize** option controls the partitioning strategy used to post files.
 The value should be one of::
 
    0 - autocompute an appropriate partitioning strategy (default)
    1 - always send entire files in a single part.
-   <blocksize> - used a fixed partition size (example size: 1M )
+   <blockSize> - used a fixed partition size (example size: 1M )
 
 Files can be announced as multiple parts.  Each part has a separate checksum.
 The parts and their checksums are stored in the cache. Partitions can traverse
@@ -522,10 +522,10 @@ Once connected to an AMQP broker, the user needs to bind a queue
 to exchanges and topics to determine the notification messages of interest.
 
 
-bufsize <size> (default: 1MB)
+bufSize <size> (default: 1MB)
 -----------------------------
 
-Files will be copied in *bufsize*-byte blocks. for use by transfer protocols.
+Files will be copied in *bufSize*-byte blocks. for use by transfer protocols.
 
 
 byteRateMax <size> (default: 0)
@@ -1227,6 +1227,14 @@ fileAgeMin
 If files are newer than this setting (default: 0), then ignore them, they are too
 new to post. 0 deactivates the setting.
 
+fileSizeMax (size: default 0)
+-----------------------------
+
+The default value of *fileSizeMax* is 0, meaning there is no limit. However one may
+wish to prevent downloads of very large files in some situations. Setting a maximum
+file size with the *fileSizeMax* option can be used to prevent unintentional 
+downloading of large data files.
+
 nodupe_ttl <off|on|999[smhdw]> 
 ------------------------------
 
@@ -1544,7 +1552,7 @@ randomize <flag>
 
 Active if *-r|--randomize* appears in the command line... or *randomize* is set
 to True in the configuration file used. If there are several notification messages because the 
-file is posted by block (the *blocksize* option was set), the block notification messages 
+file is posted by block (the *blockSize* option was set), the block notification messages 
 are randomized meaning that they will not be posted
 
 realpathAdjust <count> (Experimental) (default: 0)

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -404,16 +404,44 @@ normalement rejeté, comme un échec. Cette option accepte le fichier même avec
 taille. Cela est utile lorsque le fichier change fréquemment, et qu’il passe en fil d’attente, donc
 le fichier est modifié au moment de sa récupération.
 
+Lorsque acceptSizeWrong est défini sur True, le téléchargement accepte le fichier même si sa taille
+ne correspond pas à celle du message de notification reçu. Cela est utile lorsque
+les ressources changent fréquemment et qu'il y a une file d'attente, de sorte que le fichier 
+est modifié au moment où il est récupéré.
+
+Dans le cas par défaut (acceptSizeWrong défini sur False), l'incompatibilité de taille est
+considérée comme un échec de téléchargement. Sarracenia vérifie ensuite si
+ce qui a été téléchargé correspond à ce qui se trouve actuellement sur le serveur en amont.
+
+Si la date de modification sur le serveur en amont est plus récente que dans le message::
+
++  2024-08-11 00:00:47,978 [INFO] sarracenia.flow download upstream resource is newer, so message https://hpfx.collab.science.gc.ca //20240811/WXO-DD/citypage_weather/xml/NB/s0000653_e.xml is obsolete. Discarding.
+
+traduction::
+
+   2024-08-11 00:00:47,978 [INFO] la ressource en amont est plus récente, donc le message https://hpfx.collab.science.gc.ca //20240811/WXO-DD/citypage_weather/xml/NB/s0000653_e.xml est obsolète. on abandonne le traitement du message.
+
+Si elle correspond à la taille en amont, alors aucune erreur ne s'est produite lors du téléchargement,
+c'est juste que la taille du message annonçant la nouvelle ressource ne
+correspond pas à ce qui est actuellement disponible. Il est inutile de réessayer le téléchargement.
+Dans les deux cas, le fichier téléchargé et le message correspondant sont tous deux
+rejetés.
+
+Si la vérification du serveur en amont échoue, ou si la récupération elle-même a échoué,
+alors la ressource est placée dans la file d'attente de nouvelles tentatives pour des tentatives ultérieures.
+
+
+
 attempts <count> (défaut: 3)
 -----------------------------
 
 L’option **attempts** indique combien de fois il faut tenter le téléchargement des données avant d’abandonner.
-Le défaut de 3 tentatives est approprié dans la plupart des cas.  Lorsque l’option **retry** a la valeur false,
+Le défaut de 3 tentatives est approprié dans la plupart des cas. Lorsque l’option **retry** a la valeur false,
 le fichier est immédiatement supprimé.
 
 Lorsque l’option **attempts** est utilisé, un échec de téléchargement après le numéro prescrit
 des **attempts** (ou d’envoi, pour un sender) va entrainer l’ajout du message d'annonce à un fichier de fil d’attente
-pour une nouvelle tentative plus tard.  Lorsque aucun message d'annonce n’est prêt à être consommé dans la fil d’attente AMQP,
+pour une nouvelle tentative plus tard. Lorsque aucun message d'annonce n’est prêt à être consommé dans la fil d’attente AMQP,
 les requêtes se feront avec la fil d’attente de "retry".
 
 baseDir <chemin> (défaut: /)

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -476,16 +476,16 @@ ajuster à 1.  Pour la plupart des situations, le défaut est bien. Pour un volu
 on pourrait l’augmenter pour réduire les frais généraux de transfert. Cette option est seulement utilisé pour les
 protocoles de transfert de fichiers, et non HTTP pour le moment.
 
-blocksize <size> défaut: 0 (auto)
+blockSize <size> défaut: 0 (auto)
 -----------------------------------
 
 REMARQUE: **EXPERIMENTAL pour sr3, devrait revenir dans la version future**
-Cette option **blocksize** contrôle la stratégie de partitionnement utilisée pour publier des fichiers.
+Cette option **blockSize** contrôle la stratégie de partitionnement utilisée pour publier des fichiers.
 La valeur doit être l’une des suivantes ::
 
    0 - calcul automatiquement une stratégie de partitionnement appropriée (défaut).
    1 - envoyez toujours des fichiers entiers en une seule partie.
-   <blocksize> - utiliser une taille de partition fixe (taille d’exemple : 1M ).
+   <blockSize> - utiliser une taille de partition fixe (taille d’exemple : 1M ).
 
 Les fichiers peuvent être annoncés en plusieurs parties.  Chaque partie à un somme de contrôle (checksum) distinct.
 Les parties et leurs somme de contrôle sont stockées dans la cache. Les partitions peuvent traverser
@@ -522,10 +522,10 @@ L’option broker indique à chaque composant quel courtier contacter.
 Une fois connecté à un courtier AMQP, l’utilisateur doit lier une fil d’attente
 aux échanges et aux thèmes pour déterminer le messages d'annonce en question.
 
-bufsize <size> (défaut: 1m)
+bufSize <size> (défaut: 1m)
 ---------------------------
 
-Les fichiers seront copiés en tranches de *bufsize* octets. Utilisé par les protocoles de transfert.
+Les fichiers seront copiés en tranches de *bufSize* octets. Utilisé par les protocoles de transfert.
 
 byteRateMax <size> (défaut: 0)
 ------------------------------
@@ -1218,6 +1218,16 @@ fileAgeMin
 Si les fichiers sont plus neuf que ce paramètre (défaut: 0 ... désactivé), ignorez-les, ils sont trop
 neufs pour qu'ils puissent être postés.
 
+
+fileSizeMax (size: default 0)
+-----------------------------
+
+La valeur par défaut de *fileSizeMax* est 0, ce qui signifie qu'il n'y a pas de limite. Cependant, on peut
+souhaiter empêcher le téléchargement de fichiers très volumineux dans certaines situations. La définition d'une
+taille de fichier maximale avec l'option *fileSizeMax* peut être utilisée pour empêcher le
+téléchargement involontaire de fichiers de données volumineux.
+
+
 nodupe_ttl <off|on|999[smhdw]>
 ------------------------------
 
@@ -1535,7 +1545,7 @@ randomize <flag>
 
 Actif si *-r|--randomize* apparaît dans la ligne de commande... ou *randomize* est défini
 à True dans le fichier de configuration utilisé. S’il y a plusieurs postes parce que
-le fichier est publié par bloc (l’option *blocksize* a été définie), les messages d'annonce de bloc
+le fichier est publié par bloc (l’option *blockSize* a été définie), les messages d'annonce de bloc
 sont randomisés, ce qui signifie qu’ils ne seront pas affichés.
 
 realpathAdjust <compte> (Experimental) (défaut: 0)

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -371,6 +371,7 @@ known_report_codes = {
     206: "Partial Content: received and inserted.",
     304: "Not modified (Checksum validated, unchanged, so no download resulted.)",
     307: "Insertion deferred (writing to temporary part file for the moment.)",
+    410: "Gone: server data different from notification message",
     417: "Expectation Failed: invalid notification message (corrupt headers)",
     422: "Unprocessable Content: could not determine path to transfer to",
     499: "Failure: Not Copied. SFTP/FTP/HTTP download problem",

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -784,11 +784,11 @@ class Message(dict):
         if 'baseUrl' in msg:
             s+=msg['baseUrl']+' '
         if 'relPath' in msg:
-            if s and s[-1] != '/':
+            if msg['relPath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+=msg['relPath']
         elif 'retrievePath' in msg:
-            if s and s[-1] != '/':
+            if msg['retrievePath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+= msg['retrievePath']
         else:

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -475,7 +475,7 @@ class Message(dict):
                         fp.seek( offset )
 
                     while i < offset+msg['size']:
-                        buf = fp.read(o.bufsize)
+                        buf = fp.read(o.bufSize)
                         if not buf: break
                         sumalgo.update(buf)
                         i += len(buf)
@@ -661,10 +661,10 @@ class Message(dict):
         elif hasattr(o, 'exchange'):
             msg['exchange'] = o.exchange
 
-        if hasattr(o, 'blocksize') and (o.blocksize > 1) and lstat and \
+        if hasattr(o, 'blockSize') and (o.blockSize > 1) and lstat and \
                 (os_stat.S_IFMT(lstat.st_mode) == os_stat.S_IFREG) and \
-                (lstat.st_size > o.blocksize):
-           msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blocksize, 'manifest': {}  }
+                (lstat.st_size > o.blockSize):
+           msg['blocks'] = { 'method': 'inplace', 'number':-1, 'size': o.blockSize, 'manifest': {}  }
 
         msg['local_offset'] = 0
         msg['_deleteOnPost'] = set(['exchange', 'local_offset', 'subtopic', '_format'])
@@ -783,11 +783,13 @@ class Message(dict):
         s=""
         if 'baseUrl' in msg:
             s+=msg['baseUrl']+' '
-        if 'relPath' in msg:
+        else:
+            s+="baseUrl missing "
+        if 'relPath' in msg and len(msg['relPath']) > 0:
             if msg['relPath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+=msg['relPath']
-        elif 'retrievePath' in msg:
+        elif 'retrievePath' in msg and len(msg['retrievePath']) > 0 :
             if msg['retrievePath'][0] != '/' and s and s[-1] != '/':
                 s+='/'
             s+= msg['retrievePath']
@@ -1025,7 +1027,7 @@ class Message(dict):
         # ide
         #if isinstance(data, io.IOBase ):
         #    with open(opath, 'wb') as f:
-        #        while buf = data.read(self.o.bufsize) > 0 :
+        #        while buf = data.read(self.o.bufSize) > 0 :
         #            sz=f.write(buf)
 
         if 'content' in msg:

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -171,7 +171,7 @@ set_choices = {
  
 perm_options = [ 'permDefault', 'permDirDefault','permLog']
 
-size_options = ['accelThreshold', 'blocksize', 'bufsize', 'byteRateMax', 'inlineByteMax']
+size_options = ['accelThreshold', 'blockSize', 'bufSize', 'byteRateMax', 'fileSizeMax', 'inlineByteMax']
 
 str_options = [
     'action', 'admin', 'baseDir', 'broker', 'cluster', 'directory', 'exchange',
@@ -703,6 +703,8 @@ class Config:
         'base_dir': 'baseDir',
         'baseurl': 'baseUrl',
         'bind_queue': 'queueBind',
+        'blocksize': 'blockSize', 
+        'bufsize': 'bufSize',
         'cache': 'nodupe_ttl',
         'c': 'include',
         'cb': 'nodupe_basis',
@@ -832,7 +834,7 @@ class Config:
             for i in parent:
                 setattr(self, i, parent[i])
 
-        self.bufsize = 1024 * 1024
+        self.bufSize = 1024 * 1024
         self.byteRateMax = 0
 
         self.fileAgeMax = 0 # disabled.
@@ -854,6 +856,7 @@ class Config:
         self.plugins_late = []
         self.plugins_early = []
         self.exchange = None
+        self.fileSizeMax = 0
         self.filename = None
         self.fixed_headers = {}
         self.flatten = '/'
@@ -2501,7 +2504,7 @@ class Config:
                             nargs='?',
                             help='how many transfers per each connection')
         parser.add_argument(
-            '--blocksize',
+            '--blockSize',
             type=int,
             nargs='?',
             help=

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1889,7 +1889,7 @@ class Flow:
                     logger.warning("downloading again, attempt %d" % i)
 
                 ok = self.download(msg, self.o)
-                if ok==1:
+                if ok == 1:
                     logger.debug("downloaded ok: %s" % new_path)
                     msg.setReport(201, "Download successful" )
                     # if content is present, but downloaded anyways, then it is no good, and should not be forwarded.
@@ -1898,7 +1898,7 @@ class Flow:
                     self.worklist.ok.append(msg)
                     self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
                     break
-                elif ok==-1:
+                elif ok == -1:
                     logger.debug("download failed permanently, discarding transfer: %s" % new_path)
                     msg.setReport(410, "message received for content that is no longer available" )
                     self.worklist.rejected.append(msg)
@@ -2211,13 +2211,13 @@ class Flow:
                                 mtime = sarracenia.timestr2flt(msg['pubTime'])
 
                             if current_stat and current_stat.st_mtime > mtime:
-                                logger.error( f'upstream source has changed, message obsolete. ' )
+                                logger.info( f'upstream resource is newer, so message {msg.getIDStr()} is obsolete. Discarding.' )
                                 retval=-1
                             elif current_stat and current_stat.st_size == len_written:
-                                logger.warning( f'downloads ok, but upstream source not as announced. Perhaps AcceptSizeWrong? ' )
+                                logger.info( f'download matches upstream source, {msg.getIDStr()} but not announcement. Discarding.' )
                                 retval=-1 
                             else:
-                                logger.error( f"unexplained size discrepancy, will retry later" )
+                                logger.error( f"unexplained size discrepancy in {msg.getIDStr()}, will retry later" )
                         elif len_written > block_length:
                             logger.error( f'download more {len_written} than expected {block_length} bytes for {new_inflight_path}' )
                         else:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1292,7 +1292,7 @@ class Flow:
                     mfn.write( f'\"{timestamp}\" : {metrics},\n')
 
             # removing old metrics files
-            logger.debug( f"looking for old metrics for {self.o.metricsFilename}" )
+            #logger.debug( f"looking for old metrics for {self.o.metricsFilename}" )
             old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
             for o in old_metrics:
                 logger.info( f"removing old metrics file: {o} " )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2215,11 +2215,11 @@ class Flow:
                             else:
                                 mtime = sarracenia.timestr2flt(msg['pubTime'])
 
-                            if current_stat and current_stat.st_mtime > mtime:
+                            if current_stat and current_stat.st_mtime and current_stat.st_mtime > mtime:
                                 logger.info( f'upstream resource is newer, so message {msg.getIDStr()} is obsolete. Discarding.' )
                                 retval=-1
-                            elif current_stat and current_stat.st_size == len_written:
-                                logger.info( f'download matches upstream source, {msg.getIDStr()} but not announcement. Discarding.' )
+                            elif current_stat and current_stat.st_size and current_stat.st_size == len_written:
+                                logger.info( f'matches upstream source, {msg.getIDStr()} but not announcement. Discarding.' )
                                 retval=-1 
                             else:
                                 logger.error( f"unexplained size discrepancy in {msg.getIDStr()}, will retry later" )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -235,7 +235,7 @@ class Flow:
         self.metrics=self.new_metrics
 
         # removing old metrics files
-        logger.info( f"looking for old metrics for {self.o.metricsFilename}" )
+        #logger.debug( f"looking for old metrics for {self.o.metricsFilename}" )
         old_metrics=sorted(glob.glob(self.o.metricsFilename+'.*'))[0:-self.o.logRotateCount]
         for o in old_metrics:
             logger.info( f"removing old metrics file: {o} " )

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1804,6 +1804,12 @@ class Flow:
                         self.reject(msg, 500, "link %s failed" % msg['fileOp'])
                     continue
 
+            # all non-files taken care of above... rest of routine is normal file download.
+
+            if self.o.fileSizeMax > 0 and msg['size'] > self.o.fileSizeMax:
+                self.reject(msg, 413, f"Payload Too Large {msg.getIDStr()}")
+                continue
+
             # establish new_inflight_path which is the file to download into initially.
             if self.o.inflight == None or (
                 ('blocks' in msg) and (msg['blocks']['method'] == 'inplace')):

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1528,11 +1528,10 @@ class Flow:
             )
             return True
 
-        logger.debug("checksum in message: %s vs. local: %s" %
-                     (msg['identity'], msg['local_identity']))
+        logger.debug( f"checksum in message: {msg['identity']} vs. local: {msg['local_identity']}" )
 
         if msg['local_identity'] == msg['identity']:
-            self.reject(msg, 304, "same checksum %s " % (msg['new_path']))
+            self.reject(msg, 304, f"same checksum {msg['new_path']}" )
             return False
         else:
             return True

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 default_options = {
     'acceptUnmatched': True,
-    'blocksize': 1,
-    'bufsize': 1024 * 1024,
+    'blockSize': 1,
+    'bufSize': 1024 * 1024,
     'chmod': 0o400,
     'pollUrl': None,
     'follow_symlinks': False,

--- a/sarracenia/flow/post.py
+++ b/sarracenia/flow/post.py
@@ -5,8 +5,8 @@ logger = logging.getLogger(__name__)
 
 default_options = {
     'acceptUnmatched': True,
-    'blocksize': 1,
-    'bufsize': 1024 * 1024,
+    'blockSize': 1,
+    'bufSize': 1024 * 1024,
     'follow_symlinks': False,
     'force_polling': False,
     'inflight': None,

--- a/sarracenia/flow/watch.py
+++ b/sarracenia/flow/watch.py
@@ -5,8 +5,8 @@ logger = logging.getLogger(__name__)
 
 default_options = {
     'acceptUnmatched': True,
-    'blocksize': 1,
-    'bufsize': 1024 * 1024,
+    'blockSize': 1,
+    'bufSize': 1024 * 1024,
     'follow_symlinks': False,
     'force_polling': False,
     'inflight': None,

--- a/sarracenia/flowcb/block_reassembly.py
+++ b/sarracenia/flowcb/block_reassembly.py
@@ -56,7 +56,7 @@ class Block_reassembly(FlowCB):
        given the reassemble setting is on, and have received a block file,
        then:
 
-       * partition file is whose name ends in §block_<blokno>,<blocksize>_§
+       * partition file is whose name ends in §block_<blokno>,<blockSize>_§
        * determing the inflight_file name for the entire file.
        * lock the inflight_file.
        * place the block in the working file.
@@ -206,14 +206,14 @@ class Block_reassembly(FlowCB):
             rf.seek(offset)     
 
             # copy data from block partition file into final destination.
-            sz=self.o.bufsize if self.o.bufsize > byteCount else byteCount
+            sz=self.o.bufSize if self.o.bufSize > byteCount else byteCount
             bytesTransferred=0
             while bytesTransferred < byteCount: 
                 b = pf.read(sz)
                 rf.write(b)
                 bytesTransferred += len(b)
                 bytesLeft = byteCount - bytesTransferred
-                sz=self.o.bufsize if self.o.bufsize > bytesLeft else bytesLeft
+                sz=self.o.bufSize if self.o.bufSize > bytesLeft else bytesLeft
 
             rf.close()
             pf.close()

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -114,7 +114,7 @@ class File(FlowCB):
         self.new_events = OrderedDict()
         self.left_events = OrderedDict()
 
-        #self.o.blocksize = 200 * 1024 * 1024
+        #self.o.blockSize = 200 * 1024 * 1024
         self.o.create_modify = ('create' in self.o.fileEvents) or (
             'modify' in self.o.fileEvents)
 
@@ -144,10 +144,10 @@ class File(FlowCB):
     def post_file(self, path, lstat, key=None, value=None):
         #logger.debug("start  %s" % path)
 
-        # check the value of blocksize
+        # check the value of blockSize
 
         fsiz = lstat.st_size
-        blksz = self.set_blocksize(self.o.blocksize, fsiz)
+        blksz = self.set_blockSize(self.o.blockSize, fsiz)
 
         # if we should send the file in parts
 
@@ -210,10 +210,10 @@ class File(FlowCB):
         msg = sarracenia.Message.fromFileInfo(path, self.o, lstat)
 
         logger.debug( f"initial msg:{msg}" )
-        # check the value of blocksize
+        # check the value of blockSize
 
         fsiz = lstat.st_size
-        chunksize = self.set_blocksize(self.o.blocksize, fsiz)
+        chunksize = self.set_blockSize(self.o.blockSize, fsiz)
 
         # count blocks and remainder
 
@@ -482,11 +482,11 @@ class File(FlowCB):
             return (True, self.post1file(src, lstat))
         return (True, [])
 
-    def set_blocksize(self, bssetting, fsiz):
+    def set_blockSize(self, bssetting, fsiz):
 
         tfactor = 50 * 1024 * 1024
 
-        if bssetting == 0:  ## default blocksize
+        if bssetting == 0:  ## default blockSize
             return tfactor
 
         elif bssetting == 1:  ## send file as one piece.

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -370,7 +370,7 @@ class Transfer():
         # 2022/12/02 - pas should see a lot of these messages in HPC case from now on...
         
         if not self.o.acceptSizeWrong and length != 0 and rw_length != length:
-            logger.warning(
+            logger.debug(
                 "util/writelocal mismatched file length writing %s. Message said to expect %d bytes.  Got %d bytes."
                 % (local_file, length, rw_length))
 

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -139,7 +139,7 @@ class Transfer():
      * permDirDefault - what permission to set on directories created.
      * timeout  - how long to wait for operations to complete.
      * byteRateMax - maximum transfer rate (throttle to avoid exceeding)
-     * bufsize - size of buffers for file transfers.
+     * bufSize - size of buffers for file transfers.
 
     """
     @staticmethod
@@ -290,7 +290,7 @@ class Transfer():
         if length == 0:
             while True:
                 if self.o.timeout: alarm_set(self.o.timeout)
-                chunk = src.read(self.o.bufsize)
+                chunk = src.read(self.o.bufSize)
                 if chunk:
                     new_chunk = self.on_data(chunk)
                     rw_length += len(new_chunk)
@@ -304,15 +304,15 @@ class Transfer():
 
         # exact length to be transfered
 
-        nc = int(length / self.o.bufsize)
-        r = length % self.o.bufsize
+        nc = int(length / self.o.bufSize)
+        r = length % self.o.bufSize
 
-        # read/write bufsize "nc" times
+        # read/write bufSize "nc" times
 
         i = 0
         while i < nc:
             if self.o.timeout: alarm_set(self.o.timeout)
-            chunk = src.read(self.o.bufsize)
+            chunk = src.read(self.o.bufSize)
             if chunk:
                 new_chunk = self.on_data(chunk)
                 rw_length += len(new_chunk)

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 #           options.permDefault
 #           options.permDirDefault
 #     opt   options.byteRateMax
-#     opt   options.bufsize
+#     opt   options.bufSize
 
 
 class File(Transfer):
@@ -197,7 +197,7 @@ def file_insert(options, msg):
     fp = open(msg['relPath'], 'rb')
     if msg.partflg == 'i': fp.seek(msg['offset'], 0)
 
-    ok = file_write_length(fp, msg, options.bufsize, msg.filesize, options)
+    ok = file_write_length(fp, msg, options.bufSize, msg.filesize, options)
 
     fp.close()
 

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -163,8 +163,10 @@ class File(Transfer):
 
     def stat(self,path,message=None):
         spath = path if path[0] == '/' else self.path + '/' + path
-        return sarracenia.stat(spath)
-
+        try:
+             return sarracenia.stat(spath)
+        except:
+             return None
     # ls
     def ls(self):
         logger.debug("sr_file ls")

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -162,7 +162,7 @@ class File(Transfer):
         return self.cwd
 
     def stat(self,path,message=None):
-        spath = path if path[0] == '/' else self.cwd + '/' + path
+        spath = path if path[0] == '/' else self.path + '/' + path
         return sarracenia.stat(spath)
 
     # ls

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -161,6 +161,10 @@ class File(Transfer):
     def getcwd(self):
         return self.cwd
 
+    def stat(self,path,message=None):
+        spath = path if path[0] == '/' else self.cwd + '/' + path
+        return sarracenia.stat(spath)
+
     # ls
     def ls(self):
         logger.debug("sr_file ls")

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -313,7 +313,7 @@ class Ftp(Transfer):
         try:
             if self.binary:
                 self.ftp.retrbinary('RETR ' + remote_file, self.write_chunk,
-                                self.o.bufsize)
+                                self.o.bufSize)
             else:
                 self.ftp.retrlines('RETR ' + remote_file, self.write_chunk)
         except Exception as Ex:
@@ -424,7 +424,7 @@ class Ftp(Transfer):
         self.write_chunk_init(None)
         try:
             if self.binary:
-                self.ftp.storbinary("STOR " + remote_file, src, self.o.bufsize,
+                self.ftp.storbinary("STOR " + remote_file, src, self.o.bufSize,
                                 self.write_chunk)
             else:
                 self.ftp.storlines("STOR " + remote_file, src, self.write_chunk)

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -383,7 +383,7 @@ class Https(Transfer):
         url += path
 
         try:
-            resp = requests.head(url)
+            resp = requests.head(url, headers = {'Accept-Encoding': 'identity'} )
             resp.raise_for_status()
 
             # parse the HTTP header response into the stat object used by sr3

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -34,9 +34,23 @@ from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
 
 import urllib.error, urllib.parse, urllib.request
 from urllib.parse import unquote
+from urllib.request import HTTPRedirectHandler 
 
 logger = logging.getLogger(__name__)
 
+class HTTPRedirectHandlerSameMethod(HTTPRedirectHandler):
+    """ Instead of returning a new Request without a method (defaults to GET), use the 
+        same method in the new Request.
+        https://docs.python.org/3/library/urllib.request.html#urllib.request.HTTPRedirectHandler.redirect_request
+        https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections note [2]
+    """
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        orig_method = req.get_method()
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        new_req.method = orig_method
+        logger.debug(f"redirect from {req.get_method()} {req.get_full_url()} "
+                     + f"to {new_req.get_method()} {new_req.get_full_url()}")
+        return new_req
 
 class Https(Transfer):
     """
@@ -209,6 +223,7 @@ class Https(Transfer):
         self.http = None
         self.details = None
         self.seek = True
+        self.opener = None
 
         self.urlstr = ''
         self.path = ''
@@ -260,14 +275,33 @@ class Https(Transfer):
 
         return dbuf
 
+    def __url_redir_str(self):
+        """ Returl self.urlstr, unless the request was redirected to a different URL.
+            If so, it will return 'self.urlstr redirected to new_url'
+        """
+        redir_msg = self.urlstr
+        try:
+            actual_url = self.http.geturl()
+            if actual_url != self.urlstr:
+                redir_msg = redir_msg + f" redirected to {actual_url}"
+        except:
+            pass
+        return redir_msg
+
     # open
-    def __open__(self, path, remote_offset=0, length=0, method:str=None, add_headers:dict=None):
-        logger.debug( f"{path}")
+    def __open__(self, path, remote_offset=0, length=0, method:str=None, add_headers:dict=None, handlers:list=[]) -> bool:
+        """ Open a URL. When the open is successful, self.http is set to a urllib.response instance that can be
+            read from like a file.
+
+            Returns True when successfully opened, False if there was a problem.
+        """
+        logger.debug( f"{path} " + (method if method else ''))
 
         self.http = None
         self.connected = False
         self.req = None
         self.urlstr = path
+        self.opener = None 
 
         # have noticed that some site does not allow // in path
         if path.startswith('http://') and '//' in path[7:]:
@@ -279,16 +313,25 @@ class Https(Transfer):
         alarm_set(self.o.timeout)
 
         try:
-            # when credentials are needed.
             headers = {'user-agent': 'Sarracenia ' + sarracenia.__version__}
+            
+            # Bearer token credential is passed as a header
             if self.bearer_token:
                 logger.debug('bearer_token: %s' % self.bearer_token)
                 headers['Authorization'] = 'Bearer ' + self.bearer_token
+
+            # set range in byte if needed
+            if remote_offset != 0:
+                str_range = 'bytes=%d-%d' % (remote_offset, remote_offset + length - 1)
+                headers['Range'] = str_range
+            
+            # add everything from add_headers dict into headers dict. if anything in add_headers already
+            # exists in headers, the values from add_headers will replace the values in headers.
+            # This is done last to allow add_headers values to override Range/Authorization.
             if add_headers:
-                # add everything from add_headers dict into headers dict. if anything in add_headers already
-                # exists in headers, the values from add_headers will replace the values in headers.
                 headers.update(add_headers)
 
+            # username and password credentials
             if self.user != None:
                 password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
                 # takeaway credentials info from urlstr
@@ -299,57 +342,44 @@ class Https(Transfer):
                     self.urlstr = self.urlstr.replace(cred, '')
 
                 # continue with authentication
-                password_mgr.add_password(None, self.urlstr, self.user,
-                                          unquote(self.password))
-                auth_handler = urllib.request.HTTPBasicAuthHandler(
-                    password_mgr)
+                password_mgr.add_password(None, self.urlstr, self.user, unquote(self.password))
+                auth_handler = urllib.request.HTTPBasicAuthHandler(password_mgr)
+                handlers.append(auth_handler)
 
-                #hctx = ssl.create_default_context()
-                #hctx.check_hostname = False
-                #hctx.verify_mode = ssl.CERT_NONE
-                ssl_handler = urllib.request.HTTPSHandler(0, self.tlsctx)
+            ssl_handler = urllib.request.HTTPSHandler(0, self.tlsctx)
+            handlers.append(ssl_handler)
 
-                # create "opener" (OpenerDirector instance)
-                opener = urllib.request.build_opener(auth_handler, ssl_handler)
+            # create "opener" (OpenerDirector instance)
+            self.opener = urllib.request.build_opener(*handlers)
 
-                # use the opener to fetch a URL
-                opener.open(self.urlstr)
-
-                # Install the opener.
-                urllib.request.install_opener(opener)
-
-            # Now all calls to get the request use our opener.
+            # Install the opener. Now all calls to get the request use our opener.
+            # NOTE not necessary since we call opener.open directly. Install only needed if we want to use urlopen.
+            # urllib.request.install_opener(opener)
+ 
+            # Build the request that will get opened. If None is passed to method it defaults to GET.
             self.req = urllib.request.Request(self.urlstr, headers=headers, method=method)
-
-            # set range in byte if needed
-            if remote_offset != 0:
-                str_range = 'bytes=%d-%d' % (remote_offset,
-                                             remote_offset + length - 1)
-                self.req.headers['Range'] = str_range
-
-            # https without user : create/use an ssl context
-            ctx = None
-            if self.user == None and self.urlstr.startswith('https'):
-                ctx = self.tlsctx
-                #ctx.check_hostname = False
-                #ctx.verify_mode = ssl.CERT_NONE
 
             # open... we are connected
             if self.timeout == None:
-                self.http = urllib.request.urlopen(self.req, context=ctx)
+                # when timeout is not passed, urllib defaults to socket._GLOBAL_DEFAULT_TIMEOUT
+                self.http = self.opener.open(self.req)
             else:
-                self.http = urllib.request.urlopen(self.req,
-                                                   timeout=self.timeout,
-                                                   context=ctx)
+                self.http = self.opener.open(self.req, timeout=self.timeout)
+
+            # knowing if we got redirected is useful for debugging
+            try:
+                actual_url = self.http.geturl()
+                if actual_url != self.urlstr:
+                    logger.debug(f"{self.urlstr} redirected to {actual_url}")
+            except:
+                pass
 
             self.connected = True
-
             alarm_cancel()
-
-            return True
+            return self.connected
 
         except urllib.error.HTTPError as e:
-            logger.error('Download failed 4 %s ' % self.urlstr)
+            logger.error(f'failed 4 {self.__url_redir_str()}')
             logger.error(
                 'Server couldn\'t fulfill the request. Error code: %s, %s' %
                 (e.code, e.reason))
@@ -357,13 +387,13 @@ class Https(Transfer):
             self.connected = False
             raise
         except urllib.error.URLError as e:
-            logger.error('Download failed 5 %s ' % self.urlstr)
+            logger.error(f'failed 5 {self.__url_redir_str()}')
             logger.error('Failed to reach server. Reason: %s' % e.reason)
             alarm_cancel()
             self.connected = False
             raise
         except:
-            logger.warning("unable to open %s" % self.urlstr)
+            logger.error(f'unable to open {self.__url_redir_str()}')
             logger.debug('Exception details: ', exc_info=True)
             self.connected = False
             alarm_cancel()
@@ -374,7 +404,7 @@ class Https(Transfer):
     
     def stat(self,path,msg) -> sarracenia.filemetadata.FmdStat:
         st = sarracenia.filemetadata.FmdStat()
-        #logger.debug( f" baseUrl:{msg['baseUrl']}, path:{self.path}, cwd:{self.cwd}, path:{path} " )
+        # logger.debug( f" baseUrl:{msg['baseUrl']}, path:{self.path}, cwd:{self.cwd}, path:{path} " )
 
         url = msg['baseUrl']
         if msg['baseUrl'][-1] != '/' and self.path[0] != '/' :
@@ -384,20 +414,17 @@ class Https(Transfer):
             url += '/' 
         url += path
 
-        ok = self.__open__(url, method='HEAD', add_headers={'Accept-Encoding': 'identity'})
+        # Default HTTPRedirectHandler may change a HEAD request to a GET when following the redirect.
+        handlers = [ HTTPRedirectHandlerSameMethod() ]
+        ok = self.__open__(url, method='HEAD', add_headers={'Accept-Encoding': 'identity'}, handlers=handlers)
         if not ok:
+            logger.debug(f"failed")
             return None
-        status_code =  self.http.getcode()
+        status_code = self.http.getcode()
         if status_code != 200:
+            logger.debug(f"status code {status_code}")
             return None
-
-        # POSSIBLE PROBLEM: if the server redirects the URL we requested, then the method will be ignored and we'll
-        # end up doing a GET, which is a waste of bandwidth and slower.
-        # Discussion here: https://stackoverflow.com/a/29327717
-        # https://github.com/python/cpython/blob/6e6855950a1891713369a6cdc84670c38d9388f0/Lib/urllib/request.py#L678-L681
-        # Need to confirm if this is (still) true, then probably need to subclass HTTPRedirectHandler to do a HEAD request
-        # any time we get redirected. Requests automatically handled this for us :-(
-
+        
         have_metadata = False
         try:
             # Content-Length: 9659
@@ -405,14 +432,14 @@ class Https(Transfer):
             have_metadata = True
         except:
             pass
-
         try: 
             # Last-Modified: Thu, 22 Aug 2024 20:37:53 GMT
             lm = self.http.getheader('Last-Modified')
             lm = datetime.datetime.strptime(lm, '%a, %d %b %Y %H:%M:%S GMT').timestamp()
-            st.st_atime = lm
-            st.st_mtime = lm
-            have_metadata = True
+            if lm:
+                st.st_atime = lm
+                st.st_mtime = lm
+                have_metadata = True
         except:
             pass
 
@@ -420,5 +447,10 @@ class Https(Transfer):
             return st
         else:
             logger.warning(f"failed, HEAD request returned {status_code} but metadata was not available for {url}")
+            try:
+                result = str(self.http.info()).replace('\n', ' , ').strip()
+            except Exception as e:
+                result = e
+            logger.debug(f"HEAD request for {self.__url_redir_str()} result: {result}")
 
         return None

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -240,7 +240,7 @@ class Https(Transfer):
             dbuf = None
             while True:
                 alarm_set(self.o.timeout)
-                chunk = self.http.read(self.o.bufsize)
+                chunk = self.http.read(self.o.bufSize)
                 alarm_cancel()
                 if not chunk: break
                 if dbuf: dbuf += chunk

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -372,16 +372,15 @@ class Https(Transfer):
     def stat(self,path,msg) -> sarracenia.filemetadata.FmdStat:
         st = sarracenia.filemetadata.FmdStat()
 
+        #logger.debug( f" baseUrl:{msg['baseUrl']}, path:{self.path}, cwd:{self.cwd}, path:{path} " )
 
         url = msg['baseUrl']
-        if msg['baseUrl'][-1] != '/' and self.cwd[0] != '/' :
+        if msg['baseUrl'][-1] != '/' and self.path[0] != '/' :
             url += '/' 
-        url += self.cwd
-        logger.critical( f" 1 url={url}")
+        url += self.path
         if url[-1] != '/':
             url += '/' 
         url += path
-        logger.critical( f" 2 url={url}")
 
         try:
             resp = requests.head(url)

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -531,7 +531,10 @@ class Sftp(Transfer):
 
     #when sftp is active, paramiko is present... STFPAttributes is then the same as FmdStat.
     def stat(self, path, msg=None) -> sarracenia.filemetadata.FmdStat:
-        return self.sftp.stat(path)
+        try:
+            return self.sftp.stat(path)
+        except:
+            return None
 
     # utime
     def utime(self, path, tup):

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -341,7 +341,7 @@ class Sftp(Transfer):
             (remote_file, local_file, remote_offset, local_offset, length, exactLength))
 
         alarm_set(2 * self.o.timeout)
-        rfp = self.sftp.file(remote_file, 'rb', self.o.bufsize)
+        rfp = self.sftp.file(remote_file, 'rb', self.o.bufSize)
         if remote_offset != 0: rfp.seek(remote_offset, 0)
         rfp.settimeout(1.0 * self.o.timeout)
         alarm_cancel()
@@ -459,7 +459,7 @@ class Sftp(Transfer):
         alarm_set(2 * self.o.timeout)
 
         if length == 0:
-            rfp = self.sftp.file(remote_file, 'wb', self.o.bufsize)
+            rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
             rfp.settimeout(1.0 * self.o.timeout)
 
         # parts
@@ -467,10 +467,10 @@ class Sftp(Transfer):
             try:
                 self.sftp.stat(remote_file)
             except:
-                rfp = self.sftp.file(remote_file, 'wb', self.o.bufsize)
+                rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
                 rfp.close()
 
-            rfp = self.sftp.file(remote_file, 'r+b', self.o.bufsize)
+            rfp = self.sftp.file(remote_file, 'r+b', self.o.bufSize)
             rfp.settimeout(1.0 * self.o.timeout)
             if remote_offset != 0: rfp.seek(remote_offset, 0)
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -25,6 +25,7 @@ import logging, paramiko, os, subprocess, sys, time
 from paramiko import *
 from stat import *
 
+import sarracenia
 from sarracenia.transfer import Transfer
 from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
 from urllib.parse import unquote
@@ -527,6 +528,10 @@ class Sftp(Transfer):
         alarm_set(self.o.timeout)
         self.sftp.rmdir(path)
         alarm_cancel()
+
+    #when sftp is active, paramiko is present... STFPAttributes is then the same as FmdStat.
+    def stat(self, path, msg=None) -> sarracenia.filemetadata.FmdStat:
+        return self.sftp.stat(path)
 
     # utime
     def utime(self, path, tup):


### PR DESCRIPTION
Implements HTTP(S) stat using urllib, which allows the existing authentication to work with stat calls.

While working on this, I had to make some changes to the existing `__open__`, which should fix problems and be a general improvement from the existing code. As long as nothing breaks...

This also includes @petersilva's implementation of stat in other protocols and the code that calls stat when a download results in a file with an unexpected size.

Fixes #1157.