### PR TITLE
Issue339 try4 part1 fail connections in main loop

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -316,23 +316,6 @@ class AMQP(Moth):
             self.metrics['brokerQueuedMessageCount'] = -1
         return -1
 
-    def setEbo(self,start)->None:
-        """  Calculate next retry time using exponential backoff
-             note that it doesn't look like classic EBO because the time
-             is multiplied by how long it took to fail. Long failures should not
-             be retried quickly, but short failures can be variable in duration.
-             If the timing of failures is variable, the "attempt_duration" will be low, 
-             and so the next_try might get smaller even though it hasn't succeeded yet... 
-             it should eventually settle down to a long period though.
-        """
-        now=time.time()
-        attempt_duration = now - start
-        self.next_connect_failures += 1
-        ebo = 2**self.next_connect_failures
-        next_try = min(attempt_duration * ebo, 600)
-        self.next_connect_time = now + next_try
-        logger.error( f"could not connect. next try in {next_try} seconds.")
-
     def getSetup(self) -> None:
         """
         Setup so we can get messages.
@@ -358,6 +341,7 @@ class AMQP(Moth):
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
+                self.connection = None
                 return
 
             if self.o['prefetch'] != 0:
@@ -408,6 +392,7 @@ class AMQP(Moth):
             logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
+            self.connection = None
 
     def putSetup(self) -> None:
 
@@ -428,6 +413,7 @@ class AMQP(Moth):
 
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
+                self.connection = None
                 return
 
             # transaction mode... confirms would be better...
@@ -468,6 +454,7 @@ class AMQP(Moth):
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
+            self.connection=None
 
     def putCleanUp(self) -> None:
 
@@ -532,8 +519,7 @@ class AMQP(Moth):
             if not self.connection:
                 self.getSetup()
 
-            if not hasattr(self,'channel'):
-                self.close()
+            if (not hasattr(self,'channel')) or (not hasattr(self,'connection')) or not self.connection:
                 return None
 
             raw_msg = self.channel.basic_get(self.o['queueName'])

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -172,7 +172,10 @@ class AMQP(Moth):
 
         super().__init__(props, is_subscriber)
 
-        self.last_qDeclare = time.time()
+        now = time.time()
+        self.last_qDeclare = now
+        self.next_connect_time = now
+        self.next_connect_failures = 0
 
         logging.basicConfig(
             format=
@@ -306,24 +309,37 @@ class AMQP(Moth):
             logger.error(
                     f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
                 )
-            logger.error("AMQP getSetup failed to {} with {}".format(
-                    self.o['broker'].url.hostname, err))
+            logger.error( f"failed queue declare to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
 
         if hasattr(self,'metrics'):
             self.metrics['brokerQueuedMessageCount'] = -1
         return -1
 
+    def setEbo(self,start)->None:
+        """  Calculate next retry time using exponential backoff
+             note that it doesn't look like classic EBO because the time
+             is multiplied by how long it took to fail. Long failures should not
+             be retried quickly, but short failures can be variable in duration.
+             If the timing of failures is variable, the "attempt_duration" will be low, 
+             and so the next_try might get smaller even though it hasn't succeeded yet... 
+             it should eventually settle down to a long period though.
+        """
+        now=time.time()
+        attempt_duration = now - start
+        self.next_connect_failures += 1
+        ebo = 2**self.next_connect_failures
+        next_try = min(attempt_duration * ebo, 600)
+        self.next_connect_time = now + next_try
+        logger.error( f"could not connect. next try in {next_try} seconds.")
 
-    def getSetup(self) -> None:
+    def getSetup(self) -> bool:
         """
         Setup so we can get messages.
 
         if message_strategy is stubborn, will loop here forever.
              connect, declare queue, apply bindings.
         """
-        ebo = 1
-
         if self._stop_requested:
             return
 
@@ -331,12 +347,17 @@ class AMQP(Moth):
             logger.critical( f"no broker given" )
             return
 
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
+
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
         try:
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
-                logger.critical('could not connect')
+                self.setEbo(start)
                 return
 
             if self.o['prefetch'] != 0:
@@ -346,6 +367,7 @@ class AMQP(Moth):
             # only first/lead instance needs to declare a queue and bindings.
             if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
+                self.next_connect_failures = 0
                 return
 
             #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
@@ -375,6 +397,7 @@ class AMQP(Moth):
 
             # Setup Successfully Complete!
             self.metricsConnect()
+            self.next_connect_failures = 0
             logger.debug('getSetup ... Done!')
             return
 
@@ -382,13 +405,16 @@ class AMQP(Moth):
             logger.error(
                 f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
             )
-            logger.error("AMQP getSetup failed to {} with {}".format(
-                self.o['broker'].url.hostname, err))
+            logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
+            self.setEbo(start)
 
     def putSetup(self) -> None:
 
-        ebo = 1
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
 
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
@@ -401,7 +427,7 @@ class AMQP(Moth):
                 return
 
             if not self.__connect(self.o['broker']):
-                logger.critical('could not connect')
+                self.setEbo(start)
                 return
 
             # transaction mode... confirms would be better...
@@ -431,6 +457,7 @@ class AMQP(Moth):
 
             # Setup Successfully Complete!
             self.metricsConnect()
+            self.next_connect_failures = 0
             logger.debug('putSetup ... Done!')
             return
 
@@ -440,6 +467,7 @@ class AMQP(Moth):
                 .format(self.o['exchange'], self.o['broker'].url.username,
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
+            self.setEbo(start)
 
     def putCleanUp(self) -> None:
 
@@ -503,6 +531,10 @@ class AMQP(Moth):
         try:
             if not self.connection:
                 self.getSetup()
+
+            if not hasattr(self,'channel'):
+                self.close()
+                return None
 
             raw_msg = self.channel.basic_get(self.o['queueName'])
             if (raw_msg is None) and (self.connection.connected):

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -324,141 +324,122 @@ class AMQP(Moth):
         """
         ebo = 1
 
