### PR TITLE
systemd integration hints were v2 oriented

### DIFF
--- a/docs/source/How2Guides/Admin.rst
+++ b/docs/source/How2Guides/Admin.rst
@@ -196,35 +196,29 @@ gather statisical information.
 Init Integration
 ~~~~~~~~~~~~~~~~
 
-By default, when sarracenia is installed, it is done as a user tool and not a system-wide resource.
-The tools/ sub-directory directory allows for integration with tools for different usage scenarios.
+If installed using a \.deb package, the `Systemd <https://systemd.io/>`_ service files will be put in the right place.
+The package installed in *disabled* state.  use *systemctl* in the normal way to manage it.
 
 .. NOTE::
-   tools/sr.init -- a sample init script suitable for sysv-init or upstart based systems.
-   tools/sarra_system.service -- for systemd base systems for a 'daemon' style deployment.
-   tools/sarra_user.service -- for systemd as a per user service.
+   debian/metpx-sr3.service -- for systemd base systems for a 'daemon' style deployment.
+   tools/metpx-sr3_user.service -- for systemd as a per user service.
 
-
-Systemd installation process, by administrator::
+If installed using python packages, there is less system integration, and one may need to
+manually create appropriate groups and copy files from the source tree into the right 
+system places:
 
    groupadd sarra
    useradd sarra
-   cp tools/sarra_system.service /etc/systemd/system/sarra.service  (if a package installs it, it should go in /usr/lib/systemd/system )
-   cp tools/sarra_user.service /etc/systemd/user/sarra.service (or /usr/lib/systemd/user, if installed by a package )
+   cp debian/metpx-sr3.service /etc/systemd/system  (if a package installs it, it should go in /usr/lib/systemd/system )
+   cp tools/metpx-sr3_user.service /etc/systemd/user/metpx-sr3.service (or /usr/lib/systemd/user, if installed by a package )
    systemctl daemon-reload
    
-It is then assumed that one uses the 'sarra' account to store the daemon oriented (or system-wide) sarra configuration.
-Users can also run their personal configuration in sessions via::
+The *sarra* user is the default account assumed to store the daemon oriented (or system-wide) sarra configuration.
+Users can also run their personal configuration (user mode systemd) in sessions via::
 
-  systemctl --user enable sarra
-  systemctl --user start sarra
+  systemctl --user enable metpx-sr3
+  systemctl --user start metpx-sr3
 
-
-On an upstart or sysv-init based system::
-
-   cp tools/sr.init /etc/init.d/sr
-   <insert magic here to get that activated.>
-  
 
 
 Rabbitmq Setup

--- a/docs/source/How2Guides/Admin.rst
+++ b/docs/source/How2Guides/Admin.rst
@@ -219,6 +219,17 @@ Users can also run their personal configuration (user mode systemd) in sessions 
   systemctl --user enable metpx-sr3
   systemctl --user start metpx-sr3
 
+To have it started on every login, the following might be helpful (assuming polkit present, which it usually is)::
+
+  loginctl enable-linger
+
+if polkit is missing, then it must be enabled by the administrator::
+
+  sudo loginctl enable-linger *user_to_run_metpx-sr3*
+
+
+
+more info: https://wiki.archlinux.org/title/Systemd/User#Automatic_start-up_of_systemd_user_instances
 
 
 Rabbitmq Setup

--- a/docs/source/Tutorials/Install.rst
+++ b/docs/source/Tutorials/Install.rst
@@ -281,6 +281,16 @@ Directories should be made read/write for sara.  The preferences will go in
 ~sarra/.config, and the state files will be in ~sarra/.cache, and the 
 periodic processing (see next session) also be implemented.
 
+If another user is expected to run metpx-sr3, then user mode *SystemD* is available.
+log in as the user::
+
+    systemctl --user enable metpx-sr3
+    systemctl --user start metpx-sr3
+
+Please investigate *SystemD* documentation for more information on running
+metpx-sr3 in either mode.
+
+
 
 Periodic Processing/Cron Jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/fr/CommentFaire/Admin.rst
