### PR TITLE
remove sleep loop from moth/setup routines.

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -427,6 +427,7 @@ known_report_codes = {
     #FIXME : should  not have 503 error code 3 times in a row
     # 503: "Service unavailable. delete (File removal not currently supported.)",
     503: "Unable to process: Service unavailable",
+    504: "Gateway Timeout: message too old"
     # 503: "Unsupported transport protocol specified in posting."
 }
 

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -417,9 +417,12 @@ known_report_codes = {
     206: "Partial Content: received and inserted.",
     304: "Not modified (Checksum validated, unchanged, so no download resulted.)",
     307: "Insertion deferred (writing to temporary part file for the moment.)",
+    404: "Not Found: no pattern match",
+    406: "Not Acceptable: file older than fileAgeMax",
     410: "Gone: server data different from notification message",
     417: "Expectation Failed: invalid notification message (corrupt headers)",
     422: "Unprocessable Content: could not determine path to transfer to",
+    425: "Too Early: file younger than fileAgeMin",
     499: "Failure: Not Copied. SFTP/FTP/HTTP download problem",
     #FIXME : should  not have 503 error code 3 times in a row
     # 503: "Service unavailable. delete (File removal not currently supported.)",

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -96,6 +96,7 @@ default_options = {
     'inline': False,
     'inlineOnly': False,
     'identity_method': 'sha512',
+    'logDuplicates': False,
     'logFormat': '%(asctime)s [%(levelname)s] %(name)s %(funcName)s %(message)s',
     'logMetrics': False,
     'logStdout': False,
@@ -142,7 +143,7 @@ count_options = [
 # all the boolean settings.
 flag_options = [ 'acceptSizeWrong', 'acceptUnmatched', 'amqp_consumer', 'baseUrl_relPath', 'debug', \
     'delete', 'discard', 'download', 'dry_run', 'durable', 'exchangeDeclare', 'exchangeSplit', 'logReject', 'realpathFilter', \
-    'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logMetrics', 'logStdout', 'logReject', 'restore', \
+    'follow_symlinks', 'force_polling', 'inline', 'inlineOnly', 'inplace', 'logDuplicates', 'logMetrics', 'logStdout', 'logReject', 'restore', \
     'messageDebugDump', 'mirror', 'timeCopy', 'notify_only', 'overwrite', 'post_on_start', \
     'permCopy', 'persistent', 'queueBind', 'queueDeclare', 'randomize', 'recursive', 'realpathPost', \
     'reconnect', 'report', 'reset', 'retry_refilter', 'retryEmptyBeforeExit', 'save', 

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -165,7 +165,7 @@ list_options = [ 'path', 'vip' ]
 set_options = [ 'logEvents', 'fileEvents' ]
 
 set_choices = { 
-    'logEvents' : set(sarracenia.flowcb.entry_points + [ 'reject' ]),
+    'logEvents' : set(sarracenia.flowcb.entry_points + [ 'reject', 'nodupe' ]),
     'fileEvents' : set( [ 'create', 'delete', 'link', 'mkdir', 'modify', 'rmdir' ] )
  }
 # FIXME: doesn't work... wonder why?
@@ -1608,6 +1608,9 @@ class Config:
                 setattr(self, k, isTrue(v))
             if k in ['logReject'] and self.logReject:
                 self.logEvents = self.logEvents | set(['reject'])
+
+            if k in ['logDuplicates'] and self.logDuplicates:
+                self.logEvents = self.logEvents | set(['nodupe'])
             return
 
         if len(line) < 2:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1105,7 +1105,7 @@ class Flow:
                                            self.o.flatten)
                     filtered_worklist.append(m)
                 else:
-                    self.reject(m, 304, "unmatched pattern %s" % url)
+                    self.reject(m, 404, "unmatched pattern %s" % url)
 
         self.worklist.incoming = filtered_worklist
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1070,7 +1070,7 @@ class Flow:
                                          (m['fileOp']['rename']))
                         else:
                             self.reject(
-                                m, 304, "mask=%s strip=%s url=%s" %
+                                m, 404, "mask=%s strip=%s url=%s" %
                                 (str(mask), strip, urlToMatch))
                         break
 
@@ -1479,7 +1479,6 @@ class Flow:
                     logger.debug("%s file size different, so cannot be the same" %
                              (msg['new_path']))
                     return True
-
             else:
                 end = 0
 
@@ -1499,7 +1498,7 @@ class Flow:
                         pass
     
                 if new_mtime <= old_mtime:
-                    self.reject(msg, 304,
+                    self.reject(msg, 406,
                             "mtime not newer %s " % (msg['new_path']))
                     return False
                 else:

--- a/sarracenia/flow/winnow.py
+++ b/sarracenia/flow/winnow.py
@@ -6,6 +6,7 @@ logger = logging.getLogger(__name__)
 default_options = {
         'acceptUnmatched': True, 
         'nodupe_ttl': 300,
+        'logDuplicates': True
 }
 
 

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -165,7 +165,7 @@ class Log(FlowCB):
                 if 'report' in msg and msg['report']['code'] in [ 304 ]:
                     logger.info(
                         "%s rejected: %d %s " %
-                        (msg['relPath'], msg['report']['code'], msg['report']['message']))
+                        (msg.getIDStr(), msg['report']['code'], msg['report']['message']))
 
         for msg in worklist.incoming:
 
@@ -194,6 +194,13 @@ class Log(FlowCB):
                         (msg['report']['code'], msg['report']['message']))
                 else:
                     logger.info("rejected: %s " % self._messageStr(msg))
+
+        elif 'nodupe' in self.o.logEvents:
+            for msg in worklist.rejected:
+                if 'report' in msg and msg['report']['code'] in [ 304 ]:
+                    logger.info(
+                        "%s rejected: %d %s " %
+                        (msg.getIDStr(), msg['report']['code'], msg['report']['message']))
 
         for msg in worklist.ok:
             if 'size' in msg:

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -159,6 +159,13 @@ class Log(FlowCB):
                         (msg['relPath'], msg['report']['code'], msg['report']['message']))
                 else:
                     logger.info("rejected: %s " % self._messageAcceptStr(msg))
