### PR TITLE
issue #624 adding INSTANCE to variable substitution

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -661,9 +661,9 @@ Creating the Queue
 Once connected to an AMQP broker, the user needs to create a queue.
 Common settings for the queue on broker :
 
-- **queueShare <strin>         (default: ${USER}_${HOSTNAME}_${RAND8})**
-- **expire        <duration>      (default: 5m  == five minutes. RECOMMEND OVERRIDING)**
-- **message_ttl   <duration>      (default: None)**
+- **queueShare    <string>       (default: ${USER}_${HOSTNAME}_${RAND8})**
+- **expire        <duration>     (default: 5m  == five minutes. RECOMMEND OVERRIDING)**
+- **message_ttl   <duration>     (default: None)**
 - **prefetch      <N>            (default: 1)**
 
 
@@ -1733,6 +1733,7 @@ right hand side to be evaluated, surrounded by ${..} The built-in variables are:
  - ${CONFIG}      - the name of the configuration file being run.
  - ${HOSTNAME}    - the hostname running the client.
  - ${RANDID}      - a random id that will be consistent within a single invocation.
+ - ${INSTANCE}    - The instance id of the running flow.
 
 
 flowCallbacks

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -142,6 +142,7 @@ option, with the use of *${..}* notation:
 * HOSTNAME    - the hostname running the client.
 * RANDID      - a random id (0-64Ki) that will be consistent within a single instance.
 * RAND8       - a random 8 digit wide number that is generated whenever it is evaluated in a string.
+* INSTANCE    - the flow process's instance number 
 
 The %Y%m%d and %h time stamps refer to the time at which the data is processed by
 the component, it is not decoded or derived from the content of the files delivered.

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -1725,6 +1725,7 @@ right hand side to be evaluated, surrounded by ${..} The built-in variables are:
  - ${CONFIG}      - le nom du fichier de configuration en cours d'exécution.
  - ${HOSTNAME}    - le hostname qui exécute le client.
  - ${RANDID}      - Un ID aléatoire qui va être consistant pendant la duration d'une seule invocation.
+ - ${INSTANCE}    - le numéro d'instance du processus.
 
 flowCallbacks
 =============

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -140,6 +140,7 @@ en utilisant la notation *${..} * :
 * HOSTNAME    - le hostname qui exécute le client.
 * RANDID      - Un ID aléatoire qui va être consistant pendant la duration d'une seule invocation.
 * RAND8 - un nombre aléatoire à 8 chiffres qui est généré chaque fois qu'il est évalué dans une chaîne de caractères.
+* INSTANCE   - le numéro d'instance du processus de flux (composant/configuration)
 
 
 Les horodatages %Y%m%d et %H font référence à l’heure à laquelle les données sont traitées par

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1038,6 +1038,12 @@ class Config:
         if ( '${RAND8}' in word ):
             result = result.replace('${RAND8}', str(randint(0, 100000000)).zfill(8))
 
+        if ( '${INSTANCE}' in word ):
+            if hasattr(self,'no'): 
+                instance=self.no
+            else:
+                instance=00
+            result = result.replace('${INSTANCE}', f"{instance:02d}" )
         if not '$' in result:
             return result
 
@@ -1058,6 +1064,8 @@ class Config:
                 repval = getattr(self, e)
                 if type(repval) is list:
                     repval = repval[0]
+                if type(repval) is not str:
+                    repval = str(repval)
                 result = result.replace('${' + E + '}', repval)
                 continue
 


### PR DESCRIPTION
working on getting #624 exchangeSplit working seamlessly.

exchangeSplit is to be the subscriber side mirror to post_exchangeSplit.
On the consumer side, each instance needs to have it's own instance-local queue, and bind to one of the post_exchangeSplit output exchanges of some other configuration.

Until now, all instances in a configuration share a single queue.  Now need to declare 1 queue per instance within a configuration.

1 step is having ${INSTANCE} available for use in queue names.

