### PR TITLE
Misc. AM/bulletin renamer fixes - April 2025

### DIFF
--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -1,5 +1,6 @@
 import logging
 import time 
+import random
 import re
 from base64 import b64decode
 
@@ -26,7 +27,6 @@ class Bulletin:
     def __init__(self,options):
         super().__init__()
         self.o = options
-        self.seq = 0
         self.binary = 0
 
     def _verifyYear(self, bulletin_year):
@@ -159,10 +159,7 @@ class Bulletin:
     def getSequence(self):
         """ sequence number to make the file unique...
         """
-        self.seq = self.seq + 1
-        if self.seq > 99999:
-            self.seq = 1
-        return str(self.seq).zfill(5)
+        return str(random.randint(0, 99999)).zfill(5)
 
 
     def getStation(self, data):
@@ -216,7 +213,8 @@ class Bulletin:
 
             elif data[0][0:6] in ["SRCN40","SXCN40","SRMT60","SXAK50", "SRND20", "SRND30"]:
             #elif data[0][0:6] in self.wmo_id:
-                station = premiereLignePleine.split()[0]
+                #station = premiereLignePleine.split()[0]
+                station = ''
 
             elif data[0][0:2] in ["FC","FT"]:
                 if premiereLignePleine.split()[1] == "AMD":

--- a/sarracenia/examples/flow/amserver.conf
+++ b/sarracenia/examples/flow/amserver.conf
@@ -2,20 +2,29 @@
 post_topicPrefix v03.post
 post_format v03
 
-callback gather.am
+callback_prepend gather.am
 callback post.message
 
 # Add appropriate data to filename
 callback rename.raw2bulletin
 
+# Some bulletins have iso-8859-1 encoded characters that UTF-8 can't resolve.
+inputCharset iso-8859-1
+
 post_broker amqp://tsource@localhost
 post_exchange xs_tsource_am
 post_baseUrl file://
 
+# A large batch is needed, when the renamer + AM receiver is being used. 
+# The AM receiver doesn't operate with an ingestion batch. So if `batch` is lower, it causes problems.
+batch 1000000
+mirror False
 download on
 directory /tmp/am_receiver
 accept .*
+
 sum sha512
+
 AllowIPs 127.0.0.1 
 AllowIPs 199.212.17.131
 AllowIPs 199.212.17.132

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -21,7 +21,7 @@ Examples:
        WACN07 CWAO 082327
        CZEG AIRMET E1 VALID 080105/080505 CWEG-
 
-       Output filename: WACN07_CWAO_082327_CZEG__00001
+       Output filename: WACN07_CWAO_082327__CZEG_00001
     
     Another RAW Ninjo file
        FTCN32 CWAO 100500 AAM
@@ -36,7 +36,7 @@ Examples:
         CACN00 CWAO 141600
         PQU
 
-       Output filename: CACN00_CWAO_141600_PQU__00003
+       Output filename: CACN00_CWAO_141600__PQU_00003
 
     A ISA binary bulletin
        Input filename: ISAA41_CYZX_162000__00035 

--- a/tests/sarracenia/flowcb/gather/am__gather_test.py
+++ b/tests/sarracenia/flowcb/gather/am__gather_test.py
@@ -1,7 +1,7 @@
 import pytest
 from tests.conftest import *
 
-import os, types, copy
+import os, types, copy, re
 
 from sarracenia.flowcb.gather.am import Am
 import sarracenia.config 
@@ -114,7 +114,7 @@ def test_am_binary_bulletin():
 
     # Check renamer.
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'ISAA41_CYWA_030000___00001'
+    assert re.match('ISAA41_CYWA_030000___.....' , worklist.incoming[0]['rename'])
 
 
 # Test 2: Check a regular CACN bulletin
@@ -146,11 +146,10 @@ def test_cacn_regular():
     worklist.incoming = [message_test2]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'CACN00_CWAO_021600__WVO_00001'
+    assert re.match('CACN00_CWAO_021600__WVO_.....' , worklist.incoming[0]['rename'])
 
 # Test 3: Check an erronous CACN bulletin (missing timestamp in bulletin contents)
 def test_cacn_erronous():
-    import re
 
     BaseOptions = Options()
     renamer = Raw2bulletin(BaseOptions)
@@ -179,7 +178,7 @@ def test_cacn_erronous():
 
 
     renamer.after_gather(worklist)