-        while True:
-            
-            if self._stop_requested:
-                break
+        if self._stop_requested:
+            return
 
-            if 'broker' not in self.o or self.o['broker'] is None:
-                logger.critical( f"no broker given" )
-                break
+        if 'broker' not in self.o or self.o['broker'] is None:
+            logger.critical( f"no broker given" )
+            return
 
-            # It does not really matter how it fails, the recovery approach is always the same:
-            # tear the whole thing down, and start over.
-            try:
-                # from sr_consumer.build_connection...
-                if not self.__connect(self.o['broker']):
-                    logger.critical('could not connect')
-                    break
-                
-                if self.o['prefetch'] != 0:
-                    # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
-                    self.channel.basic_qos(0, self.o['prefetch'], False)
+        # It does not really matter how it fails, the recovery approach is always the same:
+        # tear the whole thing down, and start over.
+        try:
+            # from sr_consumer.build_connection...
+            if not self.__connect(self.o['broker']):
+                logger.critical('could not connect')
+                return
 
-                # only first/lead instance needs to declare a queue and bindings.
-                if 'no' in self.o and self.o['no'] >= 2:
-                    self.metricsConnect()
-                    return
+            if self.o['prefetch'] != 0:
+                # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
+                self.channel.basic_qos(0, self.o['prefetch'], False)
 
-                #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
-
-                #FIXME: test self.first_setup and props['reset']... delete queue...
-                broker_str = self.o['broker'].url.geturl().replace(
-                    ':' + self.o['broker'].url.password + '@', '@')
-
-                # from Queue declare
-                msg_count = self._queueDeclare()
-                
-                if msg_count == -2: break
-
-                if self.o['queueBind'] and self.o['queueName']:
-                    for tup in self.o['bindings']:
-                        exchange, prefix, subtopic = tup
-                        topic = '.'.join(prefix + subtopic)
-                        if self.o['dry_run']:
-                            logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
-                                ( self.o['queueName'], topic, exchange, broker_str ) )
-                        else:
-                            logger.info('binding %s with %s to %s (as: %s)' % \
-                                ( self.o['queueName'], topic, exchange, broker_str ) )
-                            if exchange:
-                                self.management_channel.queue_bind(self.o['queueName'], exchange,
-                                                topic)
-
-                # Setup Successfully Complete!
+            # only first/lead instance needs to declare a queue and bindings.
+            if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
-                logger.debug('getSetup ... Done!')
-                break
+                return
 
