### PR TITLE
Add `scheduled_time` for #1209

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -954,8 +954,13 @@ to poll the remote resources every thirty minutes. Alternatively::
    scheduled_hour 1,13,19
    scheduled_minute 27
 
-specifies that poll be run at 1:27, 13:27, and 19:27 each day.
- 
+specifies that poll be run at 1:27, 13:27, and 19:27 each day. Alternatively::
+
+   scheduled_time 15:30,20:30,23:15
+
+will poll the remote resources at exactly 15:30, 16:30 and 23:15.
+
+
 By default, sr_poll sends its post notification message to the broker with default exchange
 (the prefix *xs_* followed by the broker username). The *post_broker* is mandatory.
 It can be given incomplete if it is well defined in the credentials.conf file.

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1762,7 +1762,7 @@ If the speed observed is to be considered normal for that flow, then set the thr
 appropriately.
 
 
-scheduled_interval,scheduled_hour,scheduled_minute
+scheduled_interval,scheduled_hour,scheduled_minute,scheduled_time
 --------------------------------------------------
 
 When working with scheduled flows, such as polls, one can configure a duration
@@ -1772,7 +1772,7 @@ given activity::
   scheduled_interval 30
 
 run the flow or poll every 30 seconds.  If no duration is set, then the 
-flowcb.scheduled.Scheduled class will look for the other two time specifiers::
+flowcb.scheduled.Scheduled class will then look for the hour/minute time specifiers::
 
   scheduled_hour 1,4,5,23
   scheduled_minute 14,17,29
@@ -1780,6 +1780,14 @@ flowcb.scheduled.Scheduled class will look for the other two time specifiers::
 
 which will have the poll run each day at: 01:14, 01:17, 01:29, then the same minutes
 after each of 4h, 5h and 23h.
+
+If no scheduled_time nor scheduled_hour is given, then flowcb.scheduled.Scheduled class will
+then look for the remaining time specifier::
+
+  scheduled_time 15:30,16:30,18:59
+
+this will poll the data at 15:30, 16:30 and 18:59 every day. This option allows you to fine tune more
+your time field then previous options.
 
 sendTo <url>
 ---------------

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -953,14 +953,18 @@ que ca devrait être calculé lors du transfert.
 
 Pour définir la fréquence de sondage, on se sert de *scheduled_*, tel que::
 
-    scheduled_interal 30m
+    scheduled_interval 30m
 
 pour sonder à toute les trente minutes, ou bien::
 
     scheduled_hour 1,13,19
     scheduled_minute 27
 
-pour sonder trois fois par jour à 1h27, 13h27 et 19h27.
+pour sonder trois fois par jour à 1h27, 13h27 et 19h27, ou bien::
+
+    scheduled_time 15:30,20:30,23:15
+
+pour sonder à seulement 15:30, 20:30 et 23:15
     
 Par défaut, sr_poll envoie son message de publication au courtier avec l'échange par défaut
 (le préfixe *xs_* suivi du nom d’utilisateur du courtier). Le *post_broker* est obligatoire.

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1773,13 +1773,21 @@ sondage devrait être lancer::
 
 Ceci partirai le flux ou sondage toutes les 30 secondes. Si aucune *scheduled_interval* n'est 
 définie, alors La classe flowcb.scheduled.Scheduled recherchera les deux autres 
-spécificateurs de temps ::
+spécificateurs de temps, en format heure/minute ::
 
   scheduled_hour 1,4,5,23
   scheduled_minute 14,17,29
 
-afin de specifier de partir un sondage chaque jour à: 01h14, 01h17, 01h29, puis les mêmes minutes
+ceci va démarrer un sondage chaque jour à: 01h14, 01h17, 01h29, puis les mêmes minutes
 après chacune des 4h, 5h et 23h.
+
+Si scheduled_time ni scheduled_hour n'est pas donné, alors la classe flowcb.scheduled.Scheduled va chercher pour
+la dernière option du spécificateur de temps::
+  
+  scheduled_time 15:30,16:30,18:59
+
+ceci va déclencher le sondage des données à 15:30, 16:30 et 18:59 à chaque jour. Cette option te permet d'encore plus
+délimiter des intervals de temps que les options précédentes.
 
 sendTo <url>
 ------------

--- a/sarracenia/config.py
+++ b/sarracenia/config.py
@@ -2055,7 +2055,7 @@ class Config:
         if (component not in ['poll' ]):
             self.path = list(map( os.path.expanduser, self.path ))
         else:
-            if not (hasattr(self,'scheduled_interval') or hasattr(self,'scheduled_hour') or hasattr(self,'scheduled_minute')):
+            if not (hasattr(self,'scheduled_interval') or hasattr(self,'scheduled_hour') or hasattr(self,'scheduled_minute') or hasattr(self,'scheduled_time')):
                 if self.sleep > 1:
                     self.scheduled_interval = self.sleep
                     self.sleep=1

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -112,7 +112,7 @@ class Scheduled(FlowCB):
         self.first_interval=True
 
         if self.o.scheduled_interval <= 0 and not self.appointments:
