### PR TITLE
Bulletin renaming miscellaneous fixes - 2025/05

### DIFF
--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -247,7 +247,7 @@ class Bulletin:
                 station = ''
 
             # Added to SR3
-            # The station needs to be alphanumeric, between 3 and 6 characters. If not, don't assign a station
+            # The station needs to be alphanumeric, between 3 and 7 characters. If not, don't assign a station
             if re.search('^[a-zA-Z0-9]{3,7}$', station) == None:
                 station = ''
 

--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -248,8 +248,8 @@ class Bulletin:
 
             # Added to SR3
             # The station needs to be alphanumeric, between 3 and 6 characters. If not, don't assign a station
-            if re.search('^[a-zA-Z0-9]{3,6}$', station) == None:
-                station = None
+            if re.search('^[a-zA-Z0-9]{3,7}$', station) == None:
+                station = ''
 
         return station
 

--- a/sarracenia/bulletin.py
+++ b/sarracenia/bulletin.py
@@ -156,8 +156,8 @@ class Bulletin:
             logger.error(f"Could not fetch file data of from either message content or {path}. Error details: {e}")
             return None
 
-    def getSequence(self):
-        """ sequence number to make the file unique...
+    def getRandom(self):
+        """ Generate Random number to make the file unique...
         """
         return str(random.randint(0, 99999)).zfill(5)
 
@@ -247,8 +247,8 @@ class Bulletin:
                 station = ''
 
             # Added to SR3
-            # The station needs to be alphanumeric, between 3 and 5 characters. If not, don't assign a station
-            if re.search('^[a-zA-Z0-9]{3,5}$', station) == None:
+            # The station needs to be alphanumeric, between 3 and 6 characters. If not, don't assign a station
+            if re.search('^[a-zA-Z0-9]{3,6}$', station) == None:
                 station = None
 
         return station

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1168,14 +1168,14 @@ class Flow:
                 self.worklist.incoming.extend(new_incoming)
                 so_far += len(new_incoming) 
 
+            self._runCallbacksWorklist('after_gather')
+
             # if we gathered enough with a subset of plugins then return.
             if not keep_going or (so_far >= self.o.batch):
                 if (self.o.component == 'poll' ):
                     self.worklist.poll_catching_up=True
 
                 return
-
-        self._runCallbacksWorklist('after_gather')
 
         # gather is an extended version of poll.
         if self.o.component != 'poll':

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -91,16 +91,21 @@ class Raw2bulletin(FlowCB):
             # If called by a sarra, should always have post_baseDir, so should be OK in specifying it
             path = self.o.post_baseDir + '/' + msg['relPath']
 
-            data = msg.getContent(self.o)
-
             # Determine if bulletin is binary or not
             # From sundew source code
-            if data.splitlines()[1][:4] in self.o.binaryInitialCharacters:
-                # Decode data, only text. The raw binary data contains the header in which we're interested. Only get that header.
-                data = data.splitlines()[0].decode('ascii')
-            else:
-                # Data is not binary
-                data = data.decode(self.o.inputCharset)
+            try:
+                data = msg.getContent(self.o)
+
+                if data.splitlines()[1][:4] in self.o.binaryInitialCharacters:
+                    # Decode data, only text. The raw binary data contains the header in which we're interested. Only get that header.
+                    data = data.splitlines()[0].decode('ascii')
+                else:
+                    # Data is not binary
+                    data = data.decode(self.o.inputCharset)
+            except Exception as e:
+                logger.error(f"Error encountered trying to fetch or decode data. Error message {e}")
+                worklist.rejected.append(msg)
+                continue
 
 
             if not data:
@@ -113,6 +118,9 @@ class Raw2bulletin(FlowCB):
             #first_line  = first_line.strip(' ')
             #first_line  = first_line.strip('\t')
             first_line  = lines[0].split(' ')
+
+            # Sometimes bulletins have carriage returns at the end of the first line. Remove if applicable
+            first_line[-1]  = first_line[-1].replace('\r', '')
 
             # Build header from bulletin
             header = self.bulletinHandler.buildHeader(first_line)
@@ -136,7 +144,7 @@ class Raw2bulletin(FlowCB):
             stn_id = self.bulletinHandler.getStation(data)
 
             # Generate a sequence (random ints)
-            seq = self.bulletinHandler.getSequence()
+            seq = self.bulletinHandler.getRandom()
 
             # Assign a default value for messages not coming from AM
             if 'isProblem' not in msg:
@@ -172,7 +180,8 @@ class Raw2bulletin(FlowCB):
                 new_worklist.append(msg)
                 
             except Exception as e:
-                logger.error(f"Error in renaming. Error message: {e}")
+                logger.error(f"Error in renaming the filename. Error message: {e}")
+                worklist.rejected.append(msg)
                 continue
 
         worklist.incoming = new_worklist

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -104,7 +104,7 @@ class Raw2bulletin(FlowCB):
                     # Data is not binary
                     data = data.decode(self.o.inputCharset)
             except Exception as e:
-                logger.error(f"Error encountered trying to fetch or decode data. Error message {e}")
+                logger.error(f"Error encountered trying to fetch or decode data. Error message: {e}")
                 worklist.rejected.append(msg)
                 continue
 

--- a/sarracenia/flowcb/rename/raw2bulletin.py
+++ b/sarracenia/flowcb/rename/raw2bulletin.py
@@ -96,7 +96,8 @@ class Raw2bulletin(FlowCB):
             try:
                 data = msg.getContent(self.o)
 
-                if data.splitlines()[1][:4] in self.o.binaryInitialCharacters:
+                # Also accept bulletins that only have one line (health check bulletins)
+                if len(data.splitlines()) == 1 or data.splitlines()[1][:4] in self.o.binaryInitialCharacters:
                     # Decode data, only text. The raw binary data contains the header in which we're interested. Only get that header.
                     data = data.splitlines()[0].decode('ascii')
                 else:
@@ -141,7 +142,9 @@ class Raw2bulletin(FlowCB):
             BBB = self.bulletinHandler.getBBB(first_line)
 
             # Get the station ID from bulletin
-            stn_id = self.bulletinHandler.getStation(data)
+            if not len(data.splitlines()) == 1:
+                stn_id = self.bulletinHandler.getStation(data)
+            else: stn_id = ''
 
             # Generate a sequence (random ints)
             seq = self.bulletinHandler.getRandom()

--- a/tests/sarracenia/flowcb/gather/am__gather_test.py
+++ b/tests/sarracenia/flowcb/gather/am__gather_test.py
@@ -297,7 +297,7 @@ def test_bulletin_wrong_station():
     worklist.incoming = [message_test7]
 
     renamer.after_gather(worklist)
-    assert re.match('UECN99_CYCX_071200___....._PROBLEM' , worklist.incoming[0]['rename'])
+    assert re.match('UECN99_CYCX_071200___.....' , worklist.incoming[0]['rename'])
 
 # Test 8: SM Bulletin - Add station mapping + SM/SI bulletin accomodities 
 def test_SM_bulletin():


### PR DESCRIPTION
Things that are fixed

- The weird `batch` problem identified in https://github.com/MetPX/sr_insects/pull/70 is triggered because the `after_gather` call location is likely wrong.
   - We now call `after_gather` plugins before the return for the batch condition.

- I think WMO bulletins will hold carriage returns at the end of the bulletin header. Current code doesn't take into account this and renames the file wrong (with the carriage return).

- DMS sometimes sends bulletins with only the header, and that makes the rename plugin crash. The bulletin is technically wrong, but the code should handle such errors better.

- Change `getSequence` to a more reflective method name.

- Some stations coming from NWS have 6 or 7 characters and seem to be correct (at least comparing to Sundew behaviour). 
   - We also don't want to fail when the station REGEX fails. Assign no station to the filename instead.

Part of the yielded results came from testing with the full suite of bulletins coming from NWS. It's been over a day now and there are much less errors then initially. I'm still running the test to try and catch more minor errors.

