### PR TITLE
Issue1206 2nd try 404

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2172,6 +2172,13 @@ class Flow:
                         len_written = self.proto[self.scheme].get(
                             msg, remote_file, new_inflight_path, remote_offset,
                             msg['local_offset'], block_length, exactLength)
+                except requests.exceptions.HTTPError as e:
+                    if e.response.status_code == 404:
+                         self.reject(msg, 404, f"url does not exist upstream, discarding message." )
+                         return -1
+                    logger.error( f"http error, could not get {remote_file}: {ex}" )
+                    return 0
+
                 except Exception as ex:
                     logger.error( f"could not get {remote_file}: {ex}" )
                     return 0

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -180,11 +180,11 @@ class FlowCB:
          to indicate failure to process a message, append to worklist.failed.
          worklist.failed processing should occur in here as it will be zeroed out after this step.
 
-    def send(self,msg) -> bool::
+    def send(self,msg) -> int::
 
          Task: looking at msg['new_dir'], msg['new_file'], and the self.o options perform a transfer
                of a single file.
-               return True on a successful transfer, False otherwise.
+               return >0 on a successful transfer, 0 if failed but temporarily, <0 if failure is permanent.
 
                if self.o.dry_run is set, simulate the output of a send without
                performing it.


### PR DESCRIPTION
Second shot at #1206 (yeah branch name is off by one...)

* change send signature to match the change in the download signature... they both return integers now. <0 means permanent failure, 0 means queue for retry > 0 means yay! it worked.
* also catch http 404's and call them permanent.

This should address the sort of bogus (will never recover) lag we see
on ops with 3.0.54.
