### PR TITLE
Doc sec zoning multihop

### DIFF
--- a/docs/source/Explanation/DeploymentConsiderations.rst
+++ b/docs/source/Explanation/DeploymentConsiderations.rst
@@ -147,6 +147,39 @@ Security Considerations
 This section is meant to provide insight to those who need to perform a security review
 of the application prior to implementation.
 
+
+Architecture
+~~~~~~~~~~~~
+
+Sarracenia can be a component in many solutions, and can be deployed as a cloud component.
+However, in it's rawest, simplest form, Sarracenia is not used like cloud services, where 
+one service is accessible from anywhere. It is more of a component or toolkit that is 
+expected to work with traditional network security zoning. Rather than have one service 
+for all, and requiring traffic/firewall exceptions and external security scanning to 
+intercept traffic, one deploys pump at each network zone demarcation. 
+
+Data is delivered to the pump at the demarcation point, and then another pump
+forwards data to the next zone. As part of demarcation processing, one can download a 
+file, run it through processing, such as malware scanning, and then only announce 
+it's availability to the following pump if it's ok.
+
+Each pump has independent authentication, and pump administrators 
+and users can define what traffic is made available to users on the other side of 
+the demarcation point. Pumps are chained together by copying from one to the next 
+to the next, where each one can have different access, purpose, and ownership.
+
+No formal federation or whole network identity is needed to pass data around 
+the network. Instead, each pump establishes authentication for the neigbouring pump. 
+If countries operated data pumps, one could imagine a situation like the following:
+The Russians and Americans want to transfer data but do not want to be exposed to each
+others' servers directly. The Russians could share with Kazakstan, The Kazakhs exchange
+with Korea, and Korea exchanges with Canada. The Americans only need to have
+a good relationship with the Canadians or Koreans. Each link in the chain 
+exposing themselves directly only to peers they have an explicit and 
+agreed relationship with. Each link in the chain can perform their own
+scanning and processing before accepting the data.
+
+
 Client
 ~~~~~~
 

--- a/docs/source/Explanation/DeploymentConsiderations.rst
+++ b/docs/source/Explanation/DeploymentConsiderations.rst
@@ -179,6 +179,14 @@ exposing themselves directly only to peers they have an explicit and
 agreed relationship with. Each link in the chain can perform their own
 scanning and processing before accepting the data.
 
+.. image:: Concepts/sr3_flow_example.svg
+    :scale: 100%
+    :align: center
+
+In this example, you can see that there are the ddsr pumps deployed on internal
+operations zones, and they push or pull from pumps in other zones, such as another
+operations zone, or a public access zone. Pumps are expected to 
+mediate traffic travelling between network zones.
 
 Client
 ~~~~~~

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -2079,10 +2079,10 @@ Examples: Canada/Pacific, Pacific/Nauru, Canada/Eastern, Europe/Paris
 Has no effect other than in when polling an FTP server.
 
 
-tlsRigour (default: medium)
+tlsRigour (default: normal)
 ---------------------------
 
-tlsRigour can be set to: *lax, medium, or strict*, and gives a hint to the
+tlsRigour can be set to: *lax, normal, or strict*, and gives a hint to the
 application of how to configure TLS connections. TLS, or Transport Level
 Security (used to be called Secure Socket Layer (SSL)) is the wrapping of
 normal TCP sockets in standard encryption. There are many aspects of TLS

--- a/docs/source/fr/Explication/ConsiderationsDeployments.rst
+++ b/docs/source/fr/Explication/ConsiderationsDeployments.rst
@@ -167,6 +167,46 @@ Considérations de sécurité
 Cette section a pour but de donner un aperçu à ceux qui ont besoin d'effectuer un examen de sécurité.
 de l'application avant la mise en œuvre.
 
+Architecture
+~~~~~~~~~~~~
+
+Sarracenia peut être un composant de nombreuses solutions et peut être déployé en tant que composant cloud.
+Cependant, dans sa forme la plus brute et la plus simple, Sarracenia n'est pas utilisé comme les services cloud, où
+un service est accessible de n'importe où. Il s'agit plutôt d'un composant ou d'une boîte à outils qui est
+censé fonctionner avec le zonage de sécurité réseau traditionnel. Plutôt que d'avoir un service
+pour tous et d'exiger des exceptions de trafic/pare-feu et une analyse de sécurité externe pour
+intercepter le trafic, on déploie une pompe à chaque démarcation de zone réseau.
+
+Les données sont livrées à la pompe au point de démarcation, puis une autre pompe
+transmet les données à la zone suivante. Dans le cadre du traitement de démarcation, on 
+peut télécharger un fichier, l'exécuter via un traitement, comme une analyse des logiciels 
+malveillants, puis annoncer sa disponibilité à la pompe suivante uniquement si elle est correcte.
+
+Chaque pompe dispose d'une authentification indépendante, et les administrateurs de pompe
+et les utilisateurs peuvent définir le trafic mis à disposition des utilisateurs de l'autre côté
+du point de démarcation. Les pompes sont enchaînées en copiant de l'une à l'autre
+à l'autre, où chacune peut avoir un accès, un but et une propriété différents.
+
+Aucune fédération formelle ou identité de réseau complet n'est nécessaire pour transmettre des données
+sur le réseau. Au lieu de cela, chaque pompe établit une authentification pour la pompe voisine.
+Si les pays exploitaient des pompes de données, on pourrait imaginer une situation comme celle-ci :
+Les Russes et les Américains veulent transférer des données mais ne veulent pas être exposés directement aux serveurs
+des autres. Les Russes pourraient partager avec le Kazakhstan, les Kazakhs échanger
+avec la Corée et la Corée échanger avec le Canada. Les Américains n'ont besoin que d'avoir
+une bonne relation avec les Canadiens ou les Coréens. Chaque maillon de la chaîne
+s'expose directement uniquement aux pairs avec lesquels il a une relation explicite et
+convenue. Chaque maillon de la chaîne peut effectuer sa propre analyse et son propre traitement avant d'accepter les données.
+
+.. image:: Concepts/sr3_exemple_de_flux.svg
+    :scale: 100%
+    :align: center
+
+Dans cet exemple, vous pouvez voir que les pompes DDR sont déployées sur des zones d'opérations
+internes et qu'elles poussent ou tirent depuis des pompes situées dans d'autres zones, telles qu'une autre
+zone d'opérations ou une zone d'accès public. Les pompes sont censées
+servir de médiateur au trafic circulant entre les zones du réseau.
+
+
 Client
 ~~~~~~
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -2063,10 +2063,10 @@ exemples: Canada/Pacific, Pacific/Nauru, Europe/Paris
 Seulement actif dans le contexte de sondage de serveur FTP.
 
 
-tlsRigour (défaut: medium)
+tlsRigour (défaut: normal)
 --------------------------
 
-*tlsRigour* peut être réglé a : *lax, medium ou strict*, et donne un indice à l'application par rapport à la
+*tlsRigour* peut être réglé a : *lax, normal ou strict*, et donne un indice à l'application par rapport à la
 configuration des connexions TLS. TLS, ou Transport Layer Security (autrefois appelée Secure Socket Layer (SSL))
 est l’encapsulation de sockets TCP normales en cryptage standard. Il existe de nombreux aspects de
 négociations TLS, vérification du nom d’hôte, vérification des certificats, validation, choix de


### PR DESCRIPTION
close #1201 

Added a description of how to place data pumps in relation to network security zones.
also fixed another documentation thing about tlsRigour.