+        
+        elif 'nodupe' in self.o.logEvents:
+            for msg in worklist.rejected:
+                if 'report' in msg and 'nodupe' in msg['report']['message']:
+                    logger.info(
+                        "%s rejected: %d %s " %
+                        (msg['relPath'], msg['report']['code'], msg['report']['message']))
 
         for msg in worklist.incoming:
 

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -162,7 +162,7 @@ class Log(FlowCB):
         
         elif 'nodupe' in self.o.logEvents:
             for msg in worklist.rejected:
-                if 'report' in msg and 'nodupe' in msg['report']['message']:
+                if 'report' in msg and msg['report']['code'] in [ 304 ]:
                     logger.info(
                         "%s rejected: %d %s " %
                         (msg['relPath'], msg['report']['code'], msg['report']['message']))

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -177,8 +177,8 @@ class Disk(NoDupe):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])
-                m['reject'] = "not modifified 1 (nodupe check)"
-                m.setReport(304, 'Not modified 1 (cache check)')
+                m['reject'] = "not modified 1 (nodupe check)"
+                m.setReport(304, 'Not modified 1 (nodupe check)')
                 worklist.rejected.append(m)
 
         if self.fp:

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -163,13 +163,13 @@ class Disk(NoDupe):
                 if mtime < min_mtime:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}"
