### PR TITLE
fix #1242 sftp making subdirs when it shouldn't

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -93,6 +93,8 @@ class Sftp(Transfer):
 
     # cd forced
     def cd_forced(self, path):
+        """ try to cd to a directory. If the cd fails, create the directory
+        """
         logger.debug("sr_sftp cd_forced %o %s" % (self.o.permDirDefault, path))
 
         # try to go directly to path
@@ -102,6 +104,8 @@ class Sftp(Transfer):
             self.sftp.chdir(self.originalDir)
             self.sftp.chdir(path)
             alarm_cancel()
+            # cd was successful, no need to create the dir, just return
+            return
         except:
             pass
         finally:


### PR DESCRIPTION
Add back the return that was removed in 7c95a6fc07c5bb72fc9f2f8efbb1d3cad4650bc to close #1242 