### PR TITLE
Issue1322 post exchange split revamp

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -2247,7 +2247,7 @@ post_exchangeSplit   <number>   (default: 0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The **post_exchangeSplit** option appends a two digit suffix resulting from 
-hashing the last character of the checksum to the post_exchange name,
+hashing the path to the post_exchange name,
 in order to divide the output amongst a number of exchanges.  This is currently used
 in high traffic pumps to allow multiple instances of winnow, which cannot be
 instanced in the normal way.  Example::

--- a/docs/source/How2Guides/Admin.rst
+++ b/docs/source/How2Guides/Admin.rst
@@ -146,7 +146,7 @@ winnow is used to suppress duplicates.
 first time a posting is received, it could be picked by one instance, and if a duplicate one is received
 it would likely be picked up by another instance. **For effective duplicate suppression with instances**,
 one must **deploy two layers of subscribers**. Use a **first layer of subscribers (shovels)** with duplicate
-suppression turned off and output with *post_exchangeSplit*, which route posts by checksum to
+suppression turned off and output with *post_exchangeSplit*, which route posts by path to
 a **second layer of subscribers (sr_winnow) whose duplicate suppression caches are active.**
 
 

--- a/docs/source/How2Guides/FlowCallbacks.rst
+++ b/docs/source/How2Guides/FlowCallbacks.rst
@@ -342,12 +342,12 @@ Customizing post_exchangeSplit
 
 The exchangeSplit function allows a single flow to send outputs to different exchanges, 
 numbered 1...n to provide load distribution. The built-in processing does this in a 
-fixed way based on the hash of the identify field. The purpose of exchangeSplit is to 
+fixed way based on the hash of the relPath field. The purpose of exchangeSplit is to 
 allow a common set of downstream paths to receive a subset of the total flow, and for 
 products with similar "routing" to land on the same downstream node. For example, a file 
 with a given checksum, for winnowing to work, has to land on the same downstream node.
 
-It could be that, rather than using a checksum, one would prefer to use some other
+It could be that, rather than using the path, one would prefer to use some other
 method to decide which exchange is used::
 
   import logging

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1307,7 +1307,7 @@ picked by one instance, and if a duplicate one is received it would likely
 be picked up by another instance. **For effective duplicate suppression with instances**,
 one must **deploy two layers of subscribers**. Use
 a **first layer of subscribers (shovels)** with duplicate suppression turned
-off and output with *post_exchangeSplit*, which route notification with the same checksum to
+off and output with *post_exchangeSplit*, which route notification with the same path to
 the same member of a **second layer of subscribers (winnow) whose duplicate suppression caches 
 are active.**
 
@@ -1453,11 +1453,18 @@ to modify messages generated about files prior to posting.
 post_exchangeSplit <count> (default: 0)
 ---------------------------------------
 
-The **post_exchangeSplit** option appends a two digit suffix resulting from
-hashing the last character of the checksum to the post_exchange name,
-in order to divide the output amongst a number of exchanges.  This is currently used
-in high traffic pumps to allow multiple instances of winnow, which cannot be
-instanced in the normal way.  Example::
+The **post_exchangeSplit** option appends a two digit suffix to the post_exchange name,
+in order to divide the output amongst a number of exchanges. 
+
+Each message is posted to one of the exchanges based on an index
+derived from the message, intended to be the same for a given path.
+The hash is calculated as the sum of the characters in *relPath* field
+or, if missing, *retrievePath*, or if missing 0) modulo the number of
+exchanges.
+
+This is currently used in high traffic pumps to allow multiple 
+instances of winnow, which cannot be instanced in the normal way.
+Example::
 
     post_exchangeSplit 5
     post_exchange xwinnow
@@ -1465,6 +1472,7 @@ instanced in the normal way.  Example::
 will result in posting messages to five exchanges named: xwinnow00, xwinnow01,
 xwinnow02, xwinnow03 and xwinnow04, where each exchange will receive only one fifth
 of the total flow.
