### PR TITLE
Issue339 try5 fail connections in main loop

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -324,141 +324,124 @@ class AMQP(Moth):
         """
         ebo = 1
 
-        if True:
+        if self._stop_requested:
+            return
+
+        if 'broker' not in self.o or self.o['broker'] is None:
+            logger.critical( f"no broker given" )
+            return
+
+        # It does not really matter how it fails, the recovery approach is always the same:
+        # tear the whole thing down, and start over.
+        try:
+            # from sr_consumer.build_connection...
+            if not self.__connect(self.o['broker']):
+                logger.critical('could not connect')
+                return
             
-            if self._stop_requested:
-                return
+            if self.o['prefetch'] != 0:
+                # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
+                self.channel.basic_qos(0, self.o['prefetch'], False)
 
-            if 'broker' not in self.o or self.o['broker'] is None:
-                logger.critical( f"no broker given" )
-                return
-
-            # It does not really matter how it fails, the recovery approach is always the same:
-            # tear the whole thing down, and start over.
-            try:
-                # from sr_consumer.build_connection...
-                if not self.__connect(self.o['broker']):
-                    logger.critical('could not connect')
-                    return
-                
-                if self.o['prefetch'] != 0:
-                    # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
-                    self.channel.basic_qos(0, self.o['prefetch'], False)
-
-                # only first/lead instance needs to declare a queue and bindings.
-                if 'no' in self.o and self.o['no'] >= 2:
-                    self.metricsConnect()
-                    return
-
-                #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
-
-                #FIXME: test self.first_setup and props['reset']... delete queue...
-                broker_str = self.o['broker'].url.geturl().replace(
-                    ':' + self.o['broker'].url.password + '@', '@')
-
-                # from Queue declare
-                msg_count = self._queueDeclare()
-                
-                if msg_count == -2: return
-
-                if self.o['queueBind'] and self.o['queueName']:
-                    for tup in self.o['bindings']:
-                        exchange, prefix, subtopic = tup
-                        topic = '.'.join(prefix + subtopic)
-                        if self.o['dry_run']:
-                            logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
-                                ( self.o['queueName'], topic, exchange, broker_str ) )
-                        else:
-                            logger.info('binding %s with %s to %s (as: %s)' % \
-                                ( self.o['queueName'], topic, exchange, broker_str ) )
-                            if exchange:
-                                self.management_channel.queue_bind(self.o['queueName'], exchange,
-                                                topic)
-
-                # Setup Successfully Complete!
+            # only first/lead instance needs to declare a queue and bindings.
+            if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
-                logger.debug('getSetup ... Done!')
                 return
 
-            except Exception as err:
-                logger.error(
-                    f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
-                )
-                logger.error("AMQP getSetup failed to {} with {}".format(
-                    self.o['broker'].url.hostname, err))
-                logger.debug('Exception details: ', exc_info=True)
+            #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
-            #if not self.o['message_strategy']['stubborn']: return
+            #FIXME: test self.first_setup and props['reset']... delete queue...
+            broker_str = self.o['broker'].url.geturl().replace(
+                ':' + self.o['broker'].url.password + '@', '@')
 
-            #if ebo < 60: ebo *= 2
+            # from Queue declare
+            msg_count = self._queueDeclare()
+            
+            if msg_count == -2: return
 
-            #logger.info("Sleeping {} seconds ...".format(ebo))
-            #interruptible_sleep(ebo, obj=self)
+            if self.o['queueBind'] and self.o['queueName']:
+                for tup in self.o['bindings']:
+                    exchange, prefix, subtopic = tup
+                    topic = '.'.join(prefix + subtopic)
+                    if self.o['dry_run']:
+                        logger.info('binding (dry run) %s with %s to %s (as: %s)' % \
+                            ( self.o['queueName'], topic, exchange, broker_str ) )
+                    else:
+                        logger.info('binding %s with %s to %s (as: %s)' % \
+                            ( self.o['queueName'], topic, exchange, broker_str ) )
+                        if exchange:
+                            self.management_channel.queue_bind(self.o['queueName'], exchange,
+                                            topic)
+
+            # Setup Successfully Complete!
+            self.metricsConnect()
+            logger.debug('getSetup ... Done!')
+            return
+
+        except Exception as err:
+            logger.error(
+                f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
+            )
+            logger.error("AMQP getSetup failed to {} with {}".format(
+                self.o['broker'].url.hostname, err))
+            logger.debug('Exception details: ', exc_info=True)
 
     def putSetup(self) -> None:
 
         ebo = 1
 
-        if True:
-
-            # It does not really matter how it fails, the recovery approach is always the same:
-            # tear the whole thing down, and start over.
-            try:
-                if self._stop_requested:
-                    return
-
-                if self.o['broker'] is None:
-                    logger.critical( f"no broker given" )
-                    return
-
-                if not self.__connect(self.o['broker']):
-                    logger.critical('could not connect')
-                    return
-
-                # transaction mode... confirms would be better...
-                self.channel.tx_select()
-                broker_str = self.o['broker'].url.geturl().replace(
-                    ':' + self.o['broker'].url.password + '@', '@')
-
-                #logger.debug('putSetup ... 1. connected to {}'.format(broker_str ) )
-
-                if self.o['exchangeDeclare']:
-                    logger.debug('putSetup ... 1. declaring {}'.format(
-                        self.o['exchange']))
-                    if type(self.o['exchange']) is not list:
-                        self.o['exchange'] = [self.o['exchange']]
-                    for x in self.o['exchange']:
-                        if self.o['dry_run']:
-                            logger.info('exchange declare (dry run): %s (as: %s)' %
-                                    (x, broker_str))
-                        else:
-                            self.channel.exchange_declare(
-                                x,
-                                'topic',
-                                auto_delete=self.o['auto_delete'],
-                                durable=self.o['durable'])
-                            logger.info('exchange declared: %s (as: %s)' %
-                                    (x, broker_str))
-
-                # Setup Successfully Complete!
-                self.metricsConnect()
-                logger.debug('putSetup ... Done!')
+        # It does not really matter how it fails, the recovery approach is always the same:
+        # tear the whole thing down, and start over.
+        try:
+            if self._stop_requested:
                 return
 
-            except Exception as err:
-                logger.error(
-                    "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
-                    .format(self.o['exchange'], self.o['broker'].url.username,
-                            self.o['broker'].url.hostname, err))
-                logger.debug('Exception details: ', exc_info=True)
+            if self.o['broker'] is None:
+                logger.critical( f"no broker given" )
+                return
 
-            #if not self.o['message_strategy']['stubborn']: return
+            if not self.__connect(self.o['broker']):
+                logger.critical('could not connect')
+                return
 
-            #if ebo < 60: ebo *= 2
+            # transaction mode... confirms would be better...
+            self.channel.tx_select()
+            broker_str = self.o['broker'].url.geturl().replace(
+                ':' + self.o['broker'].url.password + '@', '@')
 
-            self.close()
-            #logger.info("Sleeping {} seconds ...".format(ebo))
-            #interruptible_sleep(ebo, obj=self)
+            #logger.debug('putSetup ... 1. connected to {}'.format(broker_str ) )
+
+            if self.o['exchangeDeclare']:
+                logger.debug('putSetup ... 1. declaring {}'.format(
+                    self.o['exchange']))
+                if type(self.o['exchange']) is not list:
+                    self.o['exchange'] = [self.o['exchange']]
+                for x in self.o['exchange']:
+                    if self.o['dry_run']:
+                        logger.info('exchange declare (dry run): %s (as: %s)' %
+                                (x, broker_str))
+                    else:
+                        self.channel.exchange_declare(
+                            x,
+                            'topic',
+                            auto_delete=self.o['auto_delete'],
+                            durable=self.o['durable'])
+                        logger.info('exchange declared: %s (as: %s)' %
+                                (x, broker_str))
+
+            # Setup Successfully Complete!
+            self.metricsConnect()
+            logger.debug('putSetup ... Done!')
+            return
+
+        except Exception as err:
+            logger.error(
+                "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
+                .format(self.o['exchange'], self.o['broker'].url.username,
+                        self.o['broker'].url.hostname, err))
+            logger.debug('Exception details: ', exc_info=True)
+
+        self.close()
 
     def putCleanUp(self) -> None:
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -333,7 +333,7 @@ class AMQP(Moth):
         self.next_connect_time = now + next_try
         logger.error( f"could not connect. next try in {next_try} seconds.")
 
-    def getSetup(self) -> bool:
+    def getSetup(self) -> None:
         """
         Setup so we can get messages.
 