-            except Exception as err:
-                logger.error(
-                    f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
-                )
-                logger.error("AMQP getSetup failed to {} with {}".format(
-                    self.o['broker'].url.hostname, err))
-                logger.debug('Exception details: ', exc_info=True)
+            #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
-            if not self.o['message_strategy']['stubborn']: return
+            #FIXME: test self.first_setup and props['reset']... delete queue...
+            broker_str = self.o['broker'].url.geturl().replace(
+                ':' + self.o['broker'].url.password + '@', '@')
 
-            if ebo < 60: ebo *= 2
+            # from Queue declare
+            msg_count = self._queueDeclare()
+            
+            if msg_count == -2: return
 
-            logger.info("Sleeping {} seconds ...".format(ebo))
-            interruptible_sleep(ebo, obj=self)
+            if self.o['queueBind'] and self.o['queueName']:
+                for tup in self.o['bindings']:
+                    exchange, prefix, subtopic = tup
+                    topic = '.'.join(prefix + subtopic)
+                    if self.o['dry_run']:
+                        logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
+                            ( self.o['queueName'], topic, exchange, broker_str ) )
+                    else:
+                        logger.info('binding %s with %s to %s (as: %s)' % \
+                            ( self.o['queueName'], topic, exchange, broker_str ) )
+                        if exchange:
+                            self.management_channel.queue_bind(self.o['queueName'], exchange,
+                                            topic)
+
+            # Setup Successfully Complete!
+            self.metricsConnect()
+            logger.debug('getSetup ... Done!')
+            return
+
+        except Exception as err:
+            logger.error(
+                f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
+            )
+            logger.error("AMQP getSetup failed to {} with {}".format(
+                self.o['broker'].url.hostname, err))
+            logger.debug('Exception details: ', exc_info=True)
 
     def putSetup(self) -> None:
 
         ebo = 1
 
-        while True:
+        # It does not really matter how it fails, the recovery approach is always the same:
+        # tear the whole thing down, and start over.
+        try:
+            if self._stop_requested:
+                return
 
-            # It does not really matter how it fails, the recovery approach is always the same:
-            # tear the whole thing down, and start over.
-            try:
-                if self._stop_requested:
-                    break
+            if self.o['broker'] is None:
+                logger.critical( f"no broker given" )
+                return
 
-                if self.o['broker'] is None:
-                    logger.critical( f"no broker given" )
-                    break
+            if not self.__connect(self.o['broker']):
+                logger.critical('could not connect')
+                return
 
-                if not self.__connect(self.o['broker']):
-                    logger.critical('could not connect')
-                    break
+            # transaction mode... confirms would be better...
+            self.channel.tx_select()
+            broker_str = self.o['broker'].url.geturl().replace(
+                ':' + self.o['broker'].url.password + '@', '@')
 
-                # transaction mode... confirms would be better...
-                self.channel.tx_select()
-                broker_str = self.o['broker'].url.geturl().replace(
-                    ':' + self.o['broker'].url.password + '@', '@')
+            #logger.debug('putSetup ... 1. connected to {}'.format(broker_str ) )
 
-                #logger.debug('putSetup ... 1. connected to {}'.format(broker_str ) )
+            if self.o['exchangeDeclare']:
+                logger.debug('putSetup ... 1. declaring {}'.format(
+                    self.o['exchange']))
+                if type(self.o['exchange']) is not list:
+                    self.o['exchange'] = [self.o['exchange']]
+                for x in self.o['exchange']:
+                    if self.o['dry_run']:
+                        logger.info('exchange declare (dry run): %s (as: %s)' %
+                                (x, broker_str))
+                    else:
+                        self.channel.exchange_declare(
+                            x,
+                            'topic',
+                            auto_delete=self.o['auto_delete'],
+                            durable=self.o['durable'])
+                        logger.info('exchange declared: %s (as: %s)' %
+                                (x, broker_str))
 
