### PR TITLE
Fix #1301

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -76,6 +76,10 @@ if features['humanize']['present']:
     import humanize
 
     def naturalSize( num ):
+        # checking for > 0 allows message rate to print just 0m/s when num is 0 instead of 0.00m/s in sr3 status
+        # also ensures that data rate displays properly
+        if num > 0 and num < 1:
+            return f"{num:.2f}m"
         return humanize.naturalsize(num,binary=True).replace(" ","")
 
     def naturalTime( dur ):


### PR DESCRIPTION
Fixes issue #1301.

When message/second rate is > 0 and < 1, will now display rate to 2 decimal places. If rate is 0, will show 0m/s. 

See example:

![image](https://github.com/user-attachments/assets/13e04730-25dd-42c0-be25-31cb86856778)
