### PR TITLE
Fix #1266 - Add a check for any disabled configs when using sr3 start

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2233,6 +2233,20 @@ class sr_GlobalState:
         if len(self.leftovers) > 0 and not self._action_all_configs:
             logging.error( f"{self.leftovers} configuration not found" )
             return
+        
+        has_disabled_config = False
+
+        # if any configs are disabled, don't start any
+        for f in self.filtered_configurations:
+            (c, cfg) = f.split(os.sep)
+            
+            if self.configs[c][cfg]['status'] == 'disabled':
+                has_disabled_config = True
+                logger.error(f"Config {c}/{cfg} is disabled. It must be enabled before starting.")
+
+        if has_disabled_config:
+            logger.error("No configs have been started due to disabled configurations.")
+            return
 
         pcount = 0
         for f in self.filtered_configurations:


### PR DESCRIPTION
Discussed with @reidsunderland:
- Change only needed for sr3 start
- Will not start any configs if any are disabled. This is consistent with #1159: "It's better to do entire operation or none of it"