### PR TITLE
add sdnotify support to cli, for Systemd

### DIFF
--- a/debian/metpx-sr3.service
+++ b/debian/metpx-sr3.service
@@ -11,7 +11,7 @@ After=network-online.target local-fs.target remote-fs.target
 Requires=network-online.target
 
 [Service]
-Type=forking
+Type=Notify
 ExecStart=/usr/bin/sr3 start
 User=sarra
 Group=sarra

--- a/debian/metpx-sr3.service
+++ b/debian/metpx-sr3.service
@@ -11,7 +11,7 @@ After=network-online.target local-fs.target remote-fs.target
 Requires=network-online.target
 
 [Service]
-Type=Notify
+Type=notify
 ExecStart=/usr/bin/sr3 start
 User=sarra
 Group=sarra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,13 +63,21 @@ sr3_tailf = "sarracenia.sr_tailf:main"
 [project.optional-dependencies]
 
 amqp = [ "amqp" ]
-ftppoll = [ 'dateparser' ]
-mqtt = [ 'paho.mqtt>=1.5.1' ]
-vip = [ 'netifaces' ]
-redis = [ 'redis' ]
+antivirus = [ "pyclamd" ]
+AWS_S3 = [ "boto3" ]
+azure = [ "azure.storage.blob" ]
 filetypes-redhat = [ 'file-magic' ]
 filetypes = [ 'python-magic' ]
-
+ftppoll = [ 'dateparser' ]
+jsonlogs = [ 'pythonjsonlogger' ]
+mqtt = [ 'paho.mqtt>=1.5.1' ]
+reassembly = [ 'flufl.lock' ]
+redis = [ 'redis' ]
+sdnotify = [ "sdnotify" ]
+geofiltering = [ "geojson", "turfpy" ]
+vip = [ 'netifaces' ]
+KIWIS = [ 'kiwis_pie' ]
+USGS = [ 'pandas' ]
 
 [project.urls]
 Documentation = "https://metpx.github.io/sarracenia"

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -91,6 +91,10 @@ features = {
     's3' : { 'modules_needed': [ 'boto3' ], 'present': False, 
         'lament' : 'cannot connect natively to S3-compatible locations (AWS S3, Minio, etc..)', 
         'rejoice': 'able to connect natively to S3-compatible locations (AWS S3, Minio, etc..)', },
+   'sdnotify' : { 'modules_needed': [ 'sdnotify' ],
+        'lament': 'cannot inform system of correct startup.',
+        'rejoice': 'can tell system when correctly started.'
+        },
    'sftp' : { 'modules_needed': [ 'paramiko' ],
         'lament': 'cannot use or access sftp/ssh based services',
         'rejoice': 'can use sftp or ssh based services'

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2276,6 +2276,13 @@ class sr_GlobalState:
 
         print('( %d ) Done' % pcount)
 
+        if sarracenia.features['sdnotify']['present']:
+            import sdnotify
+
+            n = sdnotify.SystemdNotifier()
+            n.notify("READY=1")
+
+
     def run(self):
         """
             docker compatible run in foreground.
@@ -2306,6 +2313,12 @@ class sr_GlobalState:
             return
 
         self._clean_missing_proc_state()
+
+        if sarracenia.features['sdnotify']['present']:
+            import sdnotify
+
+            n = sdnotify.SystemdNotifier()
+            n.notify("STOPPING=1")
 
         if len(self.procs) == 0:
             print('no procs running...already stopped')

--- a/tools/metpx-sr3_user.service
+++ b/tools/metpx-sr3_user.service
@@ -20,10 +20,8 @@ Description=Sarracenia V3 File Copy Service
 After=network.target
 
 [Service]
-Type=forking
+Type=notify
 ExecStart=/usr/bin/sr3 start
-User=%i
-Group=users
 
 ExecReload=/usr/bin/sr3 reload
 ExecStop=/usr/bin/sr3 stop


### PR DESCRIPTION
fixes #1318 systemd recommends against Type=forking, preferring TYPE=notify. To do that, we need to make little api calls during startup and shutdown. Added those.

This makes systemd happier on startup and seems to show status messages correctly.