-                    m.setReport(304,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
+                    m.setReport(406,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
                     worklist.rejected.append(m)
                     continue
                 elif mtime > max_mtime:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
-                    m.setReport(304,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
+                    m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
                     worklist.rejected.append(m)
                     continue
 

--- a/sarracenia/flowcb/nodupe/redis.py
+++ b/sarracenia/flowcb/nodupe/redis.py
@@ -163,13 +163,13 @@ class Redis(NoDupe):
                 if mtime < min_mtime:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}"
-                    m.setReport(304,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
+                    m.setReport(406,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
                     worklist.rejected.append(m)
                     continue
                 elif mtime > max_mtime:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
-                    m.setReport(304,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
+                    m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
                     worklist.rejected.append(m)
                     continue
 
@@ -177,8 +177,8 @@ class Redis(NoDupe):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])
-                m['reject'] = "not modifified 1 (nodupe check)"
-                m.setReport(304, 'Not modified 1 (cache check)')
+                m['reject'] = "not modified 1 (nodupe check)"
+                m.setReport(304, 'Not modified 1 (nodupe check)')
                 worklist.rejected.append(m)
 
         logger.debug("items registered in duplicate suppression cache: %d" % (len(self._redis.keys(self._rkey_base + ":*"))) )

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -172,7 +172,10 @@ class AMQP(Moth):
 
         super().__init__(props, is_subscriber)
 
-        self.last_qDeclare = time.time()
+        now = time.time()
+        self.last_qDeclare = now
+        self.next_connect_time = now
+        self.next_connect_failures = 0
 
         logging.basicConfig(
             format=
@@ -306,24 +309,37 @@ class AMQP(Moth):
             logger.error(
                     f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
                 )
-            logger.error("AMQP getSetup failed to {} with {}".format(
-                    self.o['broker'].url.hostname, err))
+            logger.error( f"failed queue declare to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
 
         if hasattr(self,'metrics'):
             self.metrics['brokerQueuedMessageCount'] = -1
         return -1
 
+    def setEbo(self,start)->None:
+        """  Calculate next retry time using exponential backoff
+             note that it doesn't look like classic EBO because the time
+             is multiplied by how long it took to fail. Long failures should not
+             be retried quickly, but short failures can be variable in duration.
+             If the timing of failures is variable, the "attempt_duration" will be low, 
+             and so the next_try might get smaller even though it hasn't succeeded yet... 
+             it should eventually settle down to a long period though.
+        """
+        now=time.time()
+        attempt_duration = now - start
+        self.next_connect_failures += 1
+        ebo = 2**self.next_connect_failures
+        next_try = min(attempt_duration * ebo, 600)
+        self.next_connect_time = now + next_try
+        logger.error( f"could not connect. next try in {next_try} seconds.")
 
-    def getSetup(self) -> None:
+    def getSetup(self) -> bool:
         """
         Setup so we can get messages.
 
         if message_strategy is stubborn, will loop here forever.
              connect, declare queue, apply bindings.
         """
-        ebo = 1
-
         if self._stop_requested:
             return
 
@@ -331,17 +347,23 @@ class AMQP(Moth):
             logger.critical( f"no broker given" )
             return
 
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
+
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
         try:
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
-                logger.critical('could not connect')
+                self.setEbo(start)
                 return
 
             # only first/lead instance needs to declare a queue and bindings.
             if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
+                self.next_connect_failures = 0
                 return
 
             #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
@@ -375,6 +397,7 @@ class AMQP(Moth):
 
             # Setup Successfully Complete!
             self.metricsConnect()
+            self.next_connect_failures = 0
             logger.debug('getSetup ... Done!')
             return
 
@@ -382,13 +405,16 @@ class AMQP(Moth):
             logger.error(
                 f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
             )
-            logger.error("AMQP getSetup failed to {} with {}".format(
-                self.o['broker'].url.hostname, err))
+            logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
+            self.setEbo(start)
 
     def putSetup(self) -> None:
 
-        ebo = 1
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
 
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
@@ -401,7 +427,7 @@ class AMQP(Moth):
                 return
 
             if not self.__connect(self.o['broker']):
-                logger.critical('could not connect')
+                self.setEbo(start)
                 return
 
             # transaction mode... confirms would be better...
@@ -431,6 +457,7 @@ class AMQP(Moth):
 
             # Setup Successfully Complete!
             self.metricsConnect()
+            self.next_connect_failures = 0
             logger.debug('putSetup ... Done!')
             return
 
@@ -440,6 +467,7 @@ class AMQP(Moth):
                 .format(self.o['exchange'], self.o['broker'].url.username,
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
+            self.setEbo(start)
 
     def putCleanUp(self) -> None:
 
@@ -503,6 +531,10 @@ class AMQP(Moth):
         try:
             if not self.connection:
                 self.getSetup()
+
+            if not hasattr(self,'channel'):
+                self.close()
+                return None
 
             raw_msg = self.channel.basic_get(self.o['queueName'])
             if (raw_msg is None) and (self.connection.connected):

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -324,141 +324,122 @@ class AMQP(Moth):
         """
         ebo = 1
 
-        while True:
-            
-            if self._stop_requested:
-                break
+        if self._stop_requested:
+            return
 
-            if 'broker' not in self.o or self.o['broker'] is None:
-                logger.critical( f"no broker given" )
-                break
+        if 'broker' not in self.o or self.o['broker'] is None:
+            logger.critical( f"no broker given" )
+            return
 
-            # It does not really matter how it fails, the recovery approach is always the same:
-            # tear the whole thing down, and start over.
-            try:
-                # from sr_consumer.build_connection...
-                if not self.__connect(self.o['broker']):
-                    logger.critical('could not connect')
-                    break
+        # It does not really matter how it fails, the recovery approach is always the same:
+        # tear the whole thing down, and start over.
+        try:
+            # from sr_consumer.build_connection...
+            if not self.__connect(self.o['broker']):
+                logger.critical('could not connect')
+                return
 
-                # only first/lead instance needs to declare a queue and bindings.
-                if 'no' in self.o and self.o['no'] >= 2:
-                    self.metricsConnect()
-                    return
-
-                #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
-
-                if self.o['prefetch'] != 0:
-                    # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
-                    self.channel.basic_qos(0, self.o['prefetch'], False)
-
-                #FIXME: test self.first_setup and props['reset']... delete queue...
-                broker_str = self.o['broker'].url.geturl().replace(
-                    ':' + self.o['broker'].url.password + '@', '@')
-
-                # from Queue declare
-                msg_count = self._queueDeclare()
-                
-                if msg_count == -2: break
-
-                if self.o['queueBind'] and self.o['queueName']:
-                    for tup in self.o['bindings']:
-                        exchange, prefix, subtopic = tup
-                        topic = '.'.join(prefix + subtopic)
-                        if self.o['dry_run']:
-                            logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
-                                ( self.o['queueName'], topic, exchange, broker_str ) )
-                        else:
-                            logger.info('binding %s with %s to %s (as: %s)' % \
-                                ( self.o['queueName'], topic, exchange, broker_str ) )
-                            if exchange:
-                                self.management_channel.queue_bind(self.o['queueName'], exchange,
-                                                topic)
-
-                # Setup Successfully Complete!
+            # only first/lead instance needs to declare a queue and bindings.
+            if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
-                logger.debug('getSetup ... Done!')
-                break
+                return
 
-            except Exception as err:
-                logger.error(
-                    f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
-                )
-                logger.error("AMQP getSetup failed to {} with {}".format(
-                    self.o['broker'].url.hostname, err))
-                logger.debug('Exception details: ', exc_info=True)
+            #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
-            if not self.o['message_strategy']['stubborn']: return
+            if self.o['prefetch'] != 0:
+                # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
+                self.channel.basic_qos(0, self.o['prefetch'], False)
 
-            if ebo < 60: ebo *= 2
+            #FIXME: test self.first_setup and props['reset']... delete queue...
+            broker_str = self.o['broker'].url.geturl().replace(
+                ':' + self.o['broker'].url.password + '@', '@')
 
-            logger.info("Sleeping {} seconds ...".format(ebo))
-            interruptible_sleep(ebo, obj=self)
+            # from Queue declare
+            msg_count = self._queueDeclare()
+            
+            if msg_count == -2: return
+
+            if self.o['queueBind'] and self.o['queueName']:
+                for tup in self.o['bindings']:
+                    exchange, prefix, subtopic = tup
+                    topic = '.'.join(prefix + subtopic)
+                    if self.o['dry_run']:
+                        logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
+                            ( self.o['queueName'], topic, exchange, broker_str ) )
+                    else:
+                        logger.info('binding %s with %s to %s (as: %s)' % \
+                            ( self.o['queueName'], topic, exchange, broker_str ) )
+                        if exchange:
+                            self.management_channel.queue_bind(self.o['queueName'], exchange,
+                                            topic)
+
+            # Setup Successfully Complete!
+            self.metricsConnect()
+            logger.debug('getSetup ... Done!')
+            return
+
+        except Exception as err:
+            logger.error(
+                f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
+            )
+            logger.error("AMQP getSetup failed to {} with {}".format(
+                self.o['broker'].url.hostname, err))
+            logger.debug('Exception details: ', exc_info=True)
 
     def putSetup(self) -> None:
 
         ebo = 1
 
-        while True:
+        # It does not really matter how it fails, the recovery approach is always the same:
+        # tear the whole thing down, and start over.
+        try:
+            if self._stop_requested:
+                return
 
-            # It does not really matter how it fails, the recovery approach is always the same:
-            # tear the whole thing down, and start over.
-            try:
-                if self._stop_requested:
-                    break
+            if self.o['broker'] is None:
+                logger.critical( f"no broker given" )
+                return
 
-                if self.o['broker'] is None:
-                    logger.critical( f"no broker given" )
-                    break
+            if not self.__connect(self.o['broker']):
+                logger.critical('could not connect')
+                return
 
-                if not self.__connect(self.o['broker']):
-                    logger.critical('could not connect')
-                    break
+            # transaction mode... confirms would be better...
+            self.channel.tx_select()
+            broker_str = self.o['broker'].url.geturl().replace(
+                ':' + self.o['broker'].url.password + '@', '@')
 
-                # transaction mode... confirms would be better...
-                self.channel.tx_select()
-                broker_str = self.o['broker'].url.geturl().replace(
-                    ':' + self.o['broker'].url.password + '@', '@')
+            #logger.debug('putSetup ... 1. connected to {}'.format(broker_str ) )
 
-                #logger.debug('putSetup ... 1. connected to {}'.format(broker_str ) )
+            if self.o['exchangeDeclare']:
+                logger.debug('putSetup ... 1. declaring {}'.format(
+                    self.o['exchange']))
+                if type(self.o['exchange']) is not list:
+                    self.o['exchange'] = [self.o['exchange']]
+                for x in self.o['exchange']:
+                    if self.o['dry_run']:
+                        logger.info('exchange declare (dry run): %s (as: %s)' %
+                                (x, broker_str))
+                    else:
+                        self.channel.exchange_declare(
+                            x,
+                            'topic',
+                            auto_delete=self.o['auto_delete'],
+                            durable=self.o['durable'])
+                        logger.info('exchange declared: %s (as: %s)' %
+                                (x, broker_str))
 
-                if self.o['exchangeDeclare']:
-                    logger.debug('putSetup ... 1. declaring {}'.format(
-                        self.o['exchange']))
-                    if type(self.o['exchange']) is not list:
-                        self.o['exchange'] = [self.o['exchange']]
-                    for x in self.o['exchange']:
-                        if self.o['dry_run']:
-                            logger.info('exchange declare (dry run): %s (as: %s)' %
-                                    (x, broker_str))
-                        else:
-                            self.channel.exchange_declare(
-                                x,
-                                'topic',
-                                auto_delete=self.o['auto_delete'],
-                                durable=self.o['durable'])
-                            logger.info('exchange declared: %s (as: %s)' %
-                                    (x, broker_str))
+            # Setup Successfully Complete!
+            self.metricsConnect()
+            logger.debug('putSetup ... Done!')
+            return
 
-                # Setup Successfully Complete!
-                self.metricsConnect()
-                logger.debug('putSetup ... Done!')
-                break
-
-            except Exception as err:
-                logger.error(
-                    "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
-                    .format(self.o['exchange'], self.o['broker'].url.username,
-                            self.o['broker'].url.hostname, err))
-                logger.debug('Exception details: ', exc_info=True)
-
-            if not self.o['message_strategy']['stubborn']: return
-
-            if ebo < 60: ebo *= 2
-
-            self.close()
-            logger.info("Sleeping {} seconds ...".format(ebo))
-            interruptible_sleep(ebo, obj=self)
+        except Exception as err:
+            logger.error(
+                "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
+                .format(self.o['exchange'], self.o['broker'].url.username,
+                        self.o['broker'].url.hostname, err))
+            logger.debug('Exception details: ', exc_info=True)
 
     def putCleanUp(self) -> None:
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -326,13 +326,13 @@ class AMQP(Moth):
         if self._stop_requested:
             return
 
-        if 'broker' not in self.o or self.o['broker'] is None:
-            logger.critical( f"no broker given" )
-            return
-
         start = time.time()
         if start < self.next_connect_time:
             logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
+
+        if 'broker' not in self.o or self.o['broker'] is None:
+            logger.critical( f"no broker given" )
             return
 
         # It does not really matter how it fails, the recovery approach is always the same:
@@ -348,10 +348,13 @@ class AMQP(Moth):
                 # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
                 self.channel.basic_qos(0, self.o['prefetch'], False)
 
+            #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
+
             # only first/lead instance needs to declare a queue and bindings.
             if 'no' in self.o and self.o['no'] >= 2:
-                    self.metricsConnect()
-                    return
+                self.metricsConnect()
+                return
+
             #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
             #FIXME: test self.first_setup and props['reset']... delete queue...

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -316,6 +316,23 @@ class AMQP(Moth):
             self.metrics['brokerQueuedMessageCount'] = -1
         return -1
 
+    def setEbo(self,start)->None:
+        """  Calculate next retry time using exponential backoff
+             note that it doesn't look like classic EBO because the time
+             is multiplied by how long it took to fail. Long failures should not
+             be retried quickly, but short failures can be variable in duration.
+             If the timing of failures is variable, the "attempt_duration" will be low, 
+             and so the next_try might get smaller even though it hasn't succeeded yet... 
+             it should eventually settle down to a long period though.
+        """
+        now=time.time()
+        attempt_duration = now - start
+        self.next_connect_failures += 1
+        ebo = 2**self.next_connect_failures
+        next_try = min(attempt_duration * ebo, 600)
+        self.next_connect_time = now + next_try
+        logger.error( f"could not connect. next try in {next_try} seconds.")
+
     def getSetup(self) -> None:
         """
         Setup so we can get messages.
@@ -335,13 +352,21 @@ class AMQP(Moth):
             logger.critical( f"no broker given" )
             return
 
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
+
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
         try:
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
+<<<<<<< HEAD
                 self.connection = None
+=======
+>>>>>>> 9264522b (implement ebo for broker connection attempts, AMQP)
                 return
 
             if self.o['prefetch'] != 0:
@@ -353,6 +378,7 @@ class AMQP(Moth):
             # only first/lead instance needs to declare a queue and bindings.
             if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
+                self.next_connect_failures = 0
                 return
 
             #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
@@ -393,7 +419,10 @@ class AMQP(Moth):
             logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
+<<<<<<< HEAD
             self.connection = None
+=======
+>>>>>>> 9264522b (implement ebo for broker connection attempts, AMQP)
 
     def putSetup(self) -> None:
 
@@ -521,6 +550,7 @@ class AMQP(Moth):
                 self.getSetup()
 
             if (not hasattr(self,'channel')) or (not hasattr(self,'connection')) or not self.connection:
+                self.close()
                 return None
 
             raw_msg = self.channel.basic_get(self.o['queueName'])

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -333,7 +333,7 @@ class AMQP(Moth):
         self.next_connect_time = now + next_try
         logger.error( f"could not connect. next try in {next_try} seconds.")
 
-    def getSetup(self) -> bool:
+    def getSetup(self) -> None:
         """
         Setup so we can get messages.
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -344,17 +344,15 @@ class AMQP(Moth):
                 self.connection = None
                 return
 
-            # only first/lead instance needs to declare a queue and bindings.
-            if 'no' in self.o and self.o['no'] >= 2:
-                self.metricsConnect()
-                self.next_connect_failures = 0
-                return
-
-            #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
-
             if self.o['prefetch'] != 0:
                 # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
                 self.channel.basic_qos(0, self.o['prefetch'], False)
+
+            # only first/lead instance needs to declare a queue and bindings.
+            if 'no' in self.o and self.o['no'] >= 2:
+                    self.metricsConnect()
+                    return
+            #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
             #FIXME: test self.first_setup and props['reset']... delete queue...
             broker_str = self.o['broker'].url.geturl().replace(

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -316,23 +316,6 @@ class AMQP(Moth):
             self.metrics['brokerQueuedMessageCount'] = -1
         return -1
 
-    def setEbo(self,start)->None:
-        """  Calculate next retry time using exponential backoff
-             note that it doesn't look like classic EBO because the time
-             is multiplied by how long it took to fail. Long failures should not
-             be retried quickly, but short failures can be variable in duration.
-             If the timing of failures is variable, the "attempt_duration" will be low, 
-             and so the next_try might get smaller even though it hasn't succeeded yet... 
-             it should eventually settle down to a long period though.
-        """
-        now=time.time()
-        attempt_duration = now - start
-        self.next_connect_failures += 1
-        ebo = 2**self.next_connect_failures
-        next_try = min(attempt_duration * ebo, 600)
-        self.next_connect_time = now + next_try
-        logger.error( f"could not connect. next try in {next_try} seconds.")
-
     def getSetup(self) -> None:
         """
         Setup so we can get messages.
@@ -363,10 +346,7 @@ class AMQP(Moth):
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
-<<<<<<< HEAD
                 self.connection = None
-=======
->>>>>>> 9264522b (implement ebo for broker connection attempts, AMQP)
                 return
 
             if self.o['prefetch'] != 0:
@@ -419,10 +399,7 @@ class AMQP(Moth):
             logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
-<<<<<<< HEAD
             self.connection = None
-=======
->>>>>>> 9264522b (implement ebo for broker connection attempts, AMQP)
 
     def putSetup(self) -> None:
 

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -129,6 +129,10 @@ class MQTT(Moth):
         self.o.update(default_options)
         self.o.update(options)
 
+        now = time.time()
+        self.next_connect_time = now
+        self.next_connect_failures = 0
+
         if 'qos' in self.o:
             if type(self.o['qos']) is not int:
                 self.o['qos'] = int(self.o['qos'])

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -93,6 +93,8 @@ class Sftp(Transfer):
 
     # cd forced
     def cd_forced(self, path):
+        """ try to cd to a directory. If the cd fails, create the directory
+        """
         logger.debug("sr_sftp cd_forced %o %s" % (self.o.permDirDefault, path))
 
         # try to go directly to path
@@ -102,6 +104,8 @@ class Sftp(Transfer):
             self.sftp.chdir(self.originalDir)
             self.sftp.chdir(path)
             alarm_cancel()
+            # cd was successful, no need to create the dir, just return
+            return
         except:
             pass
         finally:


### PR DESCRIPTION
working on #339.

We if we have multiple broker connections, then we can't loop waiting to connect to each one... because every time 
one broker connection goes down, it will just get stuck there.  

* old behaviour: getSetup and putSetup loop waiting to get a connection.
* new behavious: getSetup and putSetup fail and return.
* main loop then calls them again.

This is also consistent with the pattern of trying to have a single place where the code sleeps.

The only change in this code is to remove the loop (which outdented the entire routine by 4... sigh...)
changing "break" to "return" in a few places, and removing the sleeps.