-                if self.o['exchangeDeclare']:
-                    logger.debug('putSetup ... 1. declaring {}'.format(
-                        self.o['exchange']))
-                    if type(self.o['exchange']) is not list:
-                        self.o['exchange'] = [self.o['exchange']]
-                    for x in self.o['exchange']:
-                        if self.o['dry_run']:
-                            logger.info('exchange declare (dry run): %s (as: %s)' %
-                                    (x, broker_str))
-                        else:
-                            self.channel.exchange_declare(
-                                x,
-                                'topic',
-                                auto_delete=self.o['auto_delete'],
-                                durable=self.o['durable'])
-                            logger.info('exchange declared: %s (as: %s)' %
-                                    (x, broker_str))
+            # Setup Successfully Complete!
+            self.metricsConnect()
+            logger.debug('putSetup ... Done!')
+            return
 
-                # Setup Successfully Complete!
-                self.metricsConnect()
-                logger.debug('putSetup ... Done!')
-                break
-
-            except Exception as err:
-                logger.error(
-                    "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
-                    .format(self.o['exchange'], self.o['broker'].url.username,
-                            self.o['broker'].url.hostname, err))
-                logger.debug('Exception details: ', exc_info=True)
-
-            if not self.o['message_strategy']['stubborn']: return
-
-            if ebo < 60: ebo *= 2
-
-            self.close()
-            logger.info("Sleeping {} seconds ...".format(ebo))
-            interruptible_sleep(ebo, obj=self)
+        except Exception as err:
+            logger.error(
+                "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
+                .format(self.o['exchange'], self.o['broker'].url.username,
+                        self.o['broker'].url.hostname, err))
+            logger.debug('Exception details: ', exc_info=True)
 
     def putCleanUp(self) -> None:
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -333,7 +333,7 @@ class AMQP(Moth):
         self.next_connect_time = now + next_try
         logger.error( f"could not connect. next try in {next_try} seconds.")
 
-    def getSetup(self) -> bool:
+    def getSetup(self) -> None:
         """
         Setup so we can get messages.
 

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -129,6 +129,10 @@ class MQTT(Moth):
         self.o.update(default_options)
         self.o.update(options)
 
+        now = time.time()
+        self.next_connect_time = now
+        self.next_connect_failures = 0
+
         if 'qos' in self.o:
             if type(self.o['qos']) is not int:
                 self.o['qos'] = int(self.o['qos'])


### PR DESCRIPTION
replaced #1244 by cherry picking just the relevant commits and adding them to an uptodate development tree... #1244 was getting very confusing with > 20 commits of mixes of the two branches.  With this restart, it's only a handful of commits, much easier to review.

goal: If we have multiple broker connections, then we can't loop waiting to connect to each one... because every time
one broker connection goes down, it will just loop there.

* old behaviour: getSetup and putSetup loop waiting to get a connection.
* new behaviour: getSetup and putSetup fail and return.
main loop then calls them again.

This is also consistent with the pattern of trying to have a single place where the code sleeps.

The only change in this code is to remove the loop (which outdented the entire routine by 4... sigh...) changing "break" to "return" in a few places, and removing the sleeps.

So that's the first few patches... later it dawned that even if you loop from mainline... when you do a connection attempt and it hangs... you will spend all your time looping and hanging.  To get some free time (so other connections can be used.) added exponential back off to connection attempts.  That's the rest of the commits.  Look at how long it took for the connection to fail, and then back off for at least twice that long.

note that when failures are quick, they can take variable amounts of time, so the ebo might not continuously increase because the backoff period is a multiple of how long it took to fail, so if it fails faster, it might want to retry sooner.

you get an odd pattern of retries... that generally does the right thing, but looks wrong...