-            logger.info( f"no scheduled_interval or appointments (combination of scheduled_hour and scheduled_minute) set defaulting to every {self.default_wait} seconds" )
+            logger.info( f"no scheduled_interval or appointments (combination of scheduled_hour and scheduled_minute) set defaulting to every {self.default_wait.seconds} seconds" )
 
     def gather(self,messageCountMax):
 

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -53,7 +53,7 @@ class Scheduled(FlowCB):
           set self.appointments to a list of when something needs to be run during the current day.
         """
         self.appointments=[]
-        if self.o.scheduled_minute and self.o.scheduled_hour:
+        if self.o.scheduled_minute or self.o.scheduled_hour:
             for h in self.hours:
                for m in self.minutes:
                    if ( h > when.hour ) or ((h == when.hour) and ( m >= when.minute )):
@@ -62,16 +62,19 @@ class Scheduled(FlowCB):
                        self.appointments.append(next_time)
                    else:
                        pass # that time is passed for today.
-        elif self.o.scheduled_time:
+        if self.o.scheduled_time:
             for time in self.sched_times:
-                hour = int(time.split(':')[0])
-                minute = int(time.split(':')[1])
+                hour,minute=time.split(':')
+                hour = int(hour)
+                minute = int(minute)
                 if ( hour > when.hour ) or ((hour == when.hour) and ( minute >= when.minute )):
                     appointment = datetime.time(hour, minute, tzinfo=datetime.timezone.utc )
                     next_time = datetime.datetime.combine(when,appointment)
                     self.appointments.append(next_time)
                 else:
                     pass # that time is passed for today.
+        
+        self.appointments.sort()
 
 
         logger.info( f"for {when}: {json.dumps(list(map( lambda x: str(x), self.appointments))) } ")
@@ -88,16 +91,16 @@ class Scheduled(FlowCB):
         self.interrupted=None
 
         self.sched_times = sum([ x.split(',') for x in self.o.scheduled_time],[])
-        self.sched_times.sort()
+        #self.sched_times.sort()
 
         sched_hours = sum([ x.split(',') for x in self.o.scheduled_hour],[])
         self.hours = list(map( lambda x: int(x), sched_hours ))
-        self.hours.sort()
+        #self.hours.sort()
         logger.debug( f"hours {self.hours}" )
 
         sched_min = sum([ x.split(',') for x in self.o.scheduled_minute ],[])
         self.minutes = list(map( lambda x: int(x), sched_min))
-        self.minutes.sort()
+        #self.minutes.sort()
 
 
         self.default_wait=300

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -94,11 +94,13 @@ class Scheduled(FlowCB):
         #self.sched_times.sort()
 
         sched_hours = sum([ x.split(',') for x in self.o.scheduled_hour],[])
+        if sched_hours == [] : sched_hours = list(range(0,24))
         self.hours = list(map( lambda x: int(x), sched_hours ))
         #self.hours.sort()
         logger.debug( f"hours {self.hours}" )
 
         sched_min = sum([ x.split(',') for x in self.o.scheduled_minute ],[])
+        if sched_min == [] : sched_min = [0]
         self.minutes = list(map( lambda x: int(x), sched_min))
         #self.minutes.sort()
 

--- a/sarracenia/flowcb/scheduled/__init__.py
+++ b/sarracenia/flowcb/scheduled/__init__.py
@@ -103,7 +103,7 @@ class Scheduled(FlowCB):
         #self.minutes.sort()
 
 
-        self.default_wait=300
+        self.default_wait=datetime.timedelta(seconds=300)
 
         logger.debug( f'minutes: {self.minutes}')
 

--- a/tests/sarracenia/flowcb/scheduled/__scheduled___test.py
+++ b/tests/sarracenia/flowcb/scheduled/__scheduled___test.py
@@ -1,6 +1,112 @@
+import datetime
+import logging
 import pytest
 from tests.conftest import *
 #from unittest.mock import Mock
 
 import sarracenia.config
 import sarracenia.flowcb.scheduled
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def build_options():
+     o = sarracenia.config.default_config()
+     o.component = 'flow'
+     o.config = 'ex1'
+     o.action = 'start'
+
+     o.parse_line( o.component, o.config, "flow/ex1", 1, "no 1" )
+     o.parse_line( o.component, o.config, "", 1, "no 1" )
+     o.finalize()
+     return o
+
+def test_broker_finalize():
+
+     options= build_options()
+     options.scheduled_time=[ "12:40", "7:37" ]
+
+     today=datetime.datetime.fromtimestamp(time.time(),datetime.timezone.utc)
+     midnight=datetime.time(0,0,tzinfo=datetime.timezone.utc)
+     midnight= datetime.datetime.combine(today,midnight)
+     
+
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+     assert( len(me.appointments) == 2 ) 
+
+     logger.error( f" {me.appointments=} {len(me.appointments)=}" )
+     logger.error( f" HOHO {len(me.appointments)=}" )
+ 
+
+     options = build_options()
+     options.scheduled_hour= [ '1','3','5',' 7',' 9',' 13','21','23']
+     options.scheduled_minute= [ '1,3,5',' 7',' 9',' 13',' 15',' 51','53' ]
+
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+
+     assert( len(me.appointments) == 72 ) 
+
+     #logger.error( f" {me.appointments=} {len(me.appointments)=}" )
+     #logger.error( f" HOHO {len(me.appointments)=}" )
+
+     """
+       this should work? but does not... dunno why... worth fixing but not part of #1206
+
+       seems to barf on only having 1 scheduled hour... so maybe you need both?
+     """
+     #options = build_options()
+     #options.scheduled_hour= [ '1' ]
+     #options.scheduled_minute= []
+     #me=sarracenia.flowcb.scheduled.Scheduled(options)
+     #me.update_appointments(midnight)
+     #assert( len(me.appointments) == 1 ) 
+
+     #logger.error( f" {me.appointments=} {len(me.appointments)=}" )
+     #logger.error( f" HOHO {len(me.appointments)=}" )
+     
+     """
+         with both hour and minute specified... it works.
+
+     """
+     options = build_options()
+     options.scheduled_hour= [ '1' ]
+     options.scheduled_minute= [ '1' ]
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+     assert( len(me.appointments) == 1 ) 
+
+     options = build_options()
+     options.scheduled_interval= [ 3600 ]
+     options.scheduled_hour= [ ]
+     options.scheduled_minute= [ ]
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+     assert( len(me.appointments) == 0 ) 
+
+     #logger.error( f" {me.appointments=} {len(me.appointments)=}" )
+     #logger.error( f" HOHO {len(me.appointments)=}" )
+     
+     options.scheduled_hour= []
+     options.scheduled_minute= []
+     options.scheduled_time=[ "12:40", "7:37" ]
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+     assert( len(me.appointments) == 2 ) 
+
+     logger.error( f"HOHO" )
+
+     options= build_options()
+     options.scheduled_hour= [ "2", "4" ]
+     options.scheduled_minute= [ "2" ]
+     options.scheduled_time=[ "12:40", "7:37" ]
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+
+     assert( len(me.appointments) == 4 ) 
+
+     #logger.error( f" {me.appointments=} {len(me.appointments)=}" )
+     #logger.error( f" HOHO {len(me.appointments)=}" )
+ 

--- a/tests/sarracenia/flowcb/scheduled/__scheduled___test.py
+++ b/tests/sarracenia/flowcb/scheduled/__scheduled___test.py
@@ -72,6 +72,18 @@ def test_schedules():
 
      """
      options = build_options()