@@ -358,6 +358,7 @@ class AMQP(Moth):
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
+                self.connection = None
                 return
             
             if self.o['prefetch'] != 0:
@@ -408,6 +409,7 @@ class AMQP(Moth):
             logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
+            self.connection = None
 
     def putSetup(self) -> None:
 
@@ -428,6 +430,7 @@ class AMQP(Moth):
 
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
+                self.connection = None
                 return
 
             # transaction mode... confirms would be better...
@@ -459,7 +462,6 @@ class AMQP(Moth):
             self.metricsConnect()
             self.next_connect_failures = 0
             logger.debug('putSetup ... Done!')
-            return
 
         except Exception as err:
             logger.error(
@@ -468,7 +470,8 @@ class AMQP(Moth):
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
-        self.close()
+            self.connection=None
+            self.close()
 
     def putCleanUp(self) -> None:
 
@@ -533,8 +536,7 @@ class AMQP(Moth):
             if not self.connection:
                 self.getSetup()
 
-            if not hasattr(self,'channel'):
-                self.close()
+            if (not hasattr(self,'channel')) or (not hasattr(self,'connection')) or not self.connection:
                 return None
 
             raw_msg = self.channel.basic_get(self.o['queueName'])

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -172,7 +172,10 @@ class AMQP(Moth):
 
         super().__init__(props, is_subscriber)
 
-        self.last_qDeclare = time.time()
+        now = time.time()
+        self.last_qDeclare = now
+        self.next_connect_time = now
+        self.next_connect_failures = 0
 
         logging.basicConfig(
             format=
@@ -306,24 +309,37 @@ class AMQP(Moth):
             logger.error(
                     f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
                 )
-            logger.error("AMQP getSetup failed to {} with {}".format(
-                    self.o['broker'].url.hostname, err))
+            logger.error( f"failed queue declare to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
 
         if hasattr(self,'metrics'):
             self.metrics['brokerQueuedMessageCount'] = -1
         return -1
 
+    def setEbo(self,start)->None:
+        """  Calculate next retry time using exponential backoff
+             note that it doesn't look like classic EBO because the time
+             is multiplied by how long it took to fail. Long failures should not
+             be retried quickly, but short failures can be variable in duration.
+             If the timing of failures is variable, the "attempt_duration" will be low, 
+             and so the next_try might get smaller even though it hasn't succeeded yet... 
+             it should eventually settle down to a long period though.
+        """
+        now=time.time()
+        attempt_duration = now - start
+        self.next_connect_failures += 1
+        ebo = 2**self.next_connect_failures
+        next_try = min(attempt_duration * ebo, 600)
+        self.next_connect_time = now + next_try
+        logger.error( f"could not connect. next try in {next_try} seconds.")
 
-    def getSetup(self) -> None:
+    def getSetup(self) -> bool:
         """
         Setup so we can get messages.
 
         if message_strategy is stubborn, will loop here forever.
              connect, declare queue, apply bindings.
         """
-        ebo = 1
-
         if self._stop_requested:
             return
 
@@ -331,12 +347,17 @@ class AMQP(Moth):
             logger.critical( f"no broker given" )
             return
 
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
+
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
         try:
             # from sr_consumer.build_connection...
             if not self.__connect(self.o['broker']):
-                logger.critical('could not connect')
+                self.setEbo(start)
                 return
             
             if self.o['prefetch'] != 0:
@@ -346,6 +367,7 @@ class AMQP(Moth):
             # only first/lead instance needs to declare a queue and bindings.
             if 'no' in self.o and self.o['no'] >= 2:
                 self.metricsConnect()
+                self.next_connect_failures = 0
                 return
 
             #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
@@ -375,6 +397,7 @@ class AMQP(Moth):
 
             # Setup Successfully Complete!
             self.metricsConnect()
+            self.next_connect_failures = 0
             logger.debug('getSetup ... Done!')
             return
 
@@ -382,13 +405,16 @@ class AMQP(Moth):
             logger.error(
                 f'connecting to: {self.o["queueName"]}, durable: {self.o["durable"]}, expire: {self.o["expire"]}, auto_delete={self.o["auto_delete"]}'
             )
-            logger.error("AMQP getSetup failed to {} with {}".format(
-                self.o['broker'].url.hostname, err))
+            logger.error( f"failed connection to {self.o['broker'].url.hostname}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
+            self.setEbo(start)
 
     def putSetup(self) -> None:
 
-        ebo = 1
+        start = time.time()
+        if start < self.next_connect_time:
+            logger.critical( f"too soon to connect again will try in: {self.next_connect_time-start} seconds" )
+            return
 
         # It does not really matter how it fails, the recovery approach is always the same:
         # tear the whole thing down, and start over.
@@ -401,7 +427,7 @@ class AMQP(Moth):
                 return
 
             if not self.__connect(self.o['broker']):
-                logger.critical('could not connect')
+                self.setEbo(start)
                 return
 
             # transaction mode... confirms would be better...
@@ -431,6 +457,7 @@ class AMQP(Moth):
 
             # Setup Successfully Complete!
             self.metricsConnect()
+            self.next_connect_failures = 0
             logger.debug('putSetup ... Done!')
             return
 
@@ -440,6 +467,7 @@ class AMQP(Moth):
                 .format(self.o['exchange'], self.o['broker'].url.username,
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
+            self.setEbo(start)
 
         self.close()
 
@@ -505,6 +533,10 @@ class AMQP(Moth):
         try:
             if not self.connection:
                 self.getSetup()
+
+            if not hasattr(self,'channel'):
+                self.close()
+                return None
 
             raw_msg = self.channel.basic_get(self.o['queueName'])
             if (raw_msg is None) and (self.connection.connected):

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -324,14 +324,14 @@ class AMQP(Moth):
         """
         ebo = 1
 
-        while True:
+        if True:
             
             if self._stop_requested:
-                break
+                return
 
             if 'broker' not in self.o or self.o['broker'] is None:
                 logger.critical( f"no broker given" )
-                break
+                return
 
             # It does not really matter how it fails, the recovery approach is always the same:
             # tear the whole thing down, and start over.
@@ -339,7 +339,7 @@ class AMQP(Moth):
                 # from sr_consumer.build_connection...
                 if not self.__connect(self.o['broker']):
                     logger.critical('could not connect')
-                    break
+                    return
                 
                 if self.o['prefetch'] != 0:
                     # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
@@ -359,7 +359,7 @@ class AMQP(Moth):
                 # from Queue declare
                 msg_count = self._queueDeclare()
                 
-                if msg_count == -2: break
+                if msg_count == -2: return
 
                 if self.o['queueBind'] and self.o['queueName']:
                     for tup in self.o['bindings']:
@@ -378,7 +378,7 @@ class AMQP(Moth):
                 # Setup Successfully Complete!
                 self.metricsConnect()
                 logger.debug('getSetup ... Done!')
-                break
+                return
 
             except Exception as err:
                 logger.error(
@@ -388,32 +388,32 @@ class AMQP(Moth):
                     self.o['broker'].url.hostname, err))
                 logger.debug('Exception details: ', exc_info=True)
 
-            if not self.o['message_strategy']['stubborn']: return
+            #if not self.o['message_strategy']['stubborn']: return
 
-            if ebo < 60: ebo *= 2
+            #if ebo < 60: ebo *= 2
 
-            logger.info("Sleeping {} seconds ...".format(ebo))
-            interruptible_sleep(ebo, obj=self)
+            #logger.info("Sleeping {} seconds ...".format(ebo))
+            #interruptible_sleep(ebo, obj=self)
 
     def putSetup(self) -> None:
 
         ebo = 1
 
-        while True:
+        if True:
 
             # It does not really matter how it fails, the recovery approach is always the same:
             # tear the whole thing down, and start over.
             try:
                 if self._stop_requested:
-                    break
+                    return
 
                 if self.o['broker'] is None:
                     logger.critical( f"no broker given" )
-                    break
+                    return
 
                 if not self.__connect(self.o['broker']):
                     logger.critical('could not connect')
-                    break
+                    return
 
                 # transaction mode... confirms would be better...
                 self.channel.tx_select()
@@ -443,7 +443,7 @@ class AMQP(Moth):
                 # Setup Successfully Complete!
                 self.metricsConnect()
                 logger.debug('putSetup ... Done!')
-                break
+                return
 
             except Exception as err:
                 logger.error(
@@ -452,13 +452,13 @@ class AMQP(Moth):
                             self.o['broker'].url.hostname, err))
                 logger.debug('Exception details: ', exc_info=True)
 
-            if not self.o['message_strategy']['stubborn']: return
+            #if not self.o['message_strategy']['stubborn']: return
 
-            if ebo < 60: ebo *= 2
+            #if ebo < 60: ebo *= 2
 
             self.close()
-            logger.info("Sleeping {} seconds ...".format(ebo))
-            interruptible_sleep(ebo, obj=self)
+            #logger.info("Sleeping {} seconds ...".format(ebo))
+            #interruptible_sleep(ebo, obj=self)
 
     def putCleanUp(self) -> None:
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -468,7 +468,6 @@ class AMQP(Moth):
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
-
         self.close()
 
     def putCleanUp(self) -> None:

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -129,6 +129,10 @@ class MQTT(Moth):
         self.o.update(default_options)
         self.o.update(options)
 
+        now = time.time()
+        self.next_connect_time = now
+        self.next_connect_failures = 0
+
         if 'qos' in self.o:
             if type(self.o['qos']) is not int:
                 self.o['qos'] = int(self.o['qos'])

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -349,74 +349,70 @@ class MQTT(Moth):
 
         something_broke = True
         self.connected=False
-        if True:
 
-            if self._stop_requested:
-                return
+        if self._stop_requested:
+            return
 
-            try:
-                cs = self.o['clean_session']
-                if ('queueName' in self.o) and ('no' in self.o):
-                    cid = self.o['queueName'] + "_i%02d" % self.o['no']
+        try:
+            cs = self.o['clean_session']
+            if ('queueName' in self.o) and ('no' in self.o):
+                cid = self.o['queueName'] + "_i%02d" % self.o['no']
+            else:
+                #cid = ''.join(random.choice(string.ascii_lowercase) for i in range(10))
+                cid = None
+                cs = True
+                logger.info( f" cid=+{cid}+"  )
+
+            props = Properties(PacketTypes.CONNECT)
+            if 'expire' in self.o and self.o['expire']:
+                props.SessionExpiryInterval = int(self.o['expire'])
+            if 'receiveMaximum' in self.o:
+                props.ReceiveMaximum = self.o['receiveMaximum']
+
+            logger.info( f"is no around? {self.o['no']} " )
+            if ('no' in self.o) and self.o['no'] > 0: # instances 'started'
+                self.client = self.__clientSetup(cid)
+                self.client.connect( self.o['broker'].url.hostname, port=self.__sslClientSetup(), \
+                       clean_start=False, properties=props )
+                self.client.enable_logger(logger)
+                self.client.loop_start()
+                ebo=1
+                while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
+                     logger.info( f"waiting for subscription to be set up. (ebo={ebo})")
+                     time.sleep(0.1*ebo)
+                     if self._stop_requested:
+                          break
+                     if ebo < 512 :
+                        ebo *= 2
+
+            else: # either 'declare' or 'foreground'
+                if 'instances' in self.o:    
+                    session_mxi=self.o['instances']+1
                 else:
-                    #cid = ''.join(random.choice(string.ascii_lowercase) for i in range(10))
-                    cid = None
-                    cs = True
-                    logger.info( f" cid=+{cid}+"  )
+                    session_mxi=2
 
-                props = Properties(PacketTypes.CONNECT)
-                if 'expire' in self.o and self.o['expire']:
-                    props.SessionExpiryInterval = int(self.o['expire'])
-                if 'receiveMaximum' in self.o:
-                    props.ReceiveMaximum = self.o['receiveMaximum']
-
-                logger.info( f"is no around? {self.o['no']} " )
-                if ('no' in self.o) and self.o['no'] > 0: # instances 'started'
-                    self.client = self.__clientSetup(cid)
-                    self.client.connect( self.o['broker'].url.hostname, port=self.__sslClientSetup(), \
-                           clean_start=False, properties=props )
-                    self.client.enable_logger(logger)
-                    self.client.loop_start()
-                    ebo=1
+                for i in range(1,session_mxi ):
+                    icid = self.o['queueName'] + "_i%02d" %  i
+                    logger.info( f"declare session for instances {icid}" )
+                    decl_client = self.__clientSetup(icid)
+                    decl_client.on_connect = MQTT.__sub_on_connect
+                    decl_client.connect( self.o['broker'].url.hostname, port=self.__sslClientSetup(decl_client), \
+                       clean_start=False, properties=props )
                     while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
-                         logger.info( f"waiting for subscription to be set up. (ebo={ebo})")
-                         time.sleep(0.1*ebo)
-                         if self._stop_requested:
-                              break
-                         if ebo < 512 :
-                            ebo *= 2
-                    return
-                else: # either 'declare' or 'foreground'
-                    if 'instances' in self.o:    
-                        session_mxi=self.o['instances']+1
-                    else:
-                        session_mxi=2
+                        logger.info( f"waiting ({ebo} seconds) for broker to confirm subscription is set up.")
+                        logger.info( f"for {icid} connect_in_progress={self.connect_in_progress} subscribe_in_progress={self.subscribe_in_progress}" )
+                        if self._stop_requested:
+                            return
+                        if ebo < 60: ebo *= 2
+                        decl_client.loop(ebo)
+                    decl_client.disconnect()
+                    decl_client.loop_stop()
+                    logger.info( f"instance declaration for {icid} done" )
+                
+        except Exception as err:
+            logger.error( f"failed to {self.o['broker'].url.hostname} with {err}" )
+            logger.error('Exception details: ', exc_info=True)
 
-                    for i in range(1,session_mxi ):
-                        icid = self.o['queueName'] + "_i%02d" %  i
-                        logger.info( f"declare session for instances {icid}" )
-                        decl_client = self.__clientSetup(icid)
-                        decl_client.on_connect = MQTT.__sub_on_connect
-                        decl_client.connect( self.o['broker'].url.hostname, port=self.__sslClientSetup(decl_client), \
-                           clean_start=False, properties=props )
-                        while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
-                            logger.info( f"waiting ({ebo} seconds) for broker to confirm subscription is set up.")
-                            logger.info( f"for {icid} connect_in_progress={self.connect_in_progress} subscribe_in_progress={self.subscribe_in_progress}" )
-                            if self._stop_requested:
-                                return
-                            if ebo < 60: ebo *= 2
-                            decl_client.loop(ebo)
-                        decl_client.disconnect()
-                        decl_client.loop_stop()
-                        logger.info( f"instance declaration for {icid} done" )
-                    return
-                    
-            except Exception as err:
-                logger.error( f"failed to {self.o['broker'].url.hostname} with {err}" )
-                logger.error('Exception details: ', exc_info=True)
-
-            #if ebo < 60: ebo *= 2
-            #time.sleep(ebo)
 
     def putSetup(self):
         """
@@ -425,64 +421,60 @@ class MQTT(Moth):
         ebo = 1
 
         self.connected=False
-        while True:
             
-            if self._stop_requested:
-                break
+        if self._stop_requested:
+            return
 
-            try:
-                self.pending_publishes = collections.deque()
-                self.unexpected_publishes = collections.deque()
+        try:
+            self.pending_publishes = collections.deque()
+            self.unexpected_publishes = collections.deque()
+ 
+            props = Properties(PacketTypes.CONNECT)
+            if self.o['messageAgeMax'] > 0:
+                props.MessageExpiryInterval = int(self.o['messageAgeMax'])
+ 
+            self.transport = 'websockets' if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
+               (self.o['broker'].url.scheme[-1] == 'w' ) else 'tcp'
+ 
+            self.client = paho.mqtt.client.Client( 
+                    callback_api_version = paho.mqtt.client.CallbackAPIVersion.VERSION2, \
+                    userdata=self, transport=self.transport, protocol=self.proto_version )
+ 
+            #self.client = paho.mqtt.client.Client(
+            #    protocol=self.proto_version, userdata=self)
+ 
+            self.client.enable_logger(logger)
+            self.client.on_connect = MQTT.__pub_on_connect
+            self.client.on_disconnect = MQTT.__pub_on_disconnect
+            self.client.on_publish = MQTT.__pub_on_publish
+            if 'max_queued_messages' in self.o:
+                self.client.max_queued_messages_set(self.o['max_queued_messages'])
+ 
+            self.client.username_pw_set(self.o['broker'].url.username,
+                                        unquote(self.o['broker'].url.password))
+            self.connect_in_progress = True
+            res = self.client.connect_async(self.o['broker'].url.hostname,
+                                      port=self.__sslClientSetup(),
+                                     properties=props)
+            logger.info( f"connecting to {self.o['broker'].url.hostname}, res={res}" )
+ 
+            self.client.loop_start()
+ 
+            ebo=1
+            while self.connect_in_progress:
+                 logger.info( f"waiting for connection to {self.o['broker']} ebo={ebo}")
+                 time.sleep(0.1*ebo)
+                 if self._stop_requested:
+                      break
+                 if ebo < 512:
+                      ebo *= 2
+                
+            if not self.connect_in_progress:
+                return
 
-                props = Properties(PacketTypes.CONNECT)
-                if self.o['messageAgeMax'] > 0:
-                    props.MessageExpiryInterval = int(self.o['messageAgeMax'])
-
-                self.transport = 'websockets' if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
-                   (self.o['broker'].url.scheme[-1] == 'w' ) else 'tcp'
-
-                self.client = paho.mqtt.client.Client( 
-                        callback_api_version = paho.mqtt.client.CallbackAPIVersion.VERSION2, \
-                        userdata=self, transport=self.transport, protocol=self.proto_version )
-
-                #self.client = paho.mqtt.client.Client(
-                #    protocol=self.proto_version, userdata=self)
-
-                self.client.enable_logger(logger)
-                self.client.on_connect = MQTT.__pub_on_connect
-                self.client.on_disconnect = MQTT.__pub_on_disconnect
-                self.client.on_publish = MQTT.__pub_on_publish
-                if 'max_queued_messages' in self.o:
-                    self.client.max_queued_messages_set(self.o['max_queued_messages'])
-
-                self.client.username_pw_set(self.o['broker'].url.username,
-                                            unquote(self.o['broker'].url.password))
-                self.connect_in_progress = True
-                res = self.client.connect_async(self.o['broker'].url.hostname,
-                                          port=self.__sslClientSetup(),
-                                         properties=props)
-                logger.info( f"connecting to {self.o['broker'].url.hostname}, res={res}" )
-
-                self.client.loop_start()
-
-                ebo=1
-                while self.connect_in_progress:
-                     logger.info( f"waiting for connection to {self.o['broker']} ebo={ebo}")
-                     time.sleep(0.1*ebo)
-                     if self._stop_requested:
-                          break
-                     if ebo < 512:
-                          ebo *= 2
-                    
-                if not self.connect_in_progress:
-                    break
-
-            except Exception as err:
-                logger.error("failed to {self.o['broker'].url.hostname} with {err}" )
-                logger.error('Exception details: ', exc_info=True)
-
-            if ebo < 60: ebo *= 2
-            time.sleep(ebo)
+        except Exception as err:
+            logger.error("failed to {self.o['broker'].url.hostname} with {err}" )
+            logger.error('Exception details: ', exc_info=True)
 
     def __sub_on_message(client, userdata, msg):
         """

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -349,10 +349,10 @@ class MQTT(Moth):
 
         something_broke = True
         self.connected=False
-        while True:
+        if True:
 
             if self._stop_requested:
-                break
+                return
 
             try:
                 cs = self.o['clean_session']
@@ -385,7 +385,7 @@ class MQTT(Moth):
                               break
                          if ebo < 512 :
                             ebo *= 2
-                    break
+                    return
                 else: # either 'declare' or 'foreground'
                     if 'instances' in self.o:    
                         session_mxi=self.o['instances']+1
@@ -403,20 +403,20 @@ class MQTT(Moth):
                             logger.info( f"waiting ({ebo} seconds) for broker to confirm subscription is set up.")
                             logger.info( f"for {icid} connect_in_progress={self.connect_in_progress} subscribe_in_progress={self.subscribe_in_progress}" )
                             if self._stop_requested:
-                                break
+                                return
                             if ebo < 60: ebo *= 2
                             decl_client.loop(ebo)
                         decl_client.disconnect()
                         decl_client.loop_stop()
                         logger.info( f"instance declaration for {icid} done" )
-                    break
+                    return
                     
             except Exception as err:
                 logger.error( f"failed to {self.o['broker'].url.hostname} with {err}" )
                 logger.error('Exception details: ', exc_info=True)
 
-            if ebo < 60: ebo *= 2
-            time.sleep(ebo)
+            #if ebo < 60: ebo *= 2
+            #time.sleep(ebo)
 
     def putSetup(self):
         """


### PR DESCRIPTION
This is a third pass at not looping to retry broker connections in the amqp and mqtt moth drivers.  They now attempt to connect once, and have an exponential backoff implementation to that they don't try to connect again too soon.

This is a preparatory change to, in future, being able to work with multiple broker connections, where if one fails the other still works.  Without this change, when a failure in one broker happens, it will just loop trying to re-connect to it, and not even look at the available good connection to the other broker.

previous attempts :  #1247 

The first two patches here are different, in that it was split into two, so that, in the first patch, you see the substantive changes made to getSetup and putSetup (removing the loop, making it return instead.) the second patch, just fixes the indenting and gets rid of the now dead code (mqtt/putSetup was missed on first pass, so both changes combined in second patch for that routine.)

The remainder of the patches implement ebo (exponential back off) of broker connections.

Ran the flow tests... seems fine.
