### PR TITLE
fix post_exchange parsing, it had a weirdness.

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server, partitioned_flow ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
        which_test: [ static_flow, no_mirror, flakey_broker, dynamic_flow, restart_server ]
-       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -26,7 +26,7 @@ jobs:
       # Don't cancel the entire matrix when one job fails
       fail-fast: false
       matrix:
-       osver: [ "ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04" ]
+       osver: [ "ubuntu-22.04", "ubuntu-24.04" ]
 
     runs-on: ${{ matrix.osver }}
   

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -2039,23 +2039,25 @@ class Config:
                                             component, cfg)
 
         if self.post_broker is not None and self.post_broker.url is not None:
-            if not hasattr(self,
-                           'post_exchange') or self.post_exchange is None:
+            if not hasattr(self, 'post_exchange') or self.post_exchange is None:
                 self.post_exchange = 'xs_%s' % self.post_broker.url.username
 
-            if hasattr(self, 'post_exchangeSuffix'):
-                self.post_exchange += '_%s' % self.post_exchangeSuffix
+            post_broker_isList = hasattr(self,'post_exchange') and type(self.post_exchange) is list
 
-            if hasattr(self,'post_exchange') and (type(self.post_exchange) is list ):
-                pass
-            elif hasattr(self, 'post_exchangeSplit') and self.post_exchangeSplit > 1:
-                l = []
-                for i in range(0, int(self.post_exchangeSplit)):
-                    y = self.post_exchange + '%02d' % i
-                    l.append(y)
-                self.post_exchange = l
-            else:
-                self.post_exchange = [self.post_exchange]
+            if not post_broker_isList:
+                if hasattr(self, 'post_exchangeSuffix'):
+                    self.post_exchange += '_%s' % self.post_exchangeSuffix
+
+                if hasattr(self,'post_exchange') and (type(self.post_exchange) is list ):
+                    pass
+                elif hasattr(self, 'post_exchangeSplit') and self.post_exchangeSplit > 1:
+                    l = []
+                    for i in range(0, int(self.post_exchangeSplit)):
+                        y = self.post_exchange + '%02d' % i
+                        l.append(y)
+                    self.post_exchange = l
+                else:
+                    self.post_exchange = [self.post_exchange]
 
             if (component in ['poll' ]) and (hasattr(self,'vip') and self.vip):
                 if (not hasattr(self,'exchange') or not self.exchange):


### PR DESCRIPTION
was adding the suffix multiple times. dunno why.  Noticed this symptom running
the static flow test... see poll/sftp_f62.conf:

```

fractal% sr3 show poll/sftp_f62 | grep post_broker
2025-04-19 09:00:55,377 736592 [INFO] sarracenia.flow.poll __init__ Good! post_exchange: xs_tsource_poll and exchange: xs_tsource_poll match so multiple instances to share a poll.
2025-04-19 09:00:55,377 736592 [WARNING] sarracenia.flow.poll __init__ nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904
2025-04-19 09:00:55,381 736592 [INFO] sarracenia.flowcb.scheduled update_appointments for 2025-04-19 13:00:55.381841+00:00: [] 
 '_Config__post_broker': 'amqp://tsource@localhost/',
 'post_broker': 'amqp://tsource@localhost/',
fractal% sr3 show poll/sftp_f62 | grep post_exchange
2025-04-19 09:01:03,444 736598 [INFO] sarracenia.flow.poll __init__ Good! post_exchange: xs_tsource_poll and exchange: xs_tsource_poll match so multiple instances to share a poll.
2025-04-19 09:01:03,444 736598 [WARNING] sarracenia.flow.poll __init__ nodupe_ttl < fileAgeMax means some files could age out of the cache and be re-ingested ( see : https://github.com/MetPX/sarracenia/issues/904
2025-04-19 09:01:03,449 736598 [INFO] sarracenia.flowcb.scheduled update_appointments for 2025-04-19 13:01:03.449223+00:00: [] 
 'post_exchange': ['xs_tsource_poll', '_', 'p', 'o', 'l', 'l'],
 'post_exchangeSuffix': 'poll',
 'post_exchanges': [],
fractal% 

```

fixed by this patch.

