### PR TITLE
enable persistence for mosquitto

### DIFF
--- a/travis/flow_autoconfig_add_mosquitto.sh
+++ b/travis/flow_autoconfig_add_mosquitto.sh
@@ -41,6 +41,12 @@ EOT
 
 sudo mv /tmp/pwfile /etc/mosquitto
 
+# "Warning: File /etc/mosquitto/pwfile owner is not mosquitto. Future versions will refuse to load this file."
+# "Warning: File /etc/mosquitto/pwfile group is not mosquitto. Future versions will refuse to load this file."
+# "Warning: File /etc/mosquitto/pwfile has world readable permissions. Future versions will refuse to load this file."
+sudo chown mosquitto:mosquitto /etc/mosquitto/pwfile
+sudo chmod 0700 /etc/mosquitto/pwfile
+
 sudo mosquitto_passwd -U /etc/mosquitto/pwfile
 
 cat >/tmp/aclfile <<EOT
@@ -60,6 +66,10 @@ password_file /etc/mosquitto/pwfile
 max_inflight_messages 1000
 max_queued_messages 1000000
 message_size_limit 500000
+# persistence is false by default
+# "If false, the data will be stored in memory only."
+# i.e. data is lost when broker is restarted
+persistence true
 EOT
 sudo mv /tmp/sarra.conf /etc/mosquitto/conf.d
 


### PR DESCRIPTION
Goes with https://github.com/MetPX/sr_insects/pull/68

This enables persistence for the Mosquitto broker. 

https://mosquitto.org/man/mosquitto-conf-5.html

> ### `persistence [ true | false ]`

> If true, connection, subscription and message data will be written to the disk in mosquitto.db at the location dictated by persistence_location. When mosquitto is restarted, it will reload the information stored in mosquitto.db. The data will be written to disk when mosquitto closes and also at periodic intervals as defined by autosave_interval. Writing of the persistence database may also be forced by sending mosquitto the SIGUSR1 signal. <mark>If false, the data will be stored in memory only. Defaults to false.</mark>

With this change + the sr_insects change, flakey_broker passes using MQTT on my test VM.