### PR TITLE
Issue339 consistent & persistent rand8 (only changes on declare and cleanup.)

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -140,8 +140,8 @@ option, with the use of *${..}* notation:
 * PROGRAM     - the name of the component (subscribe, shovel, etc...)
 * CONFIG      - the name of the configuration file being run.
 * HOSTNAME    - the hostname running the client.
-* RANDID      - a random id (0-64Ki) that will be consistent within a single instance.
-* RAND8       - a random 8 digit wide number that is generated whenever it is evaluated in a string.
+* RANDID      - a random id (0-64Ki) consistent within a single confiuguration.
+* RAND8       - a random 8 digit wide number consistent within a single confiuguration.
 * INSTANCE    - the flow process's instance number 
 
 The %Y%m%d and %h time stamps refer to the time at which the data is processed by
@@ -1559,8 +1559,8 @@ Where:
 
 * *configName* is the configuration file used to tune component behaviour.
 
-* *queueShare* defaults to ${USER}_${HOSTNAME}_${RAND8} but should be overridden with the 
-  *queueShare* configuration option.
+* *queueShare* defaults to ${USER}_${HOSTNAME}_${RAND8} but should be overridden 
+  when, say HOSTNAME does not correctly identify the scope of queue sharing.
 
 Users can override the default provided that it starts with **q_<brokerUser>**.
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -138,8 +138,8 @@ en utilisant la notation *${..} * :
 * PROGRAM     - le nom du composant (subscribe, shovel, etc...)
 * CONFIG      - le nom du fichier de configuration en cours d'exécution.
 * HOSTNAME    - le hostname qui exécute le client.
-* RANDID      - Un ID aléatoire qui va être consistant pendant la duration d'une seule invocation.
-* RAND8 - un nombre aléatoire à 8 chiffres qui est généré chaque fois qu'il est évalué dans une chaîne de caractères.
+* RANDID      - Un ID aléatoire cohérent à l'intérieur d'une seule configuration.
+* RAND8  - un nombre aléatoire de 8 chiffres cohérent à l'intérieur d'une seule configuration.
 * INSTANCE   - le numéro d'instance du processus de flux (composant/configuration)
 
 
@@ -1547,8 +1547,9 @@ Ou:
 
 * *nomDeConfig* est le fichier de configuration utilisé pour régler le comportement des composants.
 
-*  *queueShare* est par défaut ${USER}_${HOSTNAME}_${RAND8} mais doit être remplacé par le
- Option de configuration *queueShare*.
+*  *queueShare* est par défaut ${USER}_${HOSTNAME}_${RAND8} mais doit être remplacé lorsque, par exemple,
+   le ${HOSTNAME} ne va pas être pareil pour tout les instances qui devrait consommer à partir de la même
+   file d´attente de messages..
 
 Les utilisateurs peuvent remplacer le défaut à condition qu’il commence par **q_<utilisateurDeCourtier>**.
 

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -76,6 +76,9 @@ if features['humanize']['present']:
     import humanize
 
     def naturalSize( num ):
+        if num < 1:
+            return f"{num:.3f}B"
+
         return humanize.naturalsize(num,binary=True).replace(" ","")
 
     def naturalTime( dur ):

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1873,12 +1873,31 @@ class Config:
         else:
             # FIXME: insert logic to look at queuefile setting and take the last 8 chars from it, if available...
             #
-            self.rand8 = str(randint(0, 100000000)).zfill(8)
+            if (self.queueName and self.queueName.endswith('_${RAND8}')) or self.queueShare.endswith('_${RAND8}'):
+
+                qfn = self._getQueueFilename(component,cfg)
+
+                queueName=None
+                if not self.__queue_file_read and os.path.isfile(qfn):
+                    f = open(qfn, 'r')
+                    queueName = f.read()
+                    f.close()
+                    self.__queue_file_read=True
+            
+                #if the queuefile is corrupt, then will need to guess anyways.
+                if queueName:
+                    last=queueName.split('_')[-1]
+                    if len(last) > 5 and last.isnumeric():
+                        self.rand8=last
+
+            if not self.rand8:
+                self.rand8 = str(randint(0, 100000000)).zfill(8)
+
             f = open(rand8file, 'w')
             f.write(self.rand8)
             f.close()
 