-    assert re.match('CACN00_CWAO_......__WPK_00001_PROBLEM' , worklist.incoming[0]['rename'])
+    assert re.match('CACN00_CWAO_......__WPK_....._PROBLEM' , worklist.incoming[0]['rename'])
 
 # Test 4: Bulletin with double line separator after header (my-header\n\n)
 def test_bulletin_double_linesep():
@@ -211,11 +210,11 @@ def test_bulletin_double_linesep():
     worklist.incoming = [message_test4]
 
     renamer.after_gather(worklist)
-    assert message_test4['rename'] == 'SXCN35_CWVR_021100___00001'
+    assert re.match('SXCN35_CWVR_021100___.....' , worklist.incoming[0]['rename'])
 
 # Test 5: Bulletin with invalid year in timestamp (Fix: https://github.com/MetPX/sarracenia/pull/973)
 def test_bulletin_invalid_timestamp(caplog):
-    import re, datetime
+    import datetime
 
     BaseOptions = Options()
     renamer = Raw2bulletin(BaseOptions)
@@ -298,7 +297,7 @@ def test_bulletin_wrong_station():
     worklist.incoming = [message_test7]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'UECN99_CYCX_071200___00001_PROBLEM'
+    assert re.match('UECN99_CYCX_071200___....._PROBLEM' , worklist.incoming[0]['rename'])
 
 # Test 8: SM Bulletin - Add station mapping + SM/SI bulletin accomodities 
 def test_SM_bulletin():
@@ -329,7 +328,7 @@ def test_SM_bulletin():
     worklist.incoming = [message_test8]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'SMCN06_CWAO_030000__71816_00001'
+    assert re.match('SMCN06_CWAO_030000__71816_.....' , worklist.incoming[0]['rename'])
 
 # Test 9: Bulletin with 5 fields in header (invalid)
 def test_bulletin_header_five_fileds():
@@ -420,7 +419,7 @@ def test_random_bulletin_with_BBB():
     worklist.incoming = [message_test12]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'FXCN06_CYTR_230939_AAA__00001'
+    assert re.match('FXCN06_CYTR_230939_AAA__.....' , worklist.incoming[0]['rename'])
 
 # Test 13: SM Bulletin with BBB - Add station mapping + SM/SI bulletin accomodities + conserve BBB header
 #          Also test AddSMHeader option
@@ -453,7 +452,7 @@ def test_SM_bulletin_with_BBB_no_addsmheader():
     worklist.incoming = [message_test13]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'SMCN06_CWAO_030000_AAA_71816_00001'
+    assert re.match('SMCN06_CWAO_030000_AAA_71816_.....' , worklist.incoming[0]['rename'])
 
 # Test 14: Complete SM Bulletin with BBXX field - Should not add AAXX line afterwards
 def test_SM_bulletin_with_BBXX():
@@ -488,7 +487,7 @@ def test_SM_bulletin_with_BBXX():
     worklist.incoming = [message_test14]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'SMVD03_CYTR_280600__BBXX_00001'
+    assert re.match('SMVD03_CYTR_280600__BBXX_.....' , worklist.incoming[0]['rename'])
 
 # Test 15: SM Bulletin with BBB - Add station mapping + SM/SI bulletin accomodities + conserve BBB header
 #          Also test AddSMHeader option
@@ -521,7 +520,7 @@ def test_SM_bulletin_with_BBB_w_addsmheader():
     worklist.incoming = [message_test15]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'SMCN06_CWAO_030000_AAA_71816_00001'
+    assert re.match('SMCN06_CWAO_030000_AAA_71816_.....' , worklist.incoming[0]['rename'])
 
 # Test 16: SN (Synoptic) Bulletin:
 def test_SN_syno_bulletin():
@@ -555,6 +554,6 @@ def test_SN_syno_bulletin():
     worklist.incoming = [message_test16]
 
     renamer.after_gather(worklist)
-    assert worklist.incoming[0]['rename'] == 'SNVD02_CWAO_280700___00001'
+    assert re.match('SNVD02_CWAO_280700___.....' , worklist.incoming[0]['rename'])
 
 


### PR DESCRIPTION
- Found an interesting bug while running AM flow tests. `batch` needs to be at a high value when the bulletin renamer is being called. The AM server doesn't have a limit of files to gather (either that or it's not known). I documented this problem in the AM servers' example.

- American bulletins (SRCN40/SXCN40/etc._KWAL) aren't causing problems anymore with the bulletin renamer. This will be huge when we migrate our sundew receivers that gather NWS data.

- Have true random ints (like sundew did) when generating the bulletin sequence number.

Flow tests for AM pass on both U18.04 and U22.04. AM flow test PR coming soon too.