### PR TITLE
Set the product name and version for AMQP connections issue #1371

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -234,7 +234,11 @@ class AMQP(Moth):
                                               broker.url.password),
                                           login_method=broker.login_method,
                                           virtual_host=vhost,
-                                          ssl=(broker.url.scheme[-1] == 's'))
+                                          ssl=(broker.url.scheme[-1] == 's'),
+                                          client_properties={'product':'MetPX Sarracenia (sr3)',
+                                                             'product_version':sarracenia.__version__,
+                                                            }
+                                          )
         self.connection_id = str(uuid.uuid4()) + ("_sub" if self.is_subscriber else "_pub")
         self.broker = host + '/' + vhost
         if hasattr(self.connection, 'connect'):


### PR DESCRIPTION
This partially implements #1371 by setting the product and product version. I think connection name should be configurable, with a default value, but I'm not quite sure exactly what to include in the default, so it can be added later.