### PR TITLE
Email sender bug when file type is None + logging improvements

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -2169,6 +2169,9 @@ class Config:
             logger.critical( f"{component}/{config} vip feature requested, but missing library: {' '.join(features['vip']['modules_needed'])} " )
             sys.exit(1)
 
+        if hasattr(self, 'broker') and self.broker is None and hasattr(self, 'post_broker') and self.post_broker is None:
+            logger.warning("Both broker and post_broker are set to None")
+
     def check_undeclared_options(self):
 
         alloptions = str_options + flag_options + float_options + list_options + set_options + count_options + size_options + duration_options

--- a/sarracenia/flowcb/send/email.py
+++ b/sarracenia/flowcb/send/email.py
@@ -147,12 +147,13 @@ class Email(FlowCB):
         # Get list of recipients for this message, from the mask that matched the filename/path
         recipients = self.o.masks[msg['_mask_index']][-1]
 
+        # i.e. (type/subtype, encoding)
         file_type = mimetypes.guess_type(ipath)
 
         # Prepare the email message
         try:
             # Build a non-text email message for the attachment if specified or if the file type can be deemed to be an image.
-            if self.o.email_attachment or 'image' in file_type[0]:
+            if self.o.email_attachment or (len(file_type) > 0 and file_type[0] and 'image' in file_type[0]):
                 emsg = MIMEMultipart()
                 emsg_text = MIMEText(f"{self.o.email_attachment_text}")
                 # Add the attachment text that will be paired with the attachment data

--- a/sarracenia/transfer/azure.py
+++ b/sarracenia/transfer/azure.py
@@ -64,6 +64,11 @@ class Azure(Transfer):
             else:
                 self.connection_verify = True
 
+        # When inflight is used in Azure, we try to copy and removing the original the temp file instead of doing a rename (like in traditional ftp/sftp).
+        # For this, we discourage users to use the inflight option
+        if self.o.inflight:
+            logger.warning(f"inflight usage is discouraged. Azure can't rename files and will copy/delete the temp file. Current inflight setting set to {self.o.inflight}.")
+
         # The default INFO level for this logger is quite verbose, we might want to reduce it some day
         # logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel('WARNING')
 


### PR DESCRIPTION
Couple of things in this PR.

1. I found a bug with the file type check logic in the email sender. It would fail when the file type is `None`. 

This was the error message encountered.
```
2025-04-03 17:58:23,802 [DEBUG] sarracenia.flowcb.send.email send Exception details:
Traceback (most recent call last):
  File "/local/home/sarra/sr3/sarracenia/flowcb/send/email.py", line 155, in send
    if self.o.email_attachment or 'image' in file_type[0]:
TypeError: argument of type 'NoneType' is not iterable
```

2. I ran into a case where I was confused when a config had an invalid credential set for `broker` and `post_broker` wasn't set. It wasn't really obvious what was the problem. When this happens, both `broker` and `post_broker` are set to `None`. There weren't any logs that seemed to give a clue to this, so I added one.
3. In regards to the recommendations in https://github.com/MetPX/sarracenia/pull/1414, I added a warning when `inflight` is used with the Azure transfer class.