### PR TITLE
got github notice about artifact@v3 being obsoleted

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -81,7 +81,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -74,7 +74,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -43,7 +43,7 @@ jobs:
          
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+        uses: mxschmitt/action-tmate@v4
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Add and Remove configs, 

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -79,7 +79,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -80,7 +80,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}


### PR DESCRIPTION
Got this letter:

> # GitHub
> 
> Artifact actions v3 will be deprecated by December 5, 2024. You are receiving this email because you have GitHub Actions workflows using v3 of actions/upload-artifact or actions/download-artifact. After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.
> 
> To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
> November 14, 12pm - 1pm EST
> November 21, 9am - 5pm EST
> What you need to do
> Update workflows to begin using v4 of the artifact actions as soon as possible. While v4 improves upload and download speeds by up to 98% and includes several new features, there are key differences from previous versions that may require updates to your workflows. Please see the documentation in the project repositories for guidance on how to migrate your workflows.

So... I just changed v3 to v4... could not be bothered to test it.
