### PR TITLE
Issue1297 part2 ordering mdelaylatest

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1863,10 +1863,14 @@ class Flow:
                         self.worklist.ok.append(msg)
                         self.metrics['flow']['transferRxFiles'] += 1
                         self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                        continue
                     else:
                         # as above...
-                        self.reject(msg, 500, "link %s failed" % msg['fileOp'])
-                    continue
+                        if 'hlink' not in msg['fileOp']:
+                            self.reject(msg, 500, "link %s failed" % msg['fileOp'])
+                            continue
+
+                        logger.info( f"since hard link failed, fall back to copying from source" )
 
             # all non-files taken care of above... rest of routine is normal file download.
 

--- a/sarracenia/flowcb/mdelaylatest.py
+++ b/sarracenia/flowcb/mdelaylatest.py
@@ -52,11 +52,21 @@ class MDelayLatest(FlowCB):
             new_ok_delay = []
             for m2 in self.ok_delay:
                 if m1['relPath'] == m2['relPath']:
-                    logger.info(
-                        f"intermediate version suppressed: {m1['relPath']}")
-                    self.suppressions += 1
-                    new_ok_delay.append(m1)
-                    worklist.rejected.append(m2)
+                    # an mkdir, rmdir, an rm, a rename, an ln: order important, publish immediately.
+                    if ('fileOp' in m2) or ('fileOp' in m1):  
+                        if 'fileOp' in m2:
+                            op=m2['fileOp']
+                        else:
+                            op=f"being later: {m1['fileOp']}"
+
+                        logger.info( f"critically ordered operation: {m2['relPath']} {op}")
+                        new_incoming.append(m2)
+                        new_ok_delay.append(m1)
+                    else:
+                        logger.info( f"intermediate version suppressed: {m1['relPath']}")
+                        self.suppressions += 1
+                        new_ok_delay.append(m1)
+                        worklist.rejected.append(m2)
                     wait = True
                 else:
                     new_ok_delay.append(m2)


### PR DESCRIPTION
This is another step towards addressing hard ordering constraints.

* noticed that a file is created with a tmp name. when the subscriber wants to reflect the link, it fails because the tmp file is gone.
* so first patch adds logic to fall-back to a normal file copy for that case.

The other commit is about the 30 second queue.  We delay processing of all events
by 30 seconds so that multiple file re-writes get collapsed into a single overwrite.  In
the case of mixed operations  "mv/ln -s" etc... operations are done on the same file, 
then order is important so dispatch  the earlier event immediately, rather than 
discarding the intermediate event.

