### PR TITLE
Fix badly expiring timers

### DIFF
--- a/sarracenia/transfer/azure.py
+++ b/sarracenia/transfer/azure.py
@@ -30,7 +30,6 @@ import stat
 import json
 
 from sarracenia.transfer import Transfer
-from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
 
 from azure.storage.blob import ContainerClient
 import azure.core.exceptions

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -82,10 +82,14 @@ class Ftp(Transfer):
         logger.debug("sr_ftp cd %s" % path)
 
         alarm_set(self.o.timeout)
-        self.ftp.cwd(self.originalDir)
-        self.ftp.cwd(path)
-        self.pwd = path
-        alarm_cancel()
+        try:
+            self.ftp.cwd(self.originalDir)
+            self.ftp.cwd(path)
+            self.pwd = path
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
 
     def cd_forced(self, perm, path):
         logger.debug("sr_ftp cd_forced %d %s" % (perm, path))
@@ -121,18 +125,30 @@ class Ftp(Transfer):
 
             # create
             alarm_set(self.o.timeout)
-            self.ftp.mkd(d)
-            alarm_cancel()
+            try:
+                self.ftp.mkd(d)
+                alarm_cancel()
+            except:
+                alarm_cancel()
+                raise
 
             # chmod
             alarm_set(self.o.timeout)
-            self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + d)
-            alarm_cancel()
+            try:
+                self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + d)
+                alarm_cancel()
+            except:
+                alarm_cancel()
+                raise
 
             # cd
             alarm_set(self.o.timeout)
-            self.ftp.cwd(d)
-            alarm_cancel()
+            try:
+                self.ftp.cwd(d)
+                alarm_cancel()
+            except:
+                alarm_cancel()
+                raise
 
     # check_is_connected
 
@@ -164,8 +180,12 @@ class Ftp(Transfer):
     def chmod(self, perm, path):
         logger.debug("sr_ftp chmod %s %s" % (str(perm), path))
         alarm_set(self.o.timeout)
-        self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + path)
-        alarm_cancel()
+        try:
+            self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + path)
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
 
     # close
     def close(self):
@@ -174,9 +194,9 @@ class Ftp(Transfer):
         old_ftp = self.ftp
 
         self.init()
+        alarm_set(self.o.timeout)
 
         try:
-            alarm_set(self.o.timeout)
             old_ftp.quit()
         except:
             pass
@@ -350,8 +370,13 @@ class Ftp(Transfer):
     # getcwd
     def getcwd(self):
         alarm_set(self.o.timeout)
-        pwd = self.ftp.pwd()
-        alarm_cancel()
+        try:
+            pwd = self.ftp.pwd()
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
+
         return pwd
 
     # ls
@@ -359,8 +384,13 @@ class Ftp(Transfer):
         logger.debug("sr_ftp ls")
         self.entries = {}
         alarm_set(self.o.timeout)
-        self.ftp.retrlines('LIST', self.line_callback)
-        alarm_cancel()
+        try:
+            self.ftp.retrlines('LIST', self.line_callback)
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
+
         logger.debug("sr_ftp ls = (size: %d) %s ..." % (len(self.entries), str(self.entries)[0:255]))
         return self.entries
 
@@ -400,13 +430,22 @@ class Ftp(Transfer):
     def mkdir(self, remote_dir):
         logger.debug("sr_ftp mkdir %s" % remote_dir)
         alarm_set(self.o.timeout)
-        self.ftp.mkd(remote_dir)
-        alarm_cancel()
+        try:
+            self.ftp.mkd(remote_dir)
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
+
         alarm_set(self.o.timeout)
