### PR TITLE
fix #1420 precise time comparison in nodupe/disk engine

### DIFF
--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -106,11 +106,7 @@ class Disk(NoDupe):
 
         logger.debug( f"entry already in NoDupe cache: key={key}" )
         kdict = self.cache_dict[key]
-        present = relpath in kdict
-
-        if kdict[relpath]+ self.o.nodupe_ttl < self.now :
-            present=False
-            del kdict[relpath]
+        present = relpath in kdict and (kdict[relpath]+self.o.nodupe_ttl) >= self.now
 
         kdict[relpath] = self.now
 

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -102,9 +102,16 @@ class Disk(NoDupe):
             self.count += 1
             return True
 
+         
+
         logger.debug( f"entry already in NoDupe cache: key={key}" )
         kdict = self.cache_dict[key]
         present = relpath in kdict
+
+        if kdict[relpath]+ self.o.nodupe_ttl < self.now :
+            present=False
+            del kdict[relpath]
+
         kdict[relpath] = self.now
 
         # differ or newer, write to file


### PR DESCRIPTION
close #1420 

I think it fixes the issue. Just ran flow tests and unit tests.
Might want some more specific tests for the issue.