### PR TITLE
Fix py3.6 crash by re-implementing #1289 

### DIFF
--- a/docs/source/Explanation/SarraPluginDev.rst
+++ b/docs/source/Explanation/SarraPluginDev.rst
@@ -908,17 +908,18 @@ of the buffer used is given by the **bufsize** option (default 8192).
 Accessing accept/reject "masks"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a message is accepted or rejected, the "mask" that was used to accept/reject it will be stored in the value of the message's ``_mask`` key. The ``_mask`` is a tuple that contains the regex from the accept/reject statement, the corresponding ``directory`` path, the value of the ``mirror`` and ``filename`` options. The last item in the tuple is a list containing any additional text, split by whitespace, that was included at the end of the accept/reject line in the config file. This additional text can be used to pass additional information to plugins.
+When a message is accepted or rejected, the list *index* of the "mask" that was used to accept/reject it will be stored in the value of the message's ``_mask_index`` key. A mask is a tuple that contains the regex from the accept/reject statement, the corresponding ``directory`` path, the value of the ``mirror`` and ``filename`` options. The last item in the tuple is a list containing any additional text, split by whitespace, that was included at the end of the accept/reject line in the config file. This additional text can be used to pass additional information to plugins.
 
 For example, with an accept statement in a config file like this::
     
     accept .*abc.*  your_text=here from_accept_abc
 
-The last item in ``msg['_mask']`` would be:
+The mask can be accessed with ``self.o.masks[msg['_mask_index']]``. The last item in the mask contains the arguments from the accept statement:
 
 .. code-block:: python
 
-    msg['_mask'][-1] # == [ 'your_text=here', 'from_accept_abc' ]
+    mask = self.o.masks[msg['_mask_index']
+    print(mask[-1]) # --> [ 'your_text=here', 'from_accept_abc' ]
 
 Why v3 API should be used whenever possible
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -789,17 +789,18 @@ du buffer utilisé est donné par l’option **bufsize** (8192 par défaut).
 Accéder aux « masques » d'accept/reject
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Lorsqu'un message est accepté ou rejeté, le « masque » qui a été utilisé pour l'accept/reject sera stocké dans la valeur de la clé ``_mask`` du message. Le ``_mask`` est un tuple qui contient l'expression régulière de l'instruction d'accept/reject, le chemin du ``directory`` correspondant, la valeur des options ``mirror`` et ``filename`` . Le dernier élément de le tuple est une liste contenant tout texte supplémentaire, divisé par espaces, inclus à la fin de la ligne d'accept/reject dans le fichier de configuration. Ce texte supplémentaire peut être utilisé pour transmettre des informations supplémentaires aux plugins.
+Lorsqu'un message est accepté ou rejeté, la liste *index* de mask qui a été utilisé pour l'accept/reject sera stocké dans la valeur de la clé ``_mask_index`` du message. Le mask est un tuple qui contient l'expression régulière de l'instruction d'accept/reject, le chemin du ``directory`` correspondant, la valeur des options ``mirror`` et ``filename`` . Le dernier élément de le tuple est une liste contenant tout texte supplémentaire, divisé par espaces, inclus à la fin de la ligne d'accept/reject dans le fichier de configuration. Ce texte supplémentaire peut être utilisé pour transmettre des informations supplémentaires aux plugins.
 
 Par exemple, avec une instruction accept dans un fichier de configuration comme ceci :
 
     accept .*abc.* votre_texte=ici from_accept_abc
 
-Le dernier élément de ``msg['_mask']`` serait :
+Le mask est accessible avec ``self.o.masks[msg['_mask_index']]``. Le dernier élément du mask contient les arguments de l'instruction accept :
 
 .. code-block:: python
-
-    msg['_mask'][-1] # == [ 'votre_text=ici', 'from_accept_abc' ]
+    
+    mask = self.o.masks[msg['_mask_index']
+    print(mask[-1]) # --> [ 'votre_text=ici', 'from_accept_abc' ]
 
 Pourquoi l’API v3 doit être utilisée dans la mesure du possible
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1023,18 +1023,18 @@ class Flow:
                 else:
                     urlToMatch = url
                 oldname_matched = False
-                for mask in self.o.masks:
+                for mask_index, mask in enumerate(self.o.masks):
                     pattern, maskDir, maskFileOption, mask_regexp, accepting, mirror, strip, pstrip, flatten, args = mask
                     if (pattern == '.*'):
                         oldname_matched = accepting
-                        m['_mask'] = mask
-                        m['_deleteOnPost'].add('_mask')
+                        m['_mask_index'] = mask_index
+                        m['_deleteOnPost'].add('_mask_index')
                         break
                     matches = mask_regexp.match(urlToMatch)
                     if matches:
                             m[ '_matches'] = matches
-                            m['_mask'] = mask
-                            m['_deleteOnPost'] |= set(['_matches', '_mask'])
+                            m['_mask_index'] = mask_index
+                            m['_deleteOnPost'] |= set(['_matches', '_mask_index'])
                             oldname_matched = accepting
                     break
 
@@ -1055,7 +1055,7 @@ class Flow:
             logger.debug( f" urlToMatch: {urlToMatch} " )
             # apply masks for accept/reject options.
             matched = False
-            for mask in self.o.masks:
+            for mask_index, mask in enumerate(self.o.masks):
                 pattern, maskDir, maskFileOption, mask_regexp, accepting, mirror, strip, pstrip, flatten, args = mask
                 if (pattern != '.*') :
                     matches = mask_regexp.match(urlToMatch)
@@ -1080,8 +1080,8 @@ class Flow:
                         break
 
 
-                    m['_mask'] = mask
-                    m['_deleteOnPost'].add('_mask')
+                    m['_mask_index'] = mask_index
+                    m['_deleteOnPost'].add('_mask_index')
 
                     if self.updateFieldsAccepted(m, url, pattern, maskDir,
                                            maskFileOption, mirror, strip,


### PR DESCRIPTION
Fix py3.6 crash by re-implementing #1289  using mask_index instead of the actual mask