### PR TITLE
user mode systemctl start should not setuid/setgid

### DIFF
--- a/tools/metpx-sr3_user.service
+++ b/tools/metpx-sr3_user.service
@@ -22,8 +22,6 @@ After=network.target
 [Service]
 Type=forking
 ExecStart=/usr/bin/sr3 start
-User=%i
-Group=users
 
 ExecReload=/usr/bin/sr3 reload
 ExecStop=/usr/bin/sr3 stop


### PR DESCRIPTION
A client was testing user mode systemd service... and as a normal user, should not have User= or Group= as the effect of those is to setuid/setgid... which we don't need.

It causes errors on startup.