+     options.scheduled_hour= []
+     options.scheduled_minute= []
+     options.scheduled_time= []
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+
+     logger.error( f"{me.appointments=}" )
+     assert( len(me.appointments) == 0 ) 
+
+
+     options = build_options()
+     options = build_options()
      options.scheduled_hour= [ '1' ]
      options.scheduled_minute= [ '1' ]
      me=sarracenia.flowcb.scheduled.Scheduled(options)

--- a/tests/sarracenia/flowcb/scheduled/__scheduled___test.py
+++ b/tests/sarracenia/flowcb/scheduled/__scheduled___test.py
@@ -22,7 +22,7 @@ def build_options():
      o.finalize()
      return o
 
-def test_broker_finalize():
+def test_schedules():
 
      options= build_options()
      options.scheduled_time=[ "12:40", "7:37" ]
@@ -96,8 +96,6 @@ def test_broker_finalize():
      me.update_appointments(midnight)
      assert( len(me.appointments) == 2 ) 
 
-     logger.error( f"HOHO" )
-
      options= build_options()
      options.scheduled_hour= [ "2", "4" ]
      options.scheduled_minute= [ "2" ]
@@ -106,6 +104,30 @@ def test_broker_finalize():
      me.update_appointments(midnight)
 
      assert( len(me.appointments) == 4 ) 
+
+     """
+       expect appointments at 2:00, and 4:00
+     """
+     options= build_options()
+     options.scheduled_hour= [ "2", "4" ]
+     options.scheduled_minute= [ ]
+     options.scheduled_time=[ ]
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+
+     assert( len(me.appointments) == 2 ) 
+
+     """
+       expect appointments at :02, and :04 every hour.
+     """
+     options= build_options()
+     options.scheduled_minute= [ "2", "4" ]
+     options.scheduled_hour= [ ]
+     options.scheduled_time=[ ]
+     me=sarracenia.flowcb.scheduled.Scheduled(options)
+     me.update_appointments(midnight)
+
+     assert( len(me.appointments) == 48 ) 
 
      #logger.error( f" {me.appointments=} {len(me.appointments)=}" )
      #logger.error( f" HOHO {len(me.appointments)=}" )


### PR DESCRIPTION
`scheduled_time` allows us to poll for files when `scheduled_minute`/`scheduled_hour` offers a too broad spectrum of appointments to choose from.

`scheduled_time` should be used when we want to specify specific appointment times when we want to poll/scheduled flow.