### PR TITLE
Fix for Issue1218 - Permission problems in directory creations on FTP/SFTP transfers

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2431,7 +2431,7 @@ class Flow:
                              (self.scheme, new_dir))
                 if not self.o.dry_run:
                     try:
-                        self.proto[self.scheme].cd_forced(775, new_dir)
+                        self.proto[self.scheme].cd_forced(new_dir)
                     except Exception as ex:
                         logger.error( f"could not chdir to {sendTo} {new_dir}: {ex}" )
                         return False
@@ -2644,8 +2644,8 @@ class Flow:
                 if not self.o.dry_run:
                     try:
                         self.proto[self.scheme].cd_forced(
-                            775, new_dir + '/' + options.inflight)
-                        self.proto[self.scheme].cd_forced(775, new_dir)
+                            new_dir + '/' + options.inflight)
+                        self.proto[self.scheme].cd_forced(new_dir)
                     except:
                         pass
                 new_inflight_path = options.inflight + new_file

--- a/sarracenia/transfer/azure.py
+++ b/sarracenia/transfer/azure.py
@@ -112,7 +112,7 @@ class Azure(Transfer):
         self.path = self.path.lstrip('/')
 
 
-    def cd_forced(self, perm, path):
+    def cd_forced(self, path):
         logger.debug(f"forcing into  {path}")
         self.cd(path)
 

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -90,7 +90,7 @@ class Ftp(Transfer):
             alarm_cancel()
 
     def cd_forced(self, path):
-        logger.debug("sr_ftp cd_forced %d %s" % (self.o.permDirDefault, path))
+        logger.debug("sr_ftp cd_forced %o %s" % (self.o.permDirDefault, path))
 
         # try to go directly to path
 

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -89,8 +89,8 @@ class Ftp(Transfer):
         finally:
             alarm_cancel()
 
-    def cd_forced(self, perm, path):
-        logger.debug("sr_ftp cd_forced %d %s" % (perm, path))
+    def cd_forced(self, path):
+        logger.debug("sr_ftp cd_forced %d %s" % (self.o.permDirDefault, path))
 
         # try to go directly to path
 
@@ -131,7 +131,7 @@ class Ftp(Transfer):
             # chmod
             alarm_set(self.o.timeout)
             try:
-                self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(perm) + ' ' + d)
+                self.ftp.voidcmd('SITE CHMOD ' + "{0:o}".format(self.o.permDirDefault) + ' ' + d)
             finally:
                 alarm_cancel()
 

--- a/sarracenia/transfer/s3.py
+++ b/sarracenia/transfer/s3.py
@@ -123,7 +123,7 @@ class S3(Transfer):
         self.cwd = os.path.dirname(path)
         self.path = path.strip('/') + "/"
 
-    def cd_forced(self, perm, path):
+    def cd_forced(self, path):
         logger.debug("sr_s3 cd %s" % path)
         self.cwd = os.path.dirname(path)
         self.path = path.strip('/') + "/"

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -127,9 +127,9 @@ class Sftp(Transfer):
             alarm_set(self.o.timeout)
             try:
                 self.sftp.mkdir(d, self.o.permDirDefault)
-                # Apply permDirDefault value. mkdir is limited by SFTP server umask value
-                self.sftp.chmod(d, self.o.permDirDefault)
                 self.sftp.chdir(d)
+                # Apply permDirDefault value. mkdir is limited by SFTP server umask value
+                self.sftp.chmod('.', self.o.permDirDefault)
             finally:
                 alarm_cancel()
 
@@ -459,6 +459,8 @@ class Sftp(Transfer):
             return
         else:
             self.sftp.mkdir(remote_dir, self.o.permDirDefault)
+            # Apply permDirDefault value. mkdir is limited by SFTP server umask value
+            self.sftp.chmod(remote_dir, self.o.permDirDefault)
         finally:
             alarm_cancel()
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -91,8 +91,8 @@ class Sftp(Transfer):
             alarm_cancel()
 
     # cd forced
-    def cd_forced(self, perm, path):
-        logger.debug("sr_sftp cd_forced %d %s" % (perm, path))
+    def cd_forced(self, path):
+        logger.debug("sr_sftp cd_forced %d %s" % (self.o.permDirDefault, path))
 
         # try to go directly to path
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -127,6 +127,8 @@ class Sftp(Transfer):
             alarm_set(self.o.timeout)
             try:
                 self.sftp.mkdir(d, self.o.permDirDefault)
+                # Apply permDirDefault value. mkdir is limited by SFTP server umask value
+                self.sftp.chmod(d, self.o.permDirDefault)
                 self.sftp.chdir(d)
             finally:
                 alarm_cancel()
@@ -455,11 +457,10 @@ class Sftp(Transfer):
             pass
         except:
             return
+        else:
+            self.sftp.mkdir(remote_dir, self.o.permDirDefault)
         finally:
             alarm_cancel()
-
-        self.sftp.mkdir(remote_dir, self.o.permDirDefault)
-        alarm_cancel()
 
     # put
     def put(self,

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -92,7 +92,7 @@ class Sftp(Transfer):
 
     # cd forced
     def cd_forced(self, path):
-        logger.debug("sr_sftp cd_forced %d %s" % (self.o.permDirDefault, path))
+        logger.debug("sr_sftp cd_forced %o %s" % (self.o.permDirDefault, path))
 
         # try to go directly to path
 

--- a/tests/sarracenia/transfer/azure_test.py
+++ b/tests/sarracenia/transfer/azure_test.py
@@ -121,7 +121,7 @@ def test_cd_forced():
     assert transfer.path == ""
     assert transfer.cwd == ""
 
-    transfer.cd_forced('777', "/this/Is/A/Path/")
+    transfer.cd_forced("/this/Is/A/Path/")
 
     assert transfer.path == "this/Is/A/Path/"
     assert transfer.cwd == "/this/Is/A/Path"

--- a/tests/sarracenia/transfer/s3_test.py
+++ b/tests/sarracenia/transfer/s3_test.py
@@ -123,7 +123,7 @@ def test_cd_forced():
     assert transfer.path == ""
     assert transfer.cwd == ""
 
-    transfer.cd_forced('777', "/this/Is/A/Path/")
+    transfer.cd_forced("/this/Is/A/Path/")
 
     assert transfer.path == "this/Is/A/Path/"
     assert transfer.cwd == "/this/Is/A/Path"


### PR DESCRIPTION
- `cd_forced` now no longer takes `perm` as an argument

- `permDirDefault` is now used as default permissions in directory creations in `cd_forced` instead of hardcoded `775` in SFTP and FTP

- the mkdirs on FTP are already accompanied with `chmod`s so no changes to be made there

- the mkdirs on SFTP are now accompanied with `chmod`s

- Improvements to `cd_forced` logging message