+
 
 post_format <name> (default: v03)
 ---------------------------------

--- a/docs/source/fr/CommentFaire/FlowCallbacks.rst
+++ b/docs/source/fr/CommentFaire/FlowCallbacks.rst
@@ -309,7 +309,7 @@ Personnalisation de post_exchangeSplit
 
 La fonction ExchangeSplit permet à un seul flux d'envoyer des sorties à différents échanges,
 numérotés 1...n pour assurer la répartition de la charge. Le traitement intégré le fait de manière
-manière fixe basée sur le hachage du champ d'identification. Le but d'exchangeSplit est de
+manière fixe basée sur le hachage du champs *relPath*. Le but d'exchangeSplit est de
 permettre à un ensemble commun de chemins en aval de recevoir un sous-ensemble du flux total, et pour
 les produits avec un « routage » similaire atterrissent sur le même nœud en aval. Par exemple, un fichier
 avec une somme de contrôle donnée, pour que le vannage fonctionne, il doit atterrir sur le même nœud en aval.

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -2230,8 +2230,8 @@ une telle configuration.
 post_exchangeSplit   <number>   (défaut: 0)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-L'option **post_exchangeSplit** ajoute un suffixe à deux chiffres résultant d'une
-division entière du dernier digit de la somme de contrôle, afin de répartir les
+L'option **post_exchangeSplit** ajoute un suffixe à deux chiffres résultant de
+hacher le chemin (relPath), afin de répartir les
 avis entre un certain nombre d'échanges, selon la valeur de leur somme de contrôle.
 C'est utilisé dans les pompes à trafic élevé pour permettre des instances
 multiples de winnow, ce qui ne peut pas être instancié de la manière normale. exemple::

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1297,7 +1297,7 @@ une fil d’attente, la première fois qu’une publication est reçue, elle peu
 et si un doublon est ensuite reçu, il sera probablement choisi par une autre instance.
 **Pour une suppression efficace des doublons avec les instances**, il faut **déployer deux couches d’abonnés**.
 Utiliser une **première couche d’abonnés (shovels)** avec la suppression de doublons éteinte et
-utiliser *post_exchangeSplit* pour la sortie. Cela achemine les publications en utilisant la somme de contrôle vers
+utiliser *post_exchangeSplit* pour la sortie. Cela achemine les publications du même chemin
 une **deuxième couche d’abonnés (winnow) dont les caches de suppression des doublons sont actives.**
 
 
@@ -1448,8 +1448,15 @@ pour modifier les messages d'annonce générés à propos des fichiers avant leu
 post_exchangeSplit <compte> (défaut: 0)
 ---------------------------------------
 
-L’option **post_exchangeSplit** ajoute un suffixe à deux chiffres qui est crée en hachant le dernier caractère
-de la somme de contrôle avec le nom de post_exchange, afin de répartir la production entre un certain nombre d’échanges.
+L'option **post_exchangeSplit** ajoute un suffixe à deux chiffres au nom post_exchange,
+afin de répartir la production entre plusieurs échanges.
+
+Chaque message est publié sur l'un des échanges en fonction d'un index
+dérivé du message, destiné à être le même pour un chemin donné.
+Le hachage est calculé comme la somme des caractères du champ *relPath*
+ou, s'il manque, *retrievePath*, ou s'il manque 0) modulo le nombre de
+échanges.
+
 Ceci est actuellement utilisé dans les pompes à trafic élevé pour avoir plusieurs instances de winnow,
 qui ne peuvent pas être instancié de la manière normale.  Exemple::
 

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -436,6 +436,25 @@ class Moth():
         self.next_connect_time = now + next_try
         logger.error( f"could not connect. next try in {next_try} seconds.")
 
