### PR TITLE
Fix #1325 by handling the exception

### DIFF
--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -33,16 +33,21 @@ class Message(FlowCB):
             self.poster = sarracenia.moth.Moth.pubFactory(props)
 
     def post(self, worklist):
-
-        still_ok = []
+        old_ok = worklist.ok
+        worklist.ok = []
         all_good=True
-        for m in worklist.ok:
-            if all_good and hasattr(self.poster,'putNewMessage') and self.poster.putNewMessage(m):
-                still_ok.append(m)
-            else:
-                all_good=False
+        for m in old_ok:
+            try:
+                if all_good and hasattr(self.poster,'putNewMessage') and self.poster.putNewMessage(m):
+                    worklist.ok.append(m)
+                else:
+                    all_good=False
+                    worklist.failed.append(m)
+            except Exception as e:
+                all_good = False
                 worklist.failed.append(m)
-        worklist.ok = still_ok
+                logger.error(f"failed: {e}")
+                logger.debug("Exception details:", exc_info=True)
 
     def metricsReport(self) -> dict:
         if hasattr(self,'poster') and self.poster:

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -46,7 +46,7 @@ class Message(FlowCB):
             except Exception as e:
                 all_good = False
                 worklist.failed.append(m)
-                logger.error(f"failed: {e}")
+                logger.error(f"crashed: {e}")
                 logger.debug("Exception details:", exc_info=True)
 
     def metricsReport(self) -> dict:


### PR DESCRIPTION
Current behaviour stays the same:

- if putNewMessage returns False, failed message and all remaining messages\* in the worklist are put into worklist.failed

New behaviour:

- if putNewMessage *crashes* the exception is handled. The current message and all remaining messages\* are put into worklist.failed

\* the remaining messages will not attempt to be posted

Any messages that were successfully posted will be put into worklist.ok