### PR TITLE
user service cannot depend on multi-user (system) target

### DIFF
--- a/tools/metpx-sr3_user.service
+++ b/tools/metpx-sr3_user.service
@@ -27,4 +27,4 @@ ExecReload=/usr/bin/sr3 reload
 ExecStop=/usr/bin/sr3 stop
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
ugh... got these error messages:
```
pas037@hpfx3:~/.config/systemd/user$ systemctl --user enable metpx-sr3_user
 ...
Unit /home/pas037/.config/systemd/user/metpx-sr3_user.service is added as a dependency to a non-existent unit multi-user.target.
...
pas037@hpfx3:~/.config/systemd/user$

```
Googled a bit, I think this means that it will not be started on boot.  a user level systemd service cannot depend on a
system-wide one.  I tried removing the [Install] stanza, but that broke it... so changed the target to *default.target* after
googling.  That should make it start on boot.
