### PR TITLE
Improve Redis Flow Tests on GitHub

### DIFF
--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - v03_disabled
-      - **redis**
+      - '**redis**'
     
     paths-ignore:
       - '.github/**'

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - v03_disabled
+      - **redis**
     
     paths-ignore:
       - '.github/**'

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - v03_disabled
-      - '**redis**'
+      - '*redis*'
     
     paths-ignore:
       - '.github/**'

--- a/travis/add_redis.sh
+++ b/travis/add_redis.sh
@@ -73,9 +73,25 @@ else
 fi
 echo -e "..done\n"
 
+# later OS versions have later versions of pip that require convincing to actually install.
+. /etc/os-release
+if [ "${VERSION_ID}" \> "22.04" ]; then
+        pip_install="pip3 install --break-system-packages --user "
+else
+        pip_install="pip3 install "
+fi
+
 echo "Install Redis Python modules... "
 # Install Python modules
-pip3 install redis python-redis-lock
+sudo apt -y install python3-redis || true
+for PKG in redis python-redis-lock; do
+    PKG_INSTALLED="`pip3 list | grep ${PKG}`"
+    if [ "$?" == "0" ] ; then
+        echo "$PKG is already installed"
+    else
+        ${pip_install} ${PKG}
+    fi
+done
 echo -e "..done\n"
 
 echo "Add redis options to sr3 default config... "


### PR DESCRIPTION
Partially fix the Redis tests on 24.04 by copying over the pip break system packages argument from the main flow_autoconfig.

I also install the python3-redis package using apt, if it's available.

They're still not perfect, but it's nice to have fewer test failures in each pull request.