### PR TITLE
implement configs_extant in sr3 status (argument for --dangerWillRobi…

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2650,7 +2650,7 @@ class sr_GlobalState:
         configs_running = 0
         now = time.time()
 
-                
+        configs_extant=0                
         for c in sorted(self.configs):
             for cfg in sorted(self.configs[c]):
                 f = c + os.sep + cfg
@@ -2658,6 +2658,7 @@ class sr_GlobalState:
                     continue
                 if self.configs[c][cfg]['status'] == 'include':
                     continue
+                configs_extant+=1
 
                 if not (c in self.states and cfg in self.states[c]):
                     continue
@@ -2748,8 +2749,8 @@ class sr_GlobalState:
                 bad = 1
                 print( f"pid:{pid} \"{self.strays[pid]}\" is not a configured instance" )
 
-            print('      Total Running Configs: %3d ( Processes: %d missing: %d stray: %d )' %
-                (configs_running, len(self.procs), len(self.missing), stray ) )
+            print('      Total Running Configs: %3d/%d ( Processes: %d missing: %d stray: %d )' %
+                (configs_running, configs_extant, len(self.procs), len(self.missing), stray ) )
             print('                     Memory: uss:%s rss:%s vms:%s ' % ( \
                   naturalSize( self.resources['uss'] ), \
                   naturalSize( self.resources['rss'] ), naturalSize( self.resources['vms'] )\


### PR DESCRIPTION
…son)

At the bottom of the *sr3 status* command, change this line:
```
      Total Running Configs:   0 ( Processes: 0 missing: 0 stray: 0 )

```
to this:
```
        Total Running Configs:   0/25 ( Processes: 0 missing: 0 stray: 0 )

```

The 25 is the number configurations existing in the pump, and the argument 
one would use to remove everything using a *--dangerWillRobinson* override
confirmation.