### PR TITLE
Add AddSMHeader for client adaptability

### DIFF
--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -95,7 +95,7 @@ class Am(FlowCB):
         self.o.add_option('MissingAMHeaders', 'str', 'CN00 CWAO')
         self.o.add_option('mapStations2AHL', 'list', [])
         self.o.add_option('binaryInitialCharacters', 'list', [b'BUFR' , b'GRIB', b'\211PNG'])
-        self.o.add_option('AddSMHeader', 'bool' , True)
+        self.o.add_option('AddSMHeader', 'flag' , True)
 
         self.host = self.url.netloc.split(':')[0]
         self.port = int(self.url.netloc.split(':')[1])

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -393,7 +393,6 @@ class Am(FlowCB):
                     break
 
         # From Sundew ->  https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L114-L115
-        # AddSMHeader is set to True on all operational Sundew configs so no need to add an option
         if self.o.AddSMHeader and bulletin_firstchars in ["SM", "SI"]:
 
             logger.debug("Adding missing line in SI/SM bulletin")

--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -36,6 +36,9 @@ Description:
             Binary bulletins are characterised by having certain sets of characters on its second line.
             This option allows to customise which binary strings to look for to determine if a bulletin is binary or not.
 
+        AddSMHeader (bool):
+            When True, add `AAXX ddhhmm4` after the bulletin header.
+
         mapStations2AHL (list):
             Some bulletins need to get their header constructed based on a bulletin station mapping file. In sr3, this file would normally be included as stations.inc.
             The format of a station mapping is the following, and is in relation to what was found on Sundew
@@ -92,6 +95,7 @@ class Am(FlowCB):
         self.o.add_option('MissingAMHeaders', 'str', 'CN00 CWAO')
         self.o.add_option('mapStations2AHL', 'list', [])
         self.o.add_option('binaryInitialCharacters', 'list', [b'BUFR' , b'GRIB', b'\211PNG'])
+        self.o.add_option('AddSMHeader', 'bool' , True)
 
         self.host = self.url.netloc.split(':')[0]
         self.port = int(self.url.netloc.split(':')[1])
@@ -390,7 +394,7 @@ class Am(FlowCB):
 
         # From Sundew ->  https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L114-L115
         # AddSMHeader is set to True on all operational Sundew configs so no need to add an option
-        if bulletin_firstchars in ["SM", "SI"]:
+        if self.o.AddSMHeader and bulletin_firstchars in ["SM", "SI"]:
 
             logger.debug("Adding missing line in SI/SM bulletin")
 

--- a/tests/sarracenia/flowcb/gather/am__gather_test.py
+++ b/tests/sarracenia/flowcb/gather/am__gather_test.py
@@ -423,9 +423,11 @@ def test_random_bulletin_with_BBB():
     assert worklist.incoming[0]['rename'] == 'FXCN06_CYTR_230939_AAA__00001'
 
 # Test 13: SM Bulletin with BBB - Add station mapping + SM/SI bulletin accomodities + conserve BBB header
+#          Also test AddSMHeader option
 def test_SM_bulletin_with_BBB():
     
     BaseOptions = Options()
+    BaseOptions.AddSMHeader = False
     renamer = Raw2bulletin(BaseOptions)
     am_instance = Am(BaseOptions)
 
@@ -442,7 +444,7 @@ def test_SM_bulletin_with_BBB():
     # Check correcting the bulletin contents of the bulletin
     am_instance.o.mapStations2AHL = ['SMCN06 CWAO COLL 71816 71818 71821 71825 71827 71828 71831 71832 71834 71841 71842 71845 71850 71854']
     new_bulletin, isProblem = am_instance.correctContents(bulletin, firstchars, lines, missing_ahl, station, charset)
-    assert new_bulletin == b'SMCN06 CWAO 030000 AAA\nAAXX 03004\n71816 11324 80313 10004 20003 30255 40318 52018 60031 77177 887//\n333 10017 20004 42001 70118 90983 93101=\n'
+    assert new_bulletin == b'SMCN06 CWAO 030000 AAA\n71816 11324 80313 10004 20003 30255 40318 52018 60031 77177 887//\n333 10017 20004 42001 70118 90983 93101=\n'
 
     message_test13['content']['value'] = new_bulletin.decode('iso-8859-1')
     message_test13["isProblem"] = isProblem


### PR DESCRIPTION
We have a client that is requesting the option to disable adding the `AAXX ddhhmm4` string to the second line of SM/SI bulletins.

They've recently started sending us `SM` bulletins that have `BBXX` as the second line of the bulletin, which doesn't need to have the  `AAXX ddhhmm4` line added. 

In sundew, the option to remove the `AAXX ddhhmm4` string was available, however I didn't port it to sr3, because all of our operational clusters had `AddSMHeader True`, so I assumed the option wasn't needed anymore.

I added the changes in the unit test. The results pass so the option seems to work.

