### PR TITLE
Change stop output to show the number of processes still running (like v2)

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2346,16 +2346,17 @@ class sr_GlobalState:
         attempts_max = 5
         now = time.time()
 
+        running_pids = len(pids_signalled)
         while attempts < attempts_max:
             for pid in self.procs:
                 if (not self.procs[pid]['claimed']) and (
-                    (now - self.procs[pid]['create_time']) > 50):
+                    (now - self.procs[pid]['create_time']) > 50 and pid not in pids_signalled):
                     print( f"pid: {pid} \"{' '.join(self.procs[pid]['cmdline'])}\" does not match any configured instance, sending it TERM" )
                     signal_pid(pid, signal.SIGTERM)
                     pids_signalled |= set([pid])
 
             ttw = 1 << attempts
-            print( f"Waiting {ttw} sec. to check if {len(pids_signalled)} processes stopped (try: {attempts})" )
+            print( f"Waiting {ttw} sec. to check if {running_pids} processes stopped (try: {attempts})" )
             time.sleep(ttw)
             # update to reflect killed processes.
             self._read_procs()

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2394,7 +2394,7 @@ class sr_GlobalState:
                 for i in self.states[c][cfg]['instance_pids']:
                     if self.states[c][cfg]['instance_pids'][i] in self.procs:
                         p=self.states[c][cfg]['instance_pids'][i]
-                        print( f"signal_pid( {p}, SIGKILL )")
+                        print( f"signal_pid( {p} \"{' '.join(self.procs[p]['cmdline'])}\", SIGKILL )")
                         signal_pid(p, signal.SIGKILL)
                         pids_signalled |= set([p])
                         print('.', end='')


### PR DESCRIPTION
Closes #1203. I'm proposing this change. If other people don't like it, that's fine with me. I just think it's nice to see that the stop is actually making progress...

Changes the sr3 stop output from this:

```
$ sr3 stop
Stopping: sending SIGTERM ........................ ( 24 ) Done
Waiting 1 sec. to check if 24 processes stopped (try: 0)
pid: 27031 "/usr/bin/python3 /usr/lib/python3/dist-packages/sarracenia/instance.py --no 1 start winnow/fdsa" does not match any configured instance, sending it TERM
pid: 27036 "/usr/bin/python3 /usr/lib/python3/dist-packages/sarracenia/instance.py --no 1 start winnow/lkjh" does not match any configured instance, sending it TERM
Waiting 2 sec. to check if 24 processes stopped (try: 1)
Waiting 4 sec. to check if 24 processes stopped (try: 2)
Waiting 8 sec. to check if 24 processes stopped (try: 3)
Waiting 16 sec. to check if 24 processes stopped (try: 4)
doing SIGKILL this time
signal_pid( 48245, SIGKILL )
.signal_pid( 48246, SIGKILL )
.signal_pid( 48249, SIGKILL )
.signal_pid( 48252, SIGKILL )
.Done
Waiting again...
All stopped after KILL
```

to this: 

```
$ sr3 stop
Stopping: sending SIGTERM .................................................................................................................................................................................................................... ( 212 ) Done
Waiting 1 sec. to check if 212 processes stopped (try: 0)
Waiting 2 sec. to check if 99 processes stopped (try: 1)
Waiting 4 sec. to check if 13 processes stopped (try: 2)
Waiting 8 sec. to check if 5 processes stopped (try: 3)
Waiting 16 sec. to check if 3 processes stopped (try: 4)
doing SIGKILL this time
signal_pid( 59048 "/usr/bin/python3 /usr/lib/python3/dist-packages/sarracenia/instance.py --no 1 start winnow/lkjh", SIGKILL )
.signal_pid( 59062 "/usr/bin/python3 /usr/lib/python3/dist-packages/sarracenia/instance.py --no 1 start sarra/lkjh", SIGKILL )
.signal_pid( 59068 "/usr/bin/python3 /usr/lib/python3/dist-packages/sarracenia/instance.py --no 1 start component/config1", SIGKILL )
.Done
Waiting again...
All stopped after KILL
```

Which matches v2:

```
$ sr stop
Stopping: sending SIGTERM .................................................................................................................................................................................................................................................................................................................................................................. ( 354 ) Done
Waiting 1 sec. to check if 354 processes stopped (try: 0)
Waiting 2 sec. to check if 2 processes stopped (try: 1)
Waiting 4 sec. to check if 2 processes stopped (try: 2)
Waiting 8 sec. to check if 2 processes stopped (try: 3)
Waiting 16 sec. to check if 2 processes stopped (try: 4)
doing SIGKILL this time
os.kill( 50061, SIGKILL )
.Done
Waiting again...
All stopped after KILL
```

I also add another case to the if, so that if it's already sent SIGTERM to that pid, it doesn't send it again. I don't think that will cause any problems, and it gets rid of the "does not match any configured instance, sending it TERM" lines in the output.