### PR TITLE
AM - SM header treatment improvements based on client recommendations/comments

### DIFF
--- a/sarracenia/flowcb/gather/am.py
+++ b/sarracenia/flowcb/gather/am.py
@@ -65,6 +65,7 @@ Author:
 """
 
 import logging, socket, struct, time, sys, os, signal, ipaddress, urllib.parse, getpass, psutil
+import re
 from base64 import b64encode
 from random import randint
 from typing import NoReturn
@@ -393,15 +394,22 @@ class Am(FlowCB):
                     break
 
         # From Sundew ->  https://github.com/MetPX/Sundew/blob/main/lib/bulletinAm.py#L114-L115
-        if self.o.AddSMHeader and bulletin_firstchars in ["SM", "SI"]:
+        if self.o.AddSMHeader and bulletin_firstchars in ["SM", "SI" ,"SN"]:
+             
+            # Check if a line with [A-Z]{2}XX already exists. 
+            # If it does, we don't want to append an extra line.
+            line2verify = lines[1].split(b' ')[0][0:4]
+            # i.e. line2verify = BBXX
 
-            logger.debug("Adding missing line in SI/SM bulletin")
+            if not re.search(b'[A-Z]{2}XX' , line2verify):
+                logger.debug("Adding missing line in SI/SM bulletin")
 
-            ddhh = lines[0].split(b' ')[2][0:4]
-            line2add = b"AAXX " + ddhh + b"4"
-            lines.insert(1, line2add)
+                ddhh = lines[0].split(b' ')[2][0:4]
+                line2add = b"AAXX " + ddhh + b"4"
+                # i.e. line2add = AAXX 27124
+                lines.insert(1, line2add)
 
-            reconstruct = 1
+                reconstruct = 1
 
         if reconstruct == 1:
            new_bulletin, lines = self.reconstruct_bulletin(lines, new_bulletin)

--- a/tests/sarracenia/flowcb/gather/am__gather_test.py
+++ b/tests/sarracenia/flowcb/gather/am__gather_test.py
@@ -424,7 +424,7 @@ def test_random_bulletin_with_BBB():
 
 # Test 13: SM Bulletin with BBB - Add station mapping + SM/SI bulletin accomodities + conserve BBB header
 #          Also test AddSMHeader option
-def test_SM_bulletin_with_BBB():
+def test_SM_bulletin_with_BBB_no_addsmheader():
     
     BaseOptions = Options()
     BaseOptions.AddSMHeader = False
@@ -454,3 +454,73 @@ def test_SM_bulletin_with_BBB():
 
     renamer.after_gather(worklist)
     assert worklist.incoming[0]['rename'] == 'SMCN06_CWAO_030000_AAA_71816_00001'
+
+# Test 14: Complete SM Bulletin with BBXX field - Should not add AAXX line afterwards
+def test_SM_bulletin_with_BBXX():
+    
+    BaseOptions = Options()
+    BaseOptions.AddSMHeader = True
+    renamer = Raw2bulletin(BaseOptions)
+    am_instance = Am(BaseOptions)
+
+    message_test14 = make_message()
+    message_test14['content']['encoding'] = 'iso-8859-1'
+    message_test14['content']['value'] = b'SMVD03 CYTR 280600\nBBXX\nCGAG 28064 99464 70525 41597 61814 10006 21014 40090 57009 70222\n86500 22213 01001 20705 86002=\n'
+
+    bulletin, firstchars, lines, missing_ahl, station, charset = _get_bulletin_info(message_test14)
+
+    bulletinHeader = lines[0].decode('iso-8859-1').replace(' ', '_')
+    message_test14['new_file'] = bulletinHeader + '__12345'
+    message_test14['new_dir'] = BaseOptions.directory
+
+    # Check correcting the bulletin contents of the bulletin
+    am_instance.o.mapStations2AHL = ['SMCN06 CWAO COLL 71816 71818 71821 71825 71827 71828 71831 71832 71834 71841 71842 71845 71850 71854']
+    new_bulletin, isProblem = am_instance.correctContents(bulletin, firstchars, lines, missing_ahl, station, charset)
+    # This is the mainline code and is needed for this particular use case. No mods to the bulletin contents.
+    if new_bulletin == b'':
+        new_bulletin = bulletin
+    assert new_bulletin == b'SMVD03 CYTR 280600\nBBXX\nCGAG 28064 99464 70525 41597 61814 10006 21014 40090 57009 70222\n86500 22213 01001 20705 86002=\n'
+
+    message_test14['content']['value'] = new_bulletin.decode('iso-8859-1')
+    message_test14["isProblem"] = isProblem
+
+    worklist = make_worklist()
+    worklist.incoming = [message_test14]
+
+    renamer.after_gather(worklist)
+    assert worklist.incoming[0]['rename'] == 'SMVD03_CYTR_280600__BBXX_00001'
+
+# Test 15: SM Bulletin with BBB - Add station mapping + SM/SI bulletin accomodities + conserve BBB header
+#          Also test AddSMHeader option
+def test_SM_bulletin_with_BBB_w_addsmheader():
+    
+    BaseOptions = Options()
+    BaseOptions.AddSMHeader = True
+    renamer = Raw2bulletin(BaseOptions)
+    am_instance = Am(BaseOptions)
+
+    message_test15 = make_message()
+    message_test15['content']['encoding'] = 'iso-8859-1'
+    message_test15['content']['value'] = b'SM 030000 AAA\n71816 11324 80313 10004 20003 30255 40318 52018 60031 77177 887//\n333 10017 20004 42001 70118 90983 93101=\n'
+
+    bulletin, firstchars, lines, missing_ahl, station, charset = _get_bulletin_info(message_test15)
+
+    bulletinHeader = lines[0].decode('iso-8859-1').replace(' ', '_')
+    message_test15['new_file'] = bulletinHeader + '__12345'
+    message_test15['new_dir'] = BaseOptions.directory
+
+    # Check correcting the bulletin contents of the bulletin
+    am_instance.o.mapStations2AHL = ['SMCN06 CWAO COLL 71816 71818 71821 71825 71827 71828 71831 71832 71834 71841 71842 71845 71850 71854']
+    new_bulletin, isProblem = am_instance.correctContents(bulletin, firstchars, lines, missing_ahl, station, charset)
+    assert new_bulletin == b'SMCN06 CWAO 030000 AAA\nAAXX 03004\n71816 11324 80313 10004 20003 30255 40318 52018 60031 77177 887//\n333 10017 20004 42001 70118 90983 93101=\n'
+
+    message_test15['content']['value'] = new_bulletin.decode('iso-8859-1')
+    message_test15["isProblem"] = isProblem
+
+    worklist = make_worklist()
+    worklist.incoming = [message_test15]
+
+    renamer.after_gather(worklist)
+    assert worklist.incoming[0]['rename'] == 'SMCN06_CWAO_030000_AAA_71816_00001'
+
+

--- a/tests/sarracenia/flowcb/gather/am__gather_test.py
+++ b/tests/sarracenia/flowcb/gather/am__gather_test.py
@@ -523,4 +523,38 @@ def test_SM_bulletin_with_BBB_w_addsmheader():
     renamer.after_gather(worklist)
     assert worklist.incoming[0]['rename'] == 'SMCN06_CWAO_030000_AAA_71816_00001'
 
+# Test 16: SN (Synoptic) Bulletin:
+def test_SN_syno_bulletin():
+    
+    BaseOptions = Options()
+    BaseOptions.AddSMHeader = True
+    renamer = Raw2bulletin(BaseOptions)
+    am_instance = Am(BaseOptions)
+
+    message_test16 = make_message()
+    message_test16['content']['encoding'] = 'iso-8859-1'
+    message_test16['content']['value'] = b'SNVD02 CWAO 280700\nBBXX\nYBVEWGM 28074 99475 70527 43/// /2610 10005 21022 40078 51029 7//// 8//// 90705 22200 0//// 2//// ='
+
+    bulletin, firstchars, lines, missing_ahl, station, charset = _get_bulletin_info(message_test16)
+
+    bulletinHeader = lines[0].decode('iso-8859-1').replace(' ', '_')
+    message_test16['new_file'] = bulletinHeader + '__12345'
+    message_test16['new_dir'] = BaseOptions.directory
+
+    # Check correcting the bulletin contents of the bulletin
+    new_bulletin, isProblem = am_instance.correctContents(bulletin, firstchars, lines, missing_ahl, station, charset)
+    # This is the mainline code and is needed for this particular use case. No mods to the bulletin contents.
+    if new_bulletin == b'':
+        new_bulletin = bulletin
+    assert new_bulletin == b'SNVD02 CWAO 280700\nBBXX\nYBVEWGM 28074 99475 70527 43/// /2610 10005 21022 40078 51029 7//// 8//// 90705 22200 0//// 2//// ='
+
+    message_test16['content']['value'] = new_bulletin.decode('iso-8859-1')
+    message_test16["isProblem"] = isProblem
+
+    worklist = make_worklist()
+    worklist.incoming = [message_test16]
+
+    renamer.after_gather(worklist)
+    assert worklist.incoming[0]['rename'] == 'SNVD02_CWAO_280700___00001'
+
 


### PR DESCRIPTION
We have a client that has made a recommendation on how the code should treat the SM/SI (and now SN) headered bulletins.

Currently, SM bulletins that come in with a `[A-Z]{2}XX` string (i.e. `SMCN20 CWAO 281200\nAAXX 28124\n...`), will try to append a new string automatically (unless `AddSMHeader` is set to `False`). 

Our code should be smart enough to identify when that `[A-Z]{2}XX` string is missing and just do the right thing.

The client also identified that the `SN` bulletins should also be going through this logic (although they come in very rarely) so I added it in the list of headers.

AM flow tests pass on U18.04 and U22.04. I've also added a couple of unit tests to have more exposure on those SM/SI/SN use cases.