### PR TITLE
Add recursion back

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1596,6 +1596,14 @@ given. This option also enforces traversing of symbolic links.
 This option is being used to investigate some use cases, and may disappear in future.
 
 
+recursive <flag> (default: on)
+------------------------------
+
+when scanning a path (for poll, post, cpost, or watch) if you encounter a directory
+do you include it's contents as well? To only scan the specified directory
+and no sub-directories, specify *recursive off*
+
+
 rename <path>
 -------------
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1587,8 +1587,12 @@ donné. Cette option impose également la traversée de liens symboliques.
 
 Cette option est utilisée pour étudier certains cas d'utilisation et pourrait disparaître à l'avenir.
 
+<flag> recursive (par défaut : activé)
+--------------------------------------
 
-
+Lors de l'analyse d'un chemin (pour un *poll*, une *post*, un *cpost* ou un *watch*), si vous 
+rencontrez un répertoire, incluez-vous également son contenu ? Pour analyser uniquement le répertoire spécifié
+et aucun sous-répertoire, spécifiez *recursive off*
 
 rename <chemin>
 ---------------

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -607,7 +607,7 @@ class File(FlowCB):
             try:
                 ow = self.observer.schedule(self.watch_handler,
                                             d,
-                                            recursive=True)
+                                            recursive=self.o.recursive)
                 self.obs_watched.append(ow)
                 self.inl[dir_dev_id] = (ow, d)
                 logger.info(

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -443,20 +443,22 @@ class Poll(FlowCB):
 
         # post poll list
 
-        msgs.extend(self.poll_list_post(pdir, dir_dict, dir_dict.keys()))
+        if self.o.recursive:
+            msgs.extend(self.poll_list_post(pdir, dir_dict, dir_dict.keys()))
 
         msgs.extend(self.poll_list_post(pdir, desclst, filelst))
 
         # poll in children directory
 
-        sdir = sorted(dir_dict.keys())
-        for d in sdir:
-            if d == '.' or d == '..': continue
+        if self.o.recursive:
+            sdir = sorted(dir_dict.keys())
+            for d in sdir:
+                if d == '.' or d == '..': continue
 
-            #d_lspath = lspath + '_' + d
-            d_pdir = pdir + os.sep + d
+                #d_lspath = lspath + '_' + d
+                d_pdir = pdir + os.sep + d
 
-            msgs.extend(self.poll_directory(d_pdir))
+                msgs.extend(self.poll_directory(d_pdir))
 
         return msgs
 


### PR DESCRIPTION
I just looked at the code and guessed where it needs to be added back.
There is one patch to add it to watch, one to document, and one to add it to poll.

I ran the flow tests and they pass as well as before.
Have not actually tested what happens when you turn recursive off.  someone perhaps should before merging this.

It's harmless, but I don't know if it does what it should.
