### PR TITLE
Add fileSizeMax to sender #1285

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2829,6 +2829,10 @@ class Flow:
                 self.reject(msg, 422, f"new_file message field missing, do not know name of file to write. skipping." )
                 continue
 
+            if self.o.fileSizeMax > 0 and msg['size'] > self.o.fileSizeMax: 
+                self.reject(msg, 413, f"Payload Too Large {msg.getIDStr()}") 
+                continue
+
             # weed out non-file transfer operations that are configured to not be done.
             if 'fileOp' in msg:
                 if ('directory' in msg['fileOp']) and ('remove' in msg['fileOp']) and ( 'rmdir' not in self.o.fileEvents ):

--- a/sarracenia/flowcb/send/am.py
+++ b/sarracenia/flowcb/send/am.py
@@ -86,7 +86,8 @@ class Am(FlowCB):
 
         # Step out of the function if the bulletin size is too big
         if len(strdata) > self.o.fileSizeMax:
-            raise Exception(f"Bulletin length too long. Bulletin limit length: {self.o.MaxBulLen}. Latest bulletin length: {len(strdata)}. Path to bulletin: {msg_path}")
+            logger.error(f"Bulletin length too long. Bulletin limit length: {self.o.fileSizeMax}. Latest bulletin length: {len(strdata)}. Path to bulletin: {msg_path}")
+            return None
 
         ## Attach rest of header with NULLs (if not long enough)
         nulheader = ['\0' for _ in range(size)]
@@ -149,6 +150,10 @@ class Am(FlowCB):
     def send(self, bulletin):
         try:
             self.packed_bulletin = self.wrapbulletin(bulletin)
+
+            # We don't want to send nothing.
+            if self.packed_bulletin == None:
+                return False
 
             while True:
                 try:

--- a/sarracenia/flowcb/send/am.py
+++ b/sarracenia/flowcb/send/am.py
@@ -53,6 +53,11 @@ class Am(FlowCB):
 
         self.o.add_option('MaxBulLen', 'count', 32768)
 
+        # Get a default value if not set
+        if self.o.fileSizeMax <= 0:
+            self.o.fileSizeMax = self.o.MaxBulLen
+            logger.warning(f"Attributing fileSizeMax, MaxBulLen value : {self.o.MaxBulLen} bytes max")
+
         # Initialise socket
         ## Create a TCP/IP socket
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -80,7 +85,7 @@ class Am(FlowCB):
         header = strdata[0:size]
 
         # Step out of the function if the bulletin size is too big
-        if len(strdata) > self.o.MaxBulLen:
+        if len(strdata) > self.o.fileSizeMax:
             raise Exception(f"Bulletin length too long. Bulletin limit length: {self.o.MaxBulLen}. Latest bulletin length: {len(strdata)}. Path to bulletin: {msg_path}")
 
         ## Attach rest of header with NULLs (if not long enough)


### PR DESCRIPTION
The sender will now refuse to send files if `fileSizeMax` is set and if a message has a size greater then the `fileSizeMax` value.

```
'fileSizeMax': 32768,
...
2024-11-05 20:58:47,278 [INFO] sarracenia.flowcb.log after_accept accepted: (lag: 2.40 )  exchange: xpublic subtopic: 20241105.SSC-DATAINTERCHANGE.MSC-BULLETINS.20241105.SSC-DATAINTERCHANGE.MSC-BULLETINS.FP.KOKX.20 a file with baseUrl: http://ddsr-cmc-dev01.cmc.ec.gc.ca relPath: 20241105/SSC-DATAINTERCHANGE/MSC-BULLETINS/20241105/SSC-DATAINTERCHANGE/MSC-BULLETINS/FP/KOKX/20/FPUS51_KOKX_052058___234 sundew_extension: cvt_nws_bulletins-sr:KOKX:FP:3:Direct:20241105205843 id: OKcNKq5 size: 40834
2024-11-05 20:58:47,279 [WARNING] sarracenia setReport unknown report code supplied: 413:Payload Too Large http://ddsr-cmc-dev01.cmc.ec.gc.ca /20241105/SSC-DATAINTERCHANGE/MSC-BULLETINS/20241105/SSC-DATAINTERCHANGE/MSC-BULLETINS/FP/KOKX/20/FPUS51_KOKX_052058___234
```

I also accomodated the AM sender code to use `fileSizeMax` and attribute a default value if ever `fileSizeMax` is missing