### PR TITLE
Refactor the interruptible_sleep test

### DIFF
--- a/tests/sarracenia/interruptible_sleep_test.py
+++ b/tests/sarracenia/interruptible_sleep_test.py
@@ -3,9 +3,7 @@ from tests.conftest import *
 #from unittest.mock import Mock
 
 import datetime
-import os
 import signal
-import subprocess
 from sarracenia.interruptible_sleep import interruptible_sleep
 
 class SleepThing():
@@ -14,54 +12,52 @@ class SleepThing():
         self.other_name = False
         signal.signal(signal.SIGTERM, self.signal_handler)
         signal.signal(signal.SIGINT, self.signal_handler)
+        signal.signal(signal.SIGALRM, self.signal_handler)
     
     def signal_handler(self, signum, stack):
         self._stop_requested = True
         self.other_name = True
 
 def test_interruptible_sleep():
-    st = SleepThing()
     stime = 10
 
     # Test that sleep sleeps for the right amount of time when not interrupted
+    st = SleepThing()
     before_time = datetime.datetime.now()
     result = interruptible_sleep(stime, st)
     after_time = datetime.datetime.now()
     assert (result == False)
-    assert ( (after_time - before_time).seconds == stime)
+    assert ( int((after_time - before_time).seconds) == stime)
 
     # Test that the sleep behaves correctly when interrupted
-    # send a SIGINT to this process after 5 seconds:
-    cmdline = f"""bash -c '/usr/bin/sleep 5; kill -SIGTERM {os.getpid()};' &"""
-    subprocess.run(cmdline, shell=True)
+    st = SleepThing()
+    # send a SIGALRM to this process after 5 seconds:
+    signal.alarm(5)
     before_time = datetime.datetime.now()
     result = interruptible_sleep(stime, st)
     after_time = datetime.datetime.now()
     assert result
-    assert ( (after_time - before_time).seconds == 5)
+    assert ( int((after_time - before_time).seconds) == 5)
 
     # Test using a different nap_time
     st = SleepThing()
-    # send a SIGINT to this process after 5 seconds:
-    cmdline = f"""bash -c '/usr/bin/sleep 5; kill -SIGTERM {os.getpid()};' &"""
-    subprocess.run(cmdline, shell=True)
+    # send a SIGALRM to this process after 5 seconds:
+    signal.alarm(5)
     before_time = datetime.datetime.now()
     result = interruptible_sleep(stime, st, nap_time=1)
     after_time = datetime.datetime.now()
     assert result
-    assert ( (after_time - before_time).seconds == 5)
-
+    assert ( int((after_time - before_time).seconds) == 5)
 
     # Test using a different attribute name
     st = SleepThing()
-    # send a SIGINT to this process after 5 seconds:
-    cmdline = f"""bash -c '/usr/bin/sleep 5; kill -SIGTERM {os.getpid()};' &"""
-    subprocess.run(cmdline, shell=True)
+    # send a SIGALRM to this process after 5 seconds:
+    signal.alarm(5)
     before_time = datetime.datetime.now()
     result = interruptible_sleep(stime, st, stop_flag_name = 'other_name')
     after_time = datetime.datetime.now()
     assert result
-    assert ( (after_time - before_time).seconds == 5)
+    assert ( int((after_time - before_time).seconds) == 5)
 
 
 


### PR DESCRIPTION
The previous method of sending signals (spawning a background process that would sleep for 5 seconds then send a SIGTERM) proved to be unreliable. This uses SIGALRM instead and didn't fail at all in my testing.