-        self.ftp.voidcmd('SITE CHMOD ' +
+        try:
+            self.ftp.voidcmd('SITE CHMOD ' +
                          "{0:o}".format(self.o.permDirDefault) + ' ' +
                          remote_dir)
-        alarm_cancel()
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
 
     # put
     def put(self,
@@ -464,19 +503,31 @@ class Ftp(Transfer):
     def rename(self, remote_old, remote_new):
         logger.debug("sr_ftp rename %s %s" % (remote_old, remote_new))
         alarm_set(self.o.timeout)
-        self.ftp.rename(remote_old, remote_new)
-        alarm_cancel()
+        try:
+            self.ftp.rename(remote_old, remote_new)
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
 
     # rmdir
     def rmdir(self, path):
         logger.debug("sr_ftp rmdir %s" % path)
         alarm_set(self.o.timeout)
-        self.ftp.rmd(path)
-        alarm_cancel()
+        try:
+            self.ftp.rmd(path)
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise
 
     # umask
     def umask(self):
         logger.debug("sr_ftp umask")
         alarm_set(self.o.timeout)
-        self.ftp.voidcmd('SITE UMASK 777')
-        alarm_cancel()
+        try:
+            self.ftp.voidcmd('SITE UMASK 777')
+            alarm_cancel()
+        except:
+            alarm_cancel()
+            raise

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -116,6 +116,7 @@ class Ftp(Transfer):
                 alarm_cancel()
                 continue
             except:
+                alarm_cancel()
                 pass
 
             # create

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -86,10 +86,8 @@ class Ftp(Transfer):
             self.ftp.cwd(self.originalDir)
             self.ftp.cwd(path)
             self.pwd = path
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
     def cd_forced(self, perm, path):
         logger.debug("sr_ftp cd_forced %d %s" % (perm, path))
@@ -103,8 +101,7 @@ class Ftp(Transfer):
             alarm_cancel()
             return
         except:
-            pass
-        alarm_cancel()
+            alarm_cancel()
 
         # need to create subdir
 
@@ -121,34 +118,27 @@ class Ftp(Transfer):
                 continue
             except:
                 alarm_cancel()
-                pass
 
             # create
             alarm_set(self.o.timeout)
             try:
                 self.ftp.mkd(d)
+            finally:
                 alarm_cancel()
-            except:
-                alarm_cancel()
-                raise
 
             # chmod
             alarm_set(self.o.timeout)
             try:
                 self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + d)
+            finally:
                 alarm_cancel()
-            except:
-                alarm_cancel()
-                raise
 
             # cd
             alarm_set(self.o.timeout)
             try:
                 self.ftp.cwd(d)
+            finally:
                 alarm_cancel()
-            except:
-                alarm_cancel()
-                raise
 
     # check_is_connected
 
@@ -182,10 +172,8 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + path)
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
     # close
     def close(self):
@@ -372,10 +360,8 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             pwd = self.ftp.pwd()
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
         return pwd
 
@@ -386,10 +372,8 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             self.ftp.retrlines('LIST', self.line_callback)
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
         logger.debug("sr_ftp ls = (size: %d) %s ..." % (len(self.entries), str(self.entries)[0:255]))
         return self.entries
