### PR TITLE
QoS should apply to all instances

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -340,6 +340,10 @@ class AMQP(Moth):
                 if not self.__connect(self.o['broker']):
                     logger.critical('could not connect')
                     break
+                
+                if self.o['prefetch'] != 0:
+                    # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
+                    self.channel.basic_qos(0, self.o['prefetch'], False)
 
                 # only first/lead instance needs to declare a queue and bindings.
                 if 'no' in self.o and self.o['no'] >= 2:
@@ -347,10 +351,6 @@ class AMQP(Moth):
                     return
 
                 #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
-
-                if self.o['prefetch'] != 0:
-                    # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
-                    self.channel.basic_qos(0, self.o['prefetch'], False)
 
                 #FIXME: test self.first_setup and props['reset']... delete queue...
                 broker_str = self.o['broker'].url.geturl().replace(

--- a/sarracenia/moth/amqpconsumer.py
+++ b/sarracenia/moth/amqpconsumer.py
@@ -69,17 +69,6 @@ class AMQPConsumer(AMQP):
         # This will block until the msg can be put in the queue
         self._raw_msg_q.put(msg)
 
-    def getCleanUp(self) -> None:
-        # TODO cancel consumer with basic_cancel(consumer_tag)?
-        try:
-            self.channel.basic_cancel(self._active_consumer_tag)
-            logger.info(f"Cancelled consumer {self._active_consumer_tag}")
-        except Exception as e:
-            logger.warning(f"Failed to cancel consumer {self._active_consumer_tag} {e}")
-            logger.debug("Exception details:", exc_info=True)
-        super().getCleanUp()
-        self._active_consumer_tag = None
-
     def getSetup(self) -> None:
         super().getSetup()
         # (re)create queue. Anything in the queue is invalid after re-creating a connection.
@@ -153,3 +142,16 @@ class AMQPConsumer(AMQP):
         self.close()
         time.sleep(1)
         return None
+
+    def close(self) -> None:
+        # TODO cancel consumer with basic_cancel(consumer_tag)?
+        if self._active_consumer_tag:
+            try:
+                self.channel.basic_cancel(self._active_consumer_tag)
+                logger.info(f"cancelled consumer with tag {self._active_consumer_tag}")
+            except Exception as e:
+                logger.warning(f"failed to cancel consumer with tag {self._active_consumer_tag} {e}")
+                logger.debug("Exception details:", exc_info=True)
+        self._active_consumer_tag = None
+        super().close()
+

--- a/sarracenia/moth/amqpconsumer.py
+++ b/sarracenia/moth/amqpconsumer.py
@@ -73,6 +73,7 @@ class AMQPConsumer(AMQP):
         # TODO cancel consumer with basic_cancel(consumer_tag)?
         try:
             self.channel.basic_cancel(self._active_consumer_tag)
+            logger.info(f"Cancelled consumer {self._active_consumer_tag}")
         except Exception as e:
             logger.warning(f"Failed to cancel consumer {self._active_consumer_tag} {e}")
             logger.debug("Exception details:", exc_info=True)

--- a/sarracenia/moth/amqpconsumer.py
+++ b/sarracenia/moth/amqpconsumer.py
@@ -71,6 +71,11 @@ class AMQPConsumer(AMQP):
 
     def getCleanUp(self) -> None:
         # TODO cancel consumer with basic_cancel(consumer_tag)?
+        try:
+            self.channel.basic_cancel(self._active_consumer_tag)
+        except Exception as e:
+            logger.warning(f"Failed to cancel consumer {self._active_consumer_tag} {e}")
+            logger.debug("Exception details:", exc_info=True)
         super().getCleanUp()
         self._active_consumer_tag = None
 


### PR DESCRIPTION
When testing consumers with more than 1 instance, I noticed that the prefetch count only applied to one of the consumers. I moved the call before the return for instances >= 2.

QoS is per-channel/per-consumer with RabbitMQ.

I also made an improvement to the consumer code, so consumers are cleanly "cancelled" when shutting down an instance.