### PR TITLE
Azure transfer tweaks

### DIFF
--- a/docs/source/Reference/sr3_credentials.7.rst
+++ b/docs/source/Reference/sr3_credentials.7.rst
@@ -55,6 +55,10 @@ passwords and settings needed by components.  The format is one entry per line. 
 - **s3://access_key_id:secret_access_key@bucket-name s3_session_token=a_big_string**
 - **s3://access_key_id:secret_access_key@bucket-name s3_endpoint=https://my-endpoint.com/**
 
+- **azure://account_name:account_key@your_storage_account.blob.core.windows.net/**
+    - Any special characters in the account_key should be URL (%) encoded when using this format. 
+- **azure://your_storage_account.blob.core.windows.net/ azure_storage_credentials=account_key**
+
 
 In other configuration files or on the command line, the url simply lacks the
 password or key specification.  The url given in the other files is looked
@@ -82,6 +86,8 @@ Supported details:
     - ``s3_endpoint=<url>`` - use a specific endpoint, such as a non-Amazon S3 service.
     - ``s3_session_token=<string>`` - when specifying credentials for S3, the username field is used as the "Access Key ID", the password as the "Secret Access Key". Sometimes a Session Token is also required, and can be provided with this option.
     - ``s3_anonymous`` - do not sign requests (anonymous access). Equivalent to ``--no-sign-request`` when using the S3 CLI.
+- Details for Azure blob storage:
+    - ``azure_storage_credentials=<string>`` - your account key. This is an alternative to using ``azure://account_name:account_key@your_storage_account.blob.core.windows.net/``. 
 
 Note::
  SFTP credentials are optional, in that sarracenia will look in the .ssh directory
@@ -89,7 +95,7 @@ Note::
 
  These strings are URL encoded, so if an account has a password with a special 
  character, its URL encoded equivalent can be supplied.  In the last example above, 
- **%2f** means that the actual password isi: **/dot8**
+ **%2f** means that the actual password is: **/dot8**
  The next to last password is:  **De:olonize**. ( %3a being the url encoded value for a colon character. )
 
 

--- a/docs/source/fr/Reference/sr3_credentials.7.rst
+++ b/docs/source/fr/Reference/sr3_credentials.7.rst
@@ -54,6 +54,10 @@ ainsi que les paramètres nécessaires aux composants.  Le format est d'une entr
 - **s3://ID_de_clé_d'accès:clé_d'accès_secrète@nom-du-compartiment s3_session_token=une_grande_chaîne**
 - **s3://ID_de_clé_d'accès:clé_d'accès_secrète@nom-du-compartiment s3_endpoint=https://my-endpoint.com/**
 
+- **azure://nom_du_compte:clé_de_compte@votre_compte_de_stockage.blob.core.windows.net/**
+    - Tous les caractères spéciaux dans account_key doivent être codés en URL (%) lors de l'utilisation de ce format.
+- **azure://votre_compte_de_stockage.blob.core.windows.net/ azure_storage_credentials=clé_de_compte**
+
 Dans d’autres fichiers de configuration ou sur la ligne de commande, l’url n’a tout simplement pas le
 spécification du mot de passe ou de la clé. L’url donné dans les autres fichiers est recherchée
 dans credentials.conf.
@@ -82,6 +86,8 @@ Détails pris en charge :
     - ``s3_endpoint=<url>`` - utiliser un point de terminaison spécifique, comme un service non Amazon S3.
     - ``s3_session_token=<string>`` - lors de la spécification des informations d'identification pour S3, le champ du nom d'utilisateur est utilisé comme « ID de clé d'accès », le mot de passe comme « clé d'accès secrète ». Parfois, un jeton de session est également requis et peut être fourni avec cette option.
     - ``s3_anonymous`` - ne pas signer les demandes (accès anonyme). Équivalent à « --no-sign-request » lors de l'utilisation de la CLI S3.