@@ -432,20 +416,16 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             self.ftp.mkd(remote_dir)
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
         alarm_set(self.o.timeout)
         try:
             self.ftp.voidcmd('SITE CHMOD ' +
                          "{0:o}".format(self.o.permDirDefault) + ' ' +
                          remote_dir)
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
     # put
     def put(self,
@@ -505,10 +485,8 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             self.ftp.rename(remote_old, remote_new)
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
     # rmdir
     def rmdir(self, path):
@@ -516,10 +494,8 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             self.ftp.rmd(path)
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise
 
     # umask
     def umask(self):
@@ -527,7 +503,5 @@ class Ftp(Transfer):
         alarm_set(self.o.timeout)
         try:
             self.ftp.voidcmd('SITE UMASK 777')
+        finally:
             alarm_cancel()
-        except:
-            alarm_cancel()
-            raise

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -98,9 +98,10 @@ class Ftp(Transfer):
         try:
             self.ftp.cwd(self.originalDir)
             self.ftp.cwd(path)
-            alarm_cancel()
             return
         except:
+            pass
+        finally:
             alarm_cancel()
 
         # need to create subdir
@@ -114,9 +115,10 @@ class Ftp(Transfer):
             try:
                 alarm_set(self.o.timeout)
                 self.ftp.cwd(d)
-                alarm_cancel()
                 continue
             except:
+                pass
+            finally:
                 alarm_cancel()
 
             # create

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -93,8 +93,8 @@ class Ftp(Transfer):
         # try to go directly to path
 
         alarm_set(self.o.timeout)
-        self.ftp.cwd(self.originalDir)
         try:
+            self.ftp.cwd(self.originalDir)
             self.ftp.cwd(path)
             alarm_cancel()
             return

--- a/sarracenia/transfer/s3.py
+++ b/sarracenia/transfer/s3.py
@@ -30,7 +30,6 @@ import stat
 import json
 
 from sarracenia.transfer import Transfer
-from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
 
 import boto3, botocore
 from boto3.s3.transfer import TransferConfig

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -81,12 +81,14 @@ class Sftp(Transfer):
     # cd
     def cd(self, path):
         alarm_set(self.o.timeout)
-        logger.debug("first cd to %s" % self.originalDir)
-        self.sftp.chdir(self.originalDir)
-        logger.debug("then cd to %s" % path)
-        self.sftp.chdir(path)
-        self.pwd = path
-        alarm_cancel()
+        try:
+            logger.debug("first cd to %s" % self.originalDir)
+            self.sftp.chdir(self.originalDir)
+            logger.debug("then cd to %s" % path)
+            self.sftp.chdir(path)
+            self.pwd = path
+        finally:
+            alarm_cancel()
 
     # cd forced
     def cd_forced(self, perm, path):
@@ -95,14 +97,14 @@ class Sftp(Transfer):
         # try to go directly to path
 
         alarm_set(self.o.timeout)
-        self.sftp.chdir(self.originalDir)
         try:
+            self.sftp.chdir(self.originalDir)
             self.sftp.chdir(path)
             alarm_cancel()
-            return
         except:
             pass
-        alarm_cancel()
+        finally:
+            alarm_cancel()
 
         # need to create subdir
 
@@ -115,16 +117,19 @@ class Sftp(Transfer):
             try:
                 alarm_set(self.o.timeout)
                 self.sftp.chdir(d)
-                alarm_cancel()
                 continue
             except:
                 pass
+            finally:
+                alarm_cancel()
 
             # create and go to subdir
             alarm_set(self.o.timeout)
-            self.sftp.mkdir(d, self.o.permDirDefault)
-            self.sftp.chdir(d)
-            alarm_cancel()
+            try:
+                self.sftp.mkdir(d, self.o.permDirDefault)
+                self.sftp.chdir(d)
+            finally:
+                alarm_cancel()
 
     def check_is_connected(self):
         logger.debug("sr_sftp check_is_connected")
@@ -145,10 +150,11 @@ class Sftp(Transfer):
         try:
             alarm_set(self.o.timeout)
             self.sftp.chdir(self.originalDir)
-            alarm_cancel()
         except:
             self.close()
             return False
+        finally:
+            alarm_cancel()
 
         return True
 
@@ -156,8 +162,10 @@ class Sftp(Transfer):
     def chmod(self, perm, path):
         logger.debug("sr_sftp chmod %s %s" % ("{0:o}".format(perm), path))
         alarm_set(self.o.timeout)
-        self.sftp.chmod(path, perm)
-        alarm_cancel()
+        try:
+            self.sftp.chmod(path, perm)
+        finally:
+            alarm_cancel()
 
     # close
     def close(self):
@@ -193,7 +201,6 @@ class Sftp(Transfer):
 
         alarm_set(self.o.timeout)
         try:
-
             sublogger = logging.getLogger('paramiko')
             sublogger.setLevel(logging.CRITICAL)
             self.ssh = paramiko.SSHClient()
@@ -223,8 +230,6 @@ class Sftp(Transfer):
 
             self.connected = True
             self.sftp = sftp
-
-            #alarm_cancel()
             return True
 
         except:
@@ -232,7 +237,8 @@ class Sftp(Transfer):
                          (self.host, self.user))
             logger.debug('Exception details: ', exc_info=True)
 
