### PR TITLE
suppress error message about missing subscriptions.json

### DIFF
--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -34,7 +34,7 @@ class Subscriptions(list):
                         s['broker'] = broker
             return self
         except Exception as Ex:
-            logger.error( f"failed to read to {fn}: {Ex}" )
+            logger.debug( f"failed {fn}: {Ex}" )
             logger.debug('Exception details: ', exc_info=True)
             return None
 
@@ -50,7 +50,7 @@ class Subscriptions(list):
             with open(fn,'w') as f:
                 f.write(json.dumps(jl))
         except Exception as Ex:
-            logger.error( f"failed to write to {fn}: {Ex}" )
+            logger.error( f"failed: {fn}: {Ex}" )
             logger.debug('Exception details: ', exc_info=True)
 
     def add(self, new_subscription):


### PR DESCRIPTION
The first time you run any configuration (or any existing configuration from an older version) you will see unable to open error.  It's normal for it not to exist on first startup (or first after upgrade.) I just demoted it to debug.  Not sure if there are useful cases of this error.