-    def _resolveQueueName(self,component,cfg):
+    def _getQueueFilename(self,component,cfg):
 
         queuefile = sarracenia.user_cache_dir(
             Config.appdir_stuff['appname'],
@@ -1895,7 +1914,15 @@ class Config:
             queuefile += "%02d" % self.no
         queuefile += '.qname'
 
-        self.queue_filename = queuefile
+        return queuefile
+
+
+
+    def _resolveQueueName(self,component,cfg):
+
+
+        self.queue_filename = self._getQueueFilename(component,cfg)
+        queuefile=self.queue_filename
 
         if not hasattr(self, 'old_subscriptions'):
             self.subscriptionsPath=self._getSubscriptionsFileName(self.component,self.config)
@@ -1927,7 +1954,7 @@ class Config:
         if hasattr(self,'no') and self.no > 1:
 
             config_read_try=0
-            if os.path.isfile(queuefile):
+            if os.path.isfile(self.queue_filename):
                 f = open(queuefile, 'r')
                 queueName = f.read()
                 f.close()

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1404,7 +1404,7 @@ class Config:
 
         self._resolveRand8(self.component,self.config)
         self._resolve_exchange()
-        self.queueName = self._resolveQueueName(self.component,self.config)
+        queueName = self._resolveQueueName(self.component,self.config)
 
         if type(subtopic_string) is str:
             if self.broker.url.scheme == 'amq' :
@@ -1414,7 +1414,7 @@ class Config:
             
         if hasattr(self, 'exchange') and hasattr(self, 'topicPrefix'):
             self.bindings.append((self.exchange, self.topicPrefix, subtopic))
-            self.subscriptions.add(Subscription(self, self.queueName, subtopic))
+            self.subscriptions.add(Subscription(self, queueName, subtopic))
 
     def _parse_v2plugin(self, entryPoint, value):
         """

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -906,6 +906,7 @@ class Config:
         self.pstrip = False
         self.queueName = None
         self.queueShare = "${USER}_${HOSTNAME}_${RAND8}"
+        self.rand8 = None
         self.randomize = False
         self.rename = None
         self.randid = "%04x" % randint(0, 65536)
@@ -1036,7 +1037,8 @@ class Config:
             result = result.replace('${POST_BROKER_USER}', self.post_broker.url.username)
 
         if ( '${RAND8}' in word ):
-            result = result.replace('${RAND8}', str(randint(0, 100000000)).zfill(8))
+            self._resolveRand8(self.component,self.config)
+            result = result.replace('${RAND8}', self.rand8 )
 
         if ( '${INSTANCE}' in word ):
             if hasattr(self,'no'): 
@@ -1400,6 +1402,7 @@ class Config:
             logger.error( f"{','.join(self.files)}:{self.lineno} broker needed before subtopic" )
             return
 
+        self._resolveRand8(self.component,self.config)
         self._resolve_exchange()
         self.queueName = self._resolveQueueName(self.component,self.config)
 
@@ -1843,6 +1846,37 @@ class Config:
             logger.debug( f'queue name {self.queueName} persisted to {self.queue_filename}' )
 
 
+
+    def _resolveRand8(self,component,cfg):
+
+        if self.rand8 != None:
+            return
+
+        rand8file = sarracenia.user_cache_dir(
+            Config.appdir_stuff['appname'],
+            Config.appdir_stuff['appauthor'])
+
+        if self.statehost:
+            rand8file += os.sep + self.hostdir
+
+        rand8file += os.sep + component + os.sep + cfg
+        rand8file += os.sep + 'rand8'
+
+        if not os.path.isdir(os.path.dirname(rand8file)):
+            pathlib.Path(os.path.dirname(rand8file)).mkdir(parents=True, exist_ok=True)
+
+        if os.path.isfile(rand8file):
+            f = open(rand8file, 'r')
+            self.rand8 = f.read()
+            f.close()
+            logger.debug( f"read rand8 {self.rand8} from state file {rand8file}" )
+        else:
+            # FIXME: insert logic to look at queuefile setting and take the last 8 chars from it, if available...
+            #
+            self.rand8 = str(randint(0, 100000000)).zfill(8)
+            f = open(rand8file, 'w')
+            f.write(self.rand8)
+            f.close()
 
     def _resolveQueueName(self,component,cfg):
 


### PR DESCRIPTION
So this is part of eventual multi queue support (which includes multi-broker support.) the RAND8 thing needs to be "reliable" evaluating to the same thing every time we resolve it.   The value only changes on a fresh declare (after a cleanup.)


This set of patches makes a rand8 state file in the state directory, allowing "self.o.rand8" to evaluate to the same thing regardless of how many times it is substituted.   Before this change, in RAND8 showed up in a variable, it would get substituted by a different value every time it got substituted.

The config parser reads the files at least twice... sometimes more often, so it won't result in the same values with each pass.   Second time you resolve a queue name that has RAND8 in it, you get a different value from the first time.  

Until now, there was only one queue. The queue name would get evaluated once and then the resolved value would be used later.  This is difficult to work with in the context of things like "exchangeSplit" where we need to create 1 queue per instance... so it needs to be evaluated n times, and each queue would have a different RAND8.  

 I guess that could work... having each queue with completely different RAND8 values, but it would be confusing... it would be much more obvious if they all used the same RAND8 value.  

Anyways... the idea is to have a more consistent RAND8 value.

The other thing this patch set does is detect in previous versions when there is a RAND8 value already used (in the queueName) and copy it into the rand8 statefile so it is understood by current  and future versions.