-        alarm_cancel()
+        finally:
+            alarm_cancel()
         return False
 
     # credentials...
@@ -301,31 +307,36 @@ class Sftp(Transfer):
             alarm_cancel()
             return
 
-        # proceed with file/link removal
-        if not S_ISDIR(s.st_mode):
-            logger.debug("sr_sftp remove %s" % path)
-            self.sftp.remove(path)
+        try:
+            # proceed with file/link removal
+            if not S_ISDIR(s.st_mode):
+                logger.debug("sr_sftp remove %s" % path)
+                self.sftp.remove(path)
 
-        # proceed with directory removal
-        else:
-            logger.debug("sr_sftp rmdir %s" % path)
-            self.sftp.rmdir(path)
-
-        alarm_cancel()
+            # proceed with directory removal
+            else:
+                logger.debug("sr_sftp rmdir %s" % path)
+                self.sftp.rmdir(path)
+        finally:
+            alarm_cancel()
 
     def readlink(self, link):
         logger.debug("%s" % (link))
         alarm_set(self.o.timeout)
-        value = self.sftp.readlink(link)
-        alarm_cancel()
+        try:
+            value = self.sftp.readlink(link)
+        finally:
+            alarm_cancel()
         return value
 
     # symlink
     def symlink(self, link, path):
         logger.debug("(in %s), create this file %s as a link to: %s" % (self.getcwd(), path, link) )
         alarm_set(self.o.timeout)
-        self.sftp.symlink(link, path)
-        alarm_cancel()
+        try:
+            self.sftp.symlink(link, path)
+        finally:
+            alarm_cancel()
 
     # get
 
@@ -341,10 +352,12 @@ class Sftp(Transfer):
             (remote_file, local_file, remote_offset, local_offset, length, exactLength))
 
         alarm_set(2 * self.o.timeout)
-        rfp = self.sftp.file(remote_file, 'rb', self.o.bufSize)
-        if remote_offset != 0: rfp.seek(remote_offset, 0)
-        rfp.settimeout(1.0 * self.o.timeout)
-        alarm_cancel()
+        try:
+            rfp = self.sftp.file(remote_file, 'rb', self.o.bufSize)
+            if remote_offset != 0: rfp.seek(remote_offset, 0)
+            rfp.settimeout(1.0 * self.o.timeout)
+        finally:
+            alarm_cancel()
 
         # read from rfp and write to local_file
 
@@ -355,8 +368,10 @@ class Sftp(Transfer):
         # close
 
         alarm_set(self.o.timeout)
-        rfp.close()
-        alarm_cancel()
+        try:
+            rfp.close()
+        finally:
+            alarm_cancel()
 
         return rw_length
 
@@ -382,8 +397,10 @@ class Sftp(Transfer):
     # getcwd
     def getcwd(self):
         alarm_set(self.o.timeout)
-        cwd = self.sftp.getcwd() if self.sftp else None
-        alarm_cancel()
+        try:
+            cwd = self.sftp.getcwd() if self.sftp else None
+        finally:
+            alarm_cancel()
         return cwd
 
     # ls
@@ -392,8 +409,11 @@ class Sftp(Transfer):
         self.entries = {}
         # timeout is at least 30 secs, say we wait for max 5 mins
         alarm_set(self.o.timeout)
-        dir_attr = self.sftp.listdir_attr()
-        alarm_cancel()
+        try:
+            dir_attr = self.sftp.listdir_attr()
+        finally:
+            alarm_cancel()
+
         for index in range(len(dir_attr)):
             attr = dir_attr[index]
             line = attr.__str__()
@@ -425,19 +445,18 @@ class Sftp(Transfer):
     def mkdir(self, remote_dir):
         logger.debug("mkdir %s" % remote_dir)
         alarm_set(self.o.timeout)
-        
         try:
             s = self.sftp.lstat(path)
             if S_ISDIR(s.st_mode):
                 return
             logger.error( f"cannot mkdir {path}, file exists" )
