### PR TITLE
Fix Azure's renaming not working when `directory` isn't `/`

### DIFF
--- a/sarracenia/transfer/azure.py
+++ b/sarracenia/transfer/azure.py
@@ -341,13 +341,17 @@ class Azure(Transfer):
     
     def rename(self, remote_old, remote_new):
         remote_new = remote_new.lstrip('/')
-        b_new = self.client.get_blob_client(remote_new)
+        remote_new_wpath = self.path + remote_new
 
-        from_url = self.container_url + "/" + remote_old + "?" + self.credentials
+        remote_old_wpath = self.path + remote_old
 
-        logger.debug(f"remote_old={remote_old}; from_url={self.container_url}/{remote_old}; remote_new={remote_new}")
+        b_new = self.client.get_blob_client(remote_new_wpath)
+
+        from_url = self.container_url + "/" + remote_old_wpath + "?" + self.credentials
+
+        logger.debug(f"remote_old={remote_old_wpath}; from_url={self.container_url}/{remote_old_wpath}; remote_new={remote_new_wpath}")
         b_new.start_copy_from_url(from_url)
-        self.client.delete_blob(remote_old.lstrip('/'))
+        self.client.delete_blob(remote_old_wpath.lstrip('/'))
     
     def rmdir(self, path):
         blobList=[*self.client.list_blobs(name_starts_with=path)]


### PR DESCRIPTION
With the patch, a transfer now succeeds when `inflight .tmp` is set in the configuration and `directory` isn't set to `/`.