+++ b/docs/source/fr/CommentFaire/Admin.rst
@@ -250,6 +250,15 @@ Les utilisateurs peuvent également exécuter leur configuration personnelle (mo
   systemctl --user enable metpx-sr3
   systemctl --user start metpx-sr3
 
+Pour le démarrer à au démarrage du système, ce qui suit peut être utile (en supposant que Polkit soit présent, ce qui est généralement le cas) ::
+
+  loginctl enable-linger
+
+Si Polkit est manquant, il doit être activé par l'administrateur ::
+
+  sudo loginctl enable-linger *user_to_run_metpx-sr3*
+
+plus d'informations (en anglais) : https://wiki.archlinux.org/title/Systemd/User#Automatic_start-up_of_systemd_user_instances
 
 
 Installation Rabbitmq

--- a/docs/source/fr/CommentFaire/Admin.rst
+++ b/docs/source/fr/CommentFaire/Admin.rst
@@ -225,39 +225,31 @@ recueillir de l'information statistique.
 Intégration Init
 ~~~~~~~~~~~~~~~~
 
-Par défaut, lorsque sarracenia est installé, il s'agit d'un outil utilisateur
-et non d'une ressource à l'échelle du système. Le répertoire
-tools/sous-répertoire permet l'intégration avec des outils pour différents
-scénarios d'utilisation.
+
+Si installé à l'aide d'un package \.deb, les fichiers de service `Systemd <https://systemd.io/>`_ seront placés au bons endroits.
+Le package est installé dans l'état *disabled* (désactivé.) Utilisez *systemctl* de la manière habituelle pour le gérer.
 
 .. NOTE::
-   tools/sr.init -- script pour sysv-init où upstart
-   tools/sarra_system.service -- pour systemd et déploiment système
-   tools/sarra_user.service -- pour systemd par usage.
+   debian/metpx-sr3.service -- pour systemd et déploiment système
+   tools/metpx-sr3_user.service -- pour systemd individuel par usager.
 
 
-Processus d'installation du système, par l'administrateur::
+Si vous l'installez des packages Python (wheel ou pip), l'intégration du système est moindre 
+et il peut être nécessaire de créer manuellement les groupes appropriés et de 
+copier les fichiers de l'arborescence source vers les emplacements système appropriés::
 
    groupadd sarra
    useradd sarra
-   cp tools/sarra_system.service /etc/systemd/system/sarra.service  (if a package installs it, it should go in /usr/lib/systemd/system )
-   cp tools/sarra_user.service /etc/systemd/user/sarra.service (or /usr/lib/systemd/user, if installed by a package )
+   cp debian/metpx-sr3.service /etc/systemd/system   
+   cp tools/metpx-sr3_user.service /etc/systemd/user/metpx-sr3.service 
    systemctl daemon-reload
    
-Il est alors supposé que l'on utilise le compte 'sarra' pour
-stocker la configuration sarra orientée démon (ou à l'échelle du système).
-Les utilisateurs peuvent également exécuter leur configuration personnelle
-dans les sessions via::
+L'utilisateur *sarra* est le compte par défaut pour la configuration sarra orientée démon (ou à l'échelle du système).
+Les utilisateurs peuvent également exécuter leur configuration personnelle (mode utilisateur systemd) dans les sessions via ::
 
-  systemctl --user enable sarra
-  systemctl --user start sarra
+  systemctl --user enable metpx-sr3
+  systemctl --user start metpx-sr3
 
-
-Sur un système basé sur upstart ou sysv-init::
-
-   cp tools/sr.init /etc/init.d/sr
-   <insert magic here to get that activated.>
-  
 
 
 Installation Rabbitmq


### PR DESCRIPTION
correcting docs to have sr3 info.  removed support for upstart (non-systemd) init systems.