+- Détails du Stockage Blob Azure:
+    - ``azure_storage_credentials=<string>`` - votre clé de compte. Il s'agit d'une alternative à l'utilisation de ``azure://nom_du_compte:clé_de_compte@votre_compte_de_stockage.blob.core.windows.net/``.
 
 déterminée. Cela peut être remplacé en spécifiant une méthode Particulière de connexion, ce qui peut être
 nécessaire si un broker prend en charge plusieurs méthodes et qu’une méthode incorrecte est automatiquement

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -54,7 +54,7 @@ features = {
     'amqp' : { 'modules_needed': [ 'amqp' ], 'present': False, 
             'lament' : 'cannot connect to rabbitmq brokers', 
             'rejoice' : 'can connect to rabbitmq brokers' },
-    'azurestorage' : { 'modules_needed': [ 'azure-storage-blob' ], 'present': False, 
+    'azurestorage' : { 'modules_needed': [ 'azure.storage.blob' ], 'present': False, 
             'lament' : 'cannot connect natively to Azure Stoarge accounts', 
             'rejoice' : 'can connect natively to Azure Stoarge accounts' },
    'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False, 

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -490,3 +490,5 @@ if features['sftp']['present']:
 if features['s3']['present']:
     import sarracenia.transfer.s3
 
+if features['azurestorage']['present']:
+    import sarracenia.transfer.azure

--- a/sarracenia/transfer/azure.py
+++ b/sarracenia/transfer/azure.py
@@ -29,6 +29,8 @@ import paramiko
 import stat
 import json
 
+import urllib.parse
+
 from sarracenia.transfer import Transfer
 
 from azure.storage.blob import ContainerClient
@@ -55,6 +57,16 @@ class Azure(Transfer):
 
         self.__user_agent = 'Sarracenia/' + sarracenia.__version__
 
+        if hasattr(self.o, 'tlsRigour'):
+            self.o.tlsRigour = self.o.tlsRigour.lower()
+            if self.o.tlsRigour == 'lax':
+                self.connection_verify = False
+            else:
+                self.connection_verify = True
+
+        # The default INFO level for this logger is quite verbose, we might want to reduce it some day
+        # logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel('WARNING')
+
         self.__init()
     
 
@@ -71,8 +83,10 @@ class Azure(Transfer):
         self.sendTo = None
 
         self.account = None
-        self.container = None
+        self.container_url = None
         self.credentials = None
+        self.account = None
+        self.key = None
 
         self.path = ""
         self.cwd = ""
@@ -82,22 +96,49 @@ class Azure(Transfer):
         self._Metadata_Key = 'sarracenia_v3'
 
     def __credentials(self) -> bool:
-        logger.debug("%s" % self.sendTo)
+        # logger.debug("%s" % self.sendTo)
+        
+        sendTo = self.sendTo.lower().replace("azure://", "https://").replace("azblob://", "https://")
 
         try:
             ok, details = self.o.credentials.get(self.sendTo)
+            url = None
+            if details:
+                url = details.url
 
-            self.account = details.url.hostname
-            self.container = details.url.path.lstrip('/')
-            self.container_url = f"https://{self.account}.blob.core.windows.net/{self.container}"
+                self.account = url.username if url.username != '' else None
 
-            if hasattr(details, 'azure_credentials'):
+                if url.password is not None and url.password != '':
+                    self.key = urllib.parse.unquote_plus(url.password)
+                else:
+                    self.key = None
+
+                if url.password is not None and url.password in sendTo:
+                    sendTo = sendTo.replace(':'+ url.password, '')
+                
+                if url.username is not None and url.username in sendTo:
+                    sendTo = sendTo.replace(url.username + '@', '')
+    
+            self.container_url = sendTo
+
+            if details and hasattr(details, 'azure_credentials') and details.azure_credentials is not None:
                 self.credentials = details.azure_credentials
+                logger.debug("azure_credentials= is set, it will override any "+
+                             "username/password (account name/key) in the URL")
+                return True
+            elif self.account and self.key:
+                self.credentials = { "account_name": self.account,
+                                     "account_key":  self.key,
+                                   }
+                return True
+            else:
+                # assuming this is ok, for anonymous access
+                self.credentials = None
+                logger.debug(f"no credential for {self.sendTo}")
+                return True
 
-            return True
-
-        except:
-            logger.error("sr_azure/credentials: unable to get credentials for %s" % self.sendTo)
+        except Exception as e:
+            logger.error(f"sr_azure/credentials: unable to get credentials for {self.sendTo} ({e})")
             logger.debug('Exception details: ', exc_info=True)
 
         return False
@@ -149,11 +190,18 @@ class Azure(Transfer):
             return False
 
         try:
-            self.client = ContainerClient.from_container_url(container_url=self.container_url, 
-                                                            credential=self.credentials, connection_timeout=5, read_timeout=5, retry_total=1)
-            info = self.client.get_account_information(user_agent=self.__user_agent)
+            # logger.debug(f"connecting to {self.container_url} with credential {self.credentials}")
+            self.client = ContainerClient.from_container_url(container_url=self.container_url,
+                                                             credential=self.credentials,
+                                                             connection_timeout=self.o.timeout,
+                                                             read_timeout=self.o.timeout,
+                                                             retry_total=self.o.attempts,
+                                                             connection_verify=self.connection_verify,
+                                                             user_agent=self.__user_agent
+                                                             )
+            info = self.client.get_account_information()
             self.connected = True
-            logger.debug(f"Connected to container {self.container} in account {self.account} ({self.container_url}); sku:{info['sku_name']}, kind:{info['account_kind']}")
+            logger.debug(f"Connected to {self.container_url}; sku:{info['sku_name']}, kind:{info['account_kind']}")
             return True
 
         except azure.core.exceptions.ClientAuthenticationError as e:
@@ -165,7 +213,7 @@ class Azure(Transfer):
 
     def delete(self, path):
         logger.debug(f"deleting {path}")
-        self.client.delete_blob(path.lstrip('/'), user_agent=self.__user_agent)
+        self.client.delete_blob(path.lstrip('/'))
 
     def get(self,
             msg,
@@ -183,7 +231,7 @@ class Azure(Transfer):
         blob = self.client.get_blob_client(file_key)
 
         with open(local_file, 'wb') as file:
-          data = blob.download_blob(user_agent=self.__user_agent)
+          data = blob.download_blob()
           file.write(data.readall())
 
         rw_length = os.stat(local_file).st_size
@@ -205,7 +253,7 @@ class Azure(Transfer):
 
         self.entries = {}
 
-        blobs = self.client.walk_blobs(name_starts_with=self.path, user_agent=self.__user_agent)
+        blobs = self.client.walk_blobs(name_starts_with=self.path)
 
         for b in blobs:
             # files
@@ -261,26 +309,28 @@ class Azure(Transfer):
             local_offset=0,
             remote_offset=0,
             length=0) -> int:
-        logger.debug(f"uploading {local_file} to {remote_file}")
+        # logger.debug(f"uploading {local_file} to {remote_file}")
 
         file_key = self.path + remote_file
-        logger.debug(f"put {local_file} to http://{self.container_url}/{file_key}")
-        logger.debug(f"msg={msg}")
+        logger.debug(f"{local_file} to {self.container_url}/{file_key}")
+        # logger.debug(f"msg={msg}")
 
-        metadata = {
-                self._Metadata_Key: json.dumps({
-                        'identity': msg['identity'],
-                        'mtime': msg['mtime'],
-                    })
-            }
+        md = {}
+        if 'identity' in msg:
+            md['identity'] = msg['identity']
+        if 'mtime' in msg:
+            md['mtime'] = msg['mtime']
+
+        metadata = { self._Metadata_Key: json.dumps(md) }
 
         # upload
         try:
             with open(local_file, 'rb') as data:
-                new_file = self.client.upload_blob(name=file_key, data=data, metadata=metadata, user_agent=self.__user_agent)
+                new_file = self.client.upload_blob(name=file_key, data=data, metadata=metadata)
             #self.client.upload_file( Filename=local_file, Bucket=self.bucket, Key=file_key, Config=self.s3_transfer_config, ExtraArgs=extra_args)
 
-            write_size = new_file.get_blob_properties(user_agent=self.__user_agent).size
+            write_size = new_file.get_blob_properties().size
+            logger.debug(f'uploaded {local_file} to {self.container_url}/{file_key}')
             return write_size
         except Exception as e:
             logger.error(f"Something went wrong with the upload: {e}", exc_info=True)
@@ -296,16 +346,16 @@ class Azure(Transfer):
         from_url = self.container_url + "/" + remote_old + "?" + self.credentials
 
         logger.debug(f"remote_old={remote_old}; from_url={self.container_url}/{remote_old}; remote_new={remote_new}")
-        b_new.start_copy_from_url(from_url, user_agent=self.__user_agent)
-        self.client.delete_blob(remote_old.lstrip('/'), user_agent=self.__user_agent)
+        b_new.start_copy_from_url(from_url)
+        self.client.delete_blob(remote_old.lstrip('/'))
     
     def rmdir(self, path):
-        blobList=[*self.client.list_blobs(name_starts_with=path, user_agent=self.__user_agent)]
+        blobList=[*self.client.list_blobs(name_starts_with=path)]
         
         logger.debug(f"deleting {len(blobList)} blobs under {path}")
         while len(blobList) > 0:
             first256 = blobList[0:255]
-            self.client.delete_blobs(*first256, delete_snapshots='include', user_agent=self.__user_agent)     # delete_blobs() is faster!
+            self.client.delete_blobs(*first256, delete_snapshots='include')     # delete_blobs() is faster!
             logger.debug("deleted " + str(len(first256)) + " of " + str(len(blobList)) + " blobs")
             del blobList[0:255]
 

--- a/tests/sarracenia/transfer/azure_test.py
+++ b/tests/sarracenia/transfer/azure_test.py
@@ -9,6 +9,7 @@ import sarracenia.transfer.azure
 from azure.storage.blob import ContainerClient, BlobServiceClient
 import azure.core.exceptions
 
+# need to have docker installed for this to work
 from testcontainers.azurite import AzuriteContainer
 
 import base64
@@ -75,30 +76,35 @@ def test___credentials():
     transfer = sarracenia.transfer.azure.Azure('azure', sarracenia.config.default_config())
 
     #simple path
-    transfer.o.credentials._parse('azure://testing_simple_account/container')
-    transfer.sendTo = 'azure://testing_simple_account/container'
+    transfer.o.credentials._parse('azure://testing_simple_account.blob.core.windows.net/container')
+    transfer.sendTo = 'azure://testing_simple_account.blob.core.windows.net/container'
     transfer._Azure__credentials()
-    assert transfer.account == 'testing_simple_account'
-    assert transfer.container == 'container'
+    assert transfer.container_url == "https://testing_simple_account.blob.core.windows.net/container"
     assert transfer.credentials == None
 
     #Complex, with all options/details
     transfer = sarracenia.transfer.azure.Azure('azure', sarracenia.config.default_config())
-    transfer.o.credentials._parse('azure://testing_complex_account/container azure_storage_credentials=testing_credentials')
-    transfer.sendTo = 'azure://testing_complex_account/container'
+    transfer.o.credentials._parse('azure://testing_complex_account.blob.core.windows.net/container azure_storage_credentials=testing_credentials')
+    transfer.sendTo = 'azure://testing_complex_account.blob.core.windows.net/container'
     transfer._Azure__credentials()
-    assert transfer.account == 'testing_complex_account'
-    assert transfer.container == 'container'
+    assert transfer.container_url == "https://testing_complex_account.blob.core.windows.net/container"
     assert transfer.credentials == 'testing_credentials'
 
     #Complex, with all options/details, using 'azblob' scheme
     transfer = sarracenia.transfer.azure.Azure('azure', sarracenia.config.default_config())
-    transfer.o.credentials._parse('azblob://testing_complex_account/container azure_storage_credentials=testing_credentials')
-    transfer.sendTo = 'azblob://testing_complex_account/container'
+    transfer.o.credentials._parse('azblob://testing_complex_account.blob.core.windows.net/container azure_storage_credentials=testing_credentials')
+    transfer.sendTo = 'azblob://testing_complex_account.blob.core.windows.net/container'
     transfer._Azure__credentials()
-    assert transfer.account == 'testing_complex_account'
-    assert transfer.container == 'container'
+    assert transfer.container_url == "https://testing_complex_account.blob.core.windows.net/container"
     assert transfer.credentials == 'testing_credentials'
+
+    # With account_name and account_key
+    transfer = sarracenia.transfer.azure.Azure('azure', sarracenia.config.default_config())
+    transfer.o.credentials._parse('azure://test_acct_name:testing%20password@testing_complex_account2.blob.core.windows.net/container')
+    transfer.sendTo = 'azure://testing_complex_account2.blob.core.windows.net/container'
+    transfer._Azure__credentials()
+    assert transfer.container_url == "https://testing_complex_account2.blob.core.windows.net/container"
+    assert transfer.credentials == {'account_name': 'test_acct_name', 'account_key': 'testing password'}
 
 def test_cd():
     options = sarracenia.config.default_config()
@@ -130,7 +136,7 @@ def test_cd_forced():
 def test_check_is_connected():
     options = sarracenia.config.default_config()
     options.logLevel = "DEBUG"
-    options.sendTo = 'azure://testing_simple_account/container'
+    options.sendTo = 'azure://testing_simple_account.blob.core.windows.net/container'
     transfer = sarracenia.transfer.azure.Azure('azure', options)
 
     assert transfer.check_is_connected() == False


### PR DESCRIPTION
- Adds support for specifying an account name in the credentials. 
    - When only specifying a key, I was getting this error: `ValueError: Unable to determine account name for shared key credential.`
    - This was the critical thing that eventually got the connection working
- Fixes the feature detection for Azure
- Allows us to ignore certificate errors with `tlsRigour lax` (I was trying to use an internal domain instead of blob.core.windows.net)
- Changes how the URL and credentials work to support different URLs. 
    - Unfortunately, this means that we have to use `azure://your_storage_account.blob.core.windows.net/container_name` instead of just `azure://your_storage_account/container_name`
- Specified the user agent when creating the ContainerClient. If it's set there, it seems to be applied to all method calls