+    def splitPick(self,message) -> int:
+        """
+           given a message and exchangeSplit, return the number to split to.
+        """
+
+        # FIXME: assert ( len(self.o['exchange']) == self.o['post_exchangeSplit'] )
+        #        if that isn't true... then there is something wrong... should we check ?
+        if 'exchangeSplitOverride' in message:
+            idx = int(message['exchangeSplitOverride'])%len(self.o['exchange'])
+        elif 'relPath' in message:
+            idx = sum( bytearray( message['relPath'], 'ascii')) % len(self.o['exchange'])
+        elif 'retrievePath' in message:
+            idx = sum( bytearray( message['retrievePath'], 'ascii')) % len(self.o['exchange'])
+        else:
+            logger.warning( f"missing fields for exchangeSplit, assigning 0")
+            idx = 0
+        return idx 
+ 
+
 if features['amqp']['present']:
     import sarracenia.moth.amqp
     import sarracenia.moth.amqpconsumer

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -673,15 +673,7 @@ class AMQP(Moth):
             if (type(self.o['exchange']) is list):
                 if (len(self.o['exchange']) > 1):
                     if ( 'exchangeSplit' in self.o) and self.o['exchangeSplit'] > 1:
-                        # FIXME: assert ( len(self.o['exchange']) == self.o['post_exchangeSplit'] )
-                        #        if that isn't true... then there is something wrong... should we check ?
-                        if 'exchangeSplitOverride' in message:
-                            idx = int(message['exchangeSplitOverride'])%len(self.o['exchange'])
-                        else:
-                            idx = sum( bytearray(body['identity']['value'],
-                                      'ascii')) % len(self.o['exchange'])
-                        
-                        exchange = self.o['exchange'][idx]
+                        exchange = self.o['exchange'][self.splitPick(message)]
                     else:
                         logger.error(
                             'do not know which exchange to publish to: %s' %

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -679,14 +679,7 @@ class MQTT(Moth):
             if (type(self.o['exchange']) is list):
                 if (len(self.o['exchange']) > 1):
                     if 'post_exchangeSplit' in self.o:
-                        # FIXME: assert ( len(self.o['exchange']) == self.o['post_exchangeSplit'] )
-                        #        if that isn't true... then there is something wrong... should we check ?
-                        if 'exchangeSplitOverride' in message:
-                            idx = int(message['exchangeSplitOverride'])%len(self.o['exchange'])
-                        else:
-                            idx = sum(bytearray(body['identity']['value'],
-                                      'ascii')) % len(self.o['exchange'])
-                        exchange = self.o['exchange'][idx]
+                        exchange = self.o['exchange'][self.splitPick(message)]
                     else:
                         logger.error( f"do not know which exchange to publish to: {self.o['exchange']}" )
                         return


### PR DESCRIPTION
fix #1322 
partially fix #1297 

The post_exchangeSplit was originally conceived as a means of scaling duplicate suppression beyond what a single process could support. Duplicates were defined as files that had the same checksum, so splitting them among exchanges based on the checksum is what made sense initially.  This method of load distribution will assign the same file path to different exchanges if they are not identical (don't have the same checksum.)


As work with mirroring has proceeded, it turns out that a file is really a stream of changes to a given path, and to make good decisions about it, you want a single process to receive all the updates for a given path.  if a file is modified and then removed... the removal event would not necessarily have a related checksum to the modification.  Similarly for a symbolic link. 

Changing the hasing algorithm to be based on path name, rather than checksum:

*  If files have the same path, and the same checksum... they are still duplicates. so that still works.
* If files have the same path, but different checksums... fine it should be processed same as today, just by the same participant in the exchangeSplit pool of flows.
* If files have the same path but different type (link, directory, file... remove event.) they should now show up in the same participant in the exchangeSplit pool of flows.
* it was a sorry that when hashing based on checksums, we hamper the effectiveness of the duplicate suppresion path by removing some hashes from it, resulting in an unbalanced tree.  hashing on path is likely to yield better/faster associative arrays for duplicate suppression within each participant in the exchangeSplit pool of flows.

