### PR TITLE
Switch from global QoS to per-consumer QoS

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -349,7 +349,8 @@ class AMQP(Moth):
                 #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
                 if self.o['prefetch'] != 0:
-                    self.channel.basic_qos(0, self.o['prefetch'], True)
+                    # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
+                    self.channel.basic_qos(0, self.o['prefetch'], False)
 
                 #FIXME: test self.first_setup and props['reset']... delete queue...
                 broker_str = self.o['broker'].url.geturl().replace(


### PR DESCRIPTION
Since quorum queues don't support global QoS, I think it makes sense to switch to per-consumer QoS.

It will also show the Prefetch Count for each consumer when looking at a queue in the RabbitMQ GUI, so that's a nice improvement as well.

I don't think there is any practical difference. We only ever have one consumer per connection and channel, so it should behave the same way.

-- edit to re-trigger tests