```
2025-04-01 14:10:40,410 [DEBUG] sarracenia.flow send azure_transport send /NUMERIC/2025/04/01/14 202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC
2025-04-01 14:10:40,410 [DEBUG] sarracenia.transfer.azure check_is_connected sr_azure check_is_connected
2025-04-01 14:10:40,410 [DEBUG] sarracenia.flow send azure_transport send cd to /NUMERIC/2025/04/01/14
2025-04-01 14:10:40,410 [DEBUG] sarracenia.transfer.azure cd_forced forcing into  /NUMERIC/2025/04/01/14
2025-04-01 14:10:40,410 [DEBUG] sarracenia.transfer.azure cd changing into /NUMERIC/2025/04/01/14
2025-04-01 14:10:40,410 [DEBUG] sarracenia.flow send hasattr=False, thresh=0, len=356066, remote_off=0, local_off=0
2025-04-01 14:10:40,411 [DEBUG] sarracenia.transfer.azure put 202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC to https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC.tmp
2025-04-01 14:10:40,414 [INFO] azure.core.pipeline.policies.http_logging_policy on_request Request URL: 'https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI%2C1.0%2CAGL%2CMPRATE%3AURP%3ACASLA_NUMERIC_AS_META%3ARADAR%3ANUMERIC.tmp?sv=REDACTED&ss=REDACTED&srt=REDACTED&sp=REDACTED&se=REDACTED&st=REDACTED&spr=REDACTED&sig=REDACTED'
Request method: 'PUT'
Request headers:
    'Content-Length': '356066'
    'x-ms-meta-sarracenia_v3': 'REDACTED'
    'x-ms-blob-type': 'REDACTED'
    'If-None-Match': '*'
    'x-ms-version': 'REDACTED'
    'Content-Type': 'application/octet-stream'
    'Accept': 'application/xml'
    'User-Agent': 'Sarracenia/3.00.58rc1 azsdk-python-storage-blob/12.13.1 Python/3.6.9 (Linux-5.4.0-211-generic-x86_64-with-Ubuntu-18.04-bionic)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '179f93d4-0f03-11f0-be52-bc97e1c38320'
A body is sent with the request
2025-04-01 14:10:40,640 [INFO] azure.core.pipeline.policies.http_logging_policy on_response Response status: 201
Response headers:
    'Content-Length': '0'
    'Content-MD5': 'REDACTED'
    'Last-Modified': 'Tue, 01 Apr 2025 14:10:40 GMT'
    'ETag': '"0x8DD7126FBF26BD2"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': '4d77d97f-001e-0024-6a0f-a3450b000000'
    'x-ms-client-request-id': '179f93d4-0f03-11f0-be52-bc97e1c38320'
    'x-ms-version': 'REDACTED'
    'x-ms-content-crc64': 'REDACTED'
    'x-ms-request-server-encrypted': 'REDACTED'
    'Date': 'Tue, 01 Apr 2025 14:10:39 GMT'
2025-04-01 14:10:40,642 [INFO] azure.core.pipeline.policies.http_logging_policy on_request Request URL: 'https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI%2C1.0%2CAGL%2CMPRATE%3AURP%3ACASLA_NUMERIC_AS_META%3ARADAR%3ANUMERIC.tmp?sv=REDACTED&ss=REDACTED&srt=REDACTED&sp=REDACTED&se=REDACTED&st=REDACTED&spr=REDACTED&sig=REDACTED'
Request method: 'HEAD'
Request headers:
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'Sarracenia/3.00.58rc1 azsdk-python-storage-blob/12.13.1 Python/3.6.9 (Linux-5.4.0-211-generic-x86_64-with-Ubuntu-18.04-bionic)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '17c2631e-0f03-11f0-be52-bc97e1c38320'
No body was attached to the request
2025-04-01 14:10:40,663 [INFO] azure.core.pipeline.policies.http_logging_policy on_response Response status: 200
Response headers:
    'Content-Length': '356066'
    'Content-Type': 'application/octet-stream'
    'Content-MD5': 'REDACTED'
    'Last-Modified': 'Tue, 01 Apr 2025 14:10:40 GMT'
    'Accept-Ranges': 'REDACTED'
    'ETag': '"0x8DD7126FBF26BD2"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': '4d77d999-001e-0024-010f-a3450b000000'
    'x-ms-client-request-id': '17c2631e-0f03-11f0-be52-bc97e1c38320'
    'x-ms-version': 'REDACTED'
    'x-ms-meta-sarracenia_v3': 'REDACTED'
    'x-ms-creation-time': 'REDACTED'
    'x-ms-lease-status': 'REDACTED'
    'x-ms-lease-state': 'REDACTED'
    'x-ms-blob-type': 'REDACTED'
    'x-ms-server-encrypted': 'REDACTED'
    'x-ms-access-tier': 'REDACTED'
    'x-ms-access-tier-inferred': 'REDACTED'
    'Date': 'Tue, 01 Apr 2025 14:10:39 GMT'
2025-04-01 14:10:40,664 [DEBUG] sarracenia.transfer.azure put uploaded 202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC to https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC.tmp
2025-04-01 14:10:40,665 [DEBUG] sarracenia.transfer.azure rename remote_old=NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC.tmp; from_url=https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC.tmp; remote_new=NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC
2025-04-01 14:10:40,666 [INFO] azure.core.pipeline.policies.http_logging_policy on_request Request URL: 'https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI%2C1.0%2CAGL%2CMPRATE%3AURP%3ACASLA_NUMERIC_AS_META%3ARADAR%3ANUMERIC?sv=REDACTED&ss=REDACTED&srt=REDACTED&sp=REDACTED&se=REDACTED&st=REDACTED&spr=REDACTED&sig=REDACTED'
Request method: 'PUT'
Request headers:
    'x-ms-copy-source': 'REDACTED'
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'Sarracenia/3.00.58rc1 azsdk-python-storage-blob/12.13.1 Python/3.6.9 (Linux-5.4.0-211-generic-x86_64-with-Ubuntu-18.04-bionic)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '17c62012-0f03-11f0-be52-bc97e1c38320'
No body was attached to the request
2025-04-01 14:10:40,736 [INFO] azure.core.pipeline.policies.http_logging_policy on_response Response status: 202
Response headers:
    'Content-Length': '0'
    'Last-Modified': 'Tue, 01 Apr 2025 14:10:40 GMT'
    'ETag': '"0x8DD7126FC008CCF"'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': '4d77d9a3-001e-0024-090f-a3450b000000'
    'x-ms-client-request-id': '17c62012-0f03-11f0-be52-bc97e1c38320'
    'x-ms-version': 'REDACTED'
    'x-ms-copy-id': 'REDACTED'
    'x-ms-copy-status': 'REDACTED'
    'Date': 'Tue, 01 Apr 2025 14:10:40 GMT'
2025-04-01 14:10:40,738 [INFO] azure.core.pipeline.policies.http_logging_policy on_request Request URL: 'https://the-destination/eccc/NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI%2C1.0%2CAGL%2CMPRATE%3AURP%3ACASLA_NUMERIC_AS_META%3ARADAR%3ANUMERIC.tmp?sv=REDACTED&ss=REDACTED&srt=REDACTED&sp=REDACTED&se=REDACTED&st=REDACTED&spr=REDACTED&sig=REDACTED'
Request method: 'DELETE'
Request headers:
    'x-ms-version': 'REDACTED'
    'Accept': 'application/xml'
    'User-Agent': 'Sarracenia/3.00.58rc1 azsdk-python-storage-blob/12.13.1 Python/3.6.9 (Linux-5.4.0-211-generic-x86_64-with-Ubuntu-18.04-bionic)'
    'x-ms-date': 'REDACTED'
    'x-ms-client-request-id': '17d11b70-0f03-11f0-be52-bc97e1c38320'
No body was attached to the request
2025-04-01 14:10:40,761 [INFO] azure.core.pipeline.policies.http_logging_policy on_response Response status: 202
Response headers:
    'Content-Length': '0'
    'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
    'x-ms-request-id': '4d77d9b3-001e-0024-190f-a3450b000000'
    'x-ms-client-request-id': '17d11b70-0f03-11f0-be52-bc97e1c38320'
    'x-ms-version': 'REDACTED'
    'x-ms-delete-type-permanent': 'REDACTED'
    'Date': 'Tue, 01 Apr 2025 14:10:40 GMT'
2025-04-01 14:10:40,762 [INFO] sarracenia.flow send Sent: /apps/sarra/public_data//20250401/MSC-CMC/RADAR/NUMERIC/CASLA_NUMERIC_AS_META/19/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC  into /NUMERIC/2025/04/01/14/202503281912~CAPPI_1.0KM_NUMERIC_AS_META~CAPPI,1.0,AGL,MPRATE:URP:CASLA_NUMERIC_AS_META:RADAR:NUMERIC 0-356065
```

I tried adding this use case in the `test_rename` azure unit test (by adding `directory /path/to/something`) but I couldn't trigger the unit test to fail without the patch.