-            alarm_cancel()
             return
         except FileNotFoundError:
             pass
         except:
-            alarm_cancel()
             return
+        finally:
+            alarm_cancel()
 
         self.sftp.mkdir(remote_dir, self.o.permDirDefault)
         alarm_cancel()
@@ -458,23 +477,25 @@ class Sftp(Transfer):
 
         alarm_set(2 * self.o.timeout)
 
-        if length == 0:
-            rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
-            rfp.settimeout(1.0 * self.o.timeout)
+        try:
+           if length == 0:
+               rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
+               rfp.settimeout(1.0 * self.o.timeout)
 
-        # parts
-        else:
-            try:
-                self.sftp.stat(remote_file)
-            except:
-                rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
-                rfp.close()
+           # parts
+           else:
+               try:
+                   self.sftp.stat(remote_file)
+               except:
+                   rfp = self.sftp.file(remote_file, 'wb', self.o.bufSize)
+                   rfp.close()
 
-            rfp = self.sftp.file(remote_file, 'r+b', self.o.bufSize)
-            rfp.settimeout(1.0 * self.o.timeout)
-            if remote_offset != 0: rfp.seek(remote_offset, 0)
+               rfp = self.sftp.file(remote_file, 'r+b', self.o.bufSize)
+               rfp.settimeout(1.0 * self.o.timeout)
+               if remote_offset != 0: rfp.seek(remote_offset, 0)
 
-        alarm_cancel()
+        finally:
+            alarm_cancel()
 
         # read from local_file and write to rfp
 
@@ -483,10 +504,12 @@ class Sftp(Transfer):
         # no sparse file... truncate where we are at
 
         alarm_set(self.o.timeout)
-        self.fpos = remote_offset + rw_length
-        if length != 0: rfp.truncate(self.fpos)
-        rfp.close()
-        alarm_cancel()
+        try:
+            self.fpos = remote_offset + rw_length
+            if length != 0: rfp.truncate(self.fpos)
+            rfp.close()
+        finally:
+           alarm_cancel()
 
         return rw_length
 
@@ -519,15 +542,19 @@ class Sftp(Transfer):
         except:
             pass
         alarm_set(self.o.timeout)
-        self.sftp.rename(remote_old, remote_new)
-        alarm_cancel()
+        try:
+            self.sftp.rename(remote_old, remote_new)
+        finally:
+            alarm_cancel()
 
     # rmdir
     def rmdir(self, path):
         logger.debug("sr_sftp rmdir %s " % path)
         alarm_set(self.o.timeout)
-        self.sftp.rmdir(path)
-        alarm_cancel()
+        try:
+            self.sftp.rmdir(path)
+        finally:
+            alarm_cancel()
 
     #when sftp is active, paramiko is present... STFPAttributes is then the same as FmdStat.
     def stat(self, path, msg=None) -> sarracenia.filemetadata.FmdStat:
@@ -540,5 +567,7 @@ class Sftp(Transfer):
     def utime(self, path, tup):
         logger.debug("sr_sftp utime %s %s " % (path, tup))
         alarm_set(self.o.timeout)
-        self.sftp.utime(path, tup)
-        alarm_cancel()
+        try:
+            self.sftp.utime(path, tup)
+        finally:
+            alarm_cancel()


### PR DESCRIPTION
more work on #966  That issued dealt with timers expiring instances being killed because transfers of large files appeared to be dead.  This is about timers being set and forgotten. In normal processing, it looks like all timers should be cleared, but in a number of failure cases, the timers might not be cleared.
It's unclear what specific case is causing a client issue.

Review of the source code showed:
* only place alarm timers are set is in the Transfer class hierarchy.
* only client report of failures is in ftp transfers.
* review of source revealed many, many places where errors could cause alarm clearing to be missed.
* potential code readability improvement from try/finally applicaiton.

So decided to look for and correct all the vulnerable parts of code where an exception would cause the timer to not be cleared.
