### PR TITLE
Fix bug from moving credentials into config subdir

### DIFF
--- a/sarracenia/config/credentials.py
+++ b/sarracenia/config/credentials.py
@@ -501,7 +501,7 @@ class CredentialDB:
         if cred_details is None:
             logging.critical("bad credential %s" % urlstr)
             # Callers expect that a Credential object will be returned
-            cred_details = credentials.Credential()
+            cred_details = Credential()
             cred_details.url = urllib.parse.urlparse(urlstr)
             return False, cred_details
         return True, cred_details


### PR DESCRIPTION
fixes this problem when you try to use a credential in a config that doesn't have a password/entry in credentials.conf

```
2024-09-27 13:14:51,421 2023550 [ERROR] sarracenia.config.credentials isValid credential not found
2024-09-27 13:14:51,421 2023550 [CRITICAL] root validate_urlstr bad credential amqp://feeder@example.com/
Traceback (most recent call last):
  File "/net/local/home/sunderlandr/.local/bin/sr3", line 8, in <module>
    sys.exit(main())
  File "/net/local/home/sunderlandr/sr3/sarracenia/sr.py", line 3089, in main
    gs = sr_GlobalState(cfg, cfg.configurations)
  File "/net/local/home/sunderlandr/sr3/sarracenia/sr.py", line 1324, in __init__
    self._read_configs()
  File "/net/local/home/sunderlandr/sr3/sarracenia/sr.py", line 333, in _read_configs
    cfgbody.parse_file(cfg,c)
  File "/net/local/home/sunderlandr/sr3/sarracenia/config/__init__.py", line 1539, in parse_file
    self.parse_line( component, cfg, cfname, lineno, l.strip() )
  File "/net/local/home/sunderlandr/sr3/sarracenia/config/__init__.py", line 1755, in parse_line
    setattr(self, k, v)
  File "/net/local/home/sunderlandr/sr3/sarracenia/config/__init__.py", line 994, in broker
    ok, cred_details = self.credentials.validate_urlstr(v)
  File "/net/local/home/sunderlandr/sr3/sarracenia/config/credentials.py", line 504, in validate_urlstr
    cred_details = credentials.Credential()
NameError: name 'credentials' is not defined. Did you mean: 'Credential'?
```