### PR TITLE
#884 Add new option to make safe https character quotes configurable

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -958,6 +958,13 @@ housekeeping <interval> (default: 300 seconds)
 The **housekeeping** option sets how often to execute periodic processing as determined by
 the list of on_housekeeping plugins. By default, it prints a log message every houskeeping interval.
 
+httpsSafeQuote <str> (default '/+')
+-----------------------------------
+
+Exclude certain special characters from being quoted (%xx format) in a https URL.
+Makes use of the *safe* parameter in https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote
+Only applicable for the HTTPs transfer driver.
+
 
 include config
 --------------

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -948,6 +948,13 @@ L’option **housekeeping** définit la fréquence d’exécution du traitement 
 la liste des plugins on_housekeeping. Par défaut, il imprime un message de journal à chaque intervalle de housekeeping.
 
 
+httpsSafeQuote <str> (default '/+')
+-----------------------------------
+
+Exclut certains caractères spéciaux du quote (format %xx) dans une URL https.
+Utilise le paramètre *safe* dans https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote
+Ne s'applique qu'aux transferts effectués avec le driver HTTPs.
+
 
 include config
 --------------

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -187,7 +187,7 @@ str_options = [
     'accelCpCommand', 'accelWgetCommand', 'accelScpCommand',
     'action', 'admin', 'baseDir', 'broker', 'cluster', 'directory', 'exchange',
     'exchangeSuffix', 'feeder', 'filename', 'flatten', 'flowMain', 'header', 
-    'hostname', 'identity', 'inlineEncoding', 'logFormat', 'logLevel', 
+    'hostname', 'httpsSafeQuote', 'identity', 'inlineEncoding', 'logFormat', 'logLevel',
     'pollUrl', 'post_baseUrl', 'post_baseDir', 'post_broker', 'post_exchange',
     'post_exchangeSuffix', 'post_format', 'post_topic', 'queueName', 'queueShare', 'sendTo', 'rename',
     'report_exchange', 'source', 'strip', 'timezone', 'nodupe_ttl', 'nodupe_driver', 

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -58,6 +58,7 @@ class Https(Transfer):
     sarracenia transfer protocol subclass supports/uses additional custom options:
 
     * accelWgetCommand (default: '/usr/bin/wget %s -o - -O %d' )
+    * httpsSafeQuote (default: '/+' )
 
     built with: 
          urllib.request ( https://docs.python.org/3/library/urllib.request.html )
@@ -67,6 +68,7 @@ class Https(Transfer):
         super().__init__(proto, options)
 
         self.o.add_option('accelWgetCommand', 'str', '/usr/bin/wget %s -o - -O %d')
+        self.o.add_option('httpsSafeQuote' , 'str' , '/+')
 
         logger.debug("sr_http __init__")
 
@@ -207,7 +209,7 @@ class Https(Transfer):
         else:
             u = urllib.parse.urlparse( self.sendTo )
             url = u.scheme + '://' + u.netloc + '/' + urllib.parse.quote(self.path + '/' +
-                                                              remote_file, safe='/+')
+                                                              remote_file, safe=self.o.httpsSafeQuote)
 
         ok = self.__open__(url, remote_offset, length)
 
@@ -273,7 +275,7 @@ class Https(Transfer):
 
         self.entries = {}
 
-        url = self.sendTo + '/' + urllib.parse.quote(self.path, safe='/+')
+        url = self.sendTo + '/' + urllib.parse.quote(self.path, safe=self.o.httpsSafeQuote)
 
         ok = self.__open__(url)
 


### PR DESCRIPTION
Without the new option

```
2025-03-11 18:31:22,646 [DEBUG] sarracenia.flow download Beginning fetch of https://aviationweather.gov/api/data/gairmet?format=geojson&date=20250311_182625Z 0--1 into G-AIRMET_20250311_182625Z 0--1
2025-03-11 18:31:22,646 [DEBUG] sarracenia.flow download hasAccel=True, thresh=0, len=0, remote_off=0, local_off=0 inflight=G-AIRMET_20250311_182625Z
2025-03-11 18:31:22,646 [DEBUG] sarracenia.transfer.https get get gairmet?format=geojson&date=20250311_182625Z G-AIRMET_20250311_182625Z 0
2025-03-11 18:31:22,646 [DEBUG] sarracenia.transfer.https get sr_http self.path /api/data
2025-03-11 18:31:22,646 [DEBUG] sarracenia.transfer.https __open__ https://aviationweather.gov//api/data/gairmet%3Fformat%3Dgeojson%26date%3D20250311_182625Z
2025-03-11 18:31:22,647 [DEBUG] sarracenia.transfer.https check_is_connected sr_http check_is_connected -> yes
2025-03-11 18:31:22,744 [ERROR] sarracenia.transfer.https __open__ failed 4 https://aviationweather.gov/api/data/gairmet%3Fformat%3Dgeojson%26date%3D20250311_182625Z
2025-03-11 18:31:22,744 [ERROR] sarracenia.transfer.https __open__ Server couldn't fulfill the request. Error code: 404, Not Found
2025-03-11 18:31:22,744 [ERROR] sarracenia.flow download could not get gairmet?format=geojson&date=20250311_182625Z: HTTP Error 404: Not Found
2025-03-11 18:31:22,744 [INFO] sarracenia.flow do_download attempt 1 failed to download https://aviationweather.gov//api/data/gairmet?format=geojson&date=20250311_182625Z to /net/local/home/leblanca/NOAA-HTTP/G
-AIRMET/18/G-AIRMET_20250311_182625Z
```

With the new option , I set `httpsSafeQuote  /+?&=$` in the config, and removed the `accelWgetCommand` logic

```
2025-03-11 18:23:21,958 [DEBUG] sarracenia.flow download Beginning fetch of https://aviationweather.gov/api/data/gairmet?format=geojson&date=20250311_182320Z 0--1 into G-AIRMET_20250311_182320Z 0--1
2025-03-11 18:23:21,958 [DEBUG] sarracenia.flow download hasAccel=True, thresh=0, len=0, remote_off=0, local_off=0 inflight=G-AIRMET_20250311_182320Z
2025-03-11 18:23:21,958 [DEBUG] sarracenia.transfer.https get get gairmet?format=geojson&date=20250311_182320Z G-AIRMET_20250311_182320Z 0
2025-03-11 18:23:21,958 [DEBUG] sarracenia.transfer.https get sr_http self.path /api/data
2025-03-11 18:23:21,958 [DEBUG] sarracenia.transfer.https __open__ https://aviationweather.gov//api/data/gairmet?format=geojson&date=20250311_182320Z
2025-03-11 18:23:21,958 [DEBUG] sarracenia.transfer.https check_is_connected sr_http check_is_connected -> yes
2025-03-11 18:23:22,178 [DEBUG] sarracenia.transfer read_write sr_proto read_write
2025-03-11 18:23:22,188 [WARNING] sarracenia.flow download downloaded 14958 of with no length given for G-AIRMET_20250311_182320Z assuming ok
2025-03-11 18:23:22,199 [DEBUG] sarracenia.flow set_local_file_attributes G-AIRMET_20250311_182320Z
2025-03-11 18:23:22,201 [DEBUG] sarracenia.flow do_download downloaded ok: /net/local/home/leblanca/NOAA-HTTP/G-AIRMET/18/G-AIRMET_20250311_182320Z
2025-03-11 18:23:22,201 [DEBUG] sarracenia.flow do processing 1 messages worked!
2025-03-11 18:23:22,202 [INFO] sarracenia.flowcb.log after_work downloaded ok: /net/local/home/leblanca/NOAA-HTTP/G-AIRMET/18/G-AIRMET_20250311_182320Z
```