### PR TITLE
Issue1436 random ebo maximum

### DIFF
--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -464,8 +464,8 @@ class Moth():
         attempt_duration = max(now - start,1)
         self.next_connect_failures += 1
 
-        # wait twice as long after each failure. 
-        ebo = 2**self.next_connect_failures
+        # wait a little longer after each failure. 
+        ebo = 1.2**self.next_connect_failures
 
         # eboIntervalMaximum is something random between 1 and 4 minutes.
         # it is the ceiling. Otherwise based on the number of failures to connect and 

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -33,6 +33,10 @@ default_options = {
     'tlsRigour': 'normal'
 }
 
+import random
+
+eboIntervalMaximum = 60 + random.random()*180
+
 def ProtocolPresent(p) -> bool:
     if ( p[0:4] in ['amqp'] ) and sarracenia.features['amqp']['present']:
        return True
@@ -336,6 +340,7 @@ class Moth():
 
         logging.basicConfig(format=self.o['logFormat'],
                             level=getattr(logging, self.o['logLevel'].upper()))
+        logger.debug( f" Maximum interval exponential back off of connecting to broker: {eboIntervalMaximum} " )
 
     def ack(self, message: sarracenia.Message ) -> bool:
         """
@@ -454,10 +459,18 @@ class Moth():
              it should eventually settle down to a long period though.
         """
         now=time.time()
-        attempt_duration = now - start
+        # if the attempt takes a long time, do not want to try again quickly.
+        # but if it fails immediately, then wait at least 1 second.
+        attempt_duration = max(now - start,1)
         self.next_connect_failures += 1
+
+        # wait twice as long after each failure. 
         ebo = 2**self.next_connect_failures
-        next_try = min(attempt_duration * ebo, 600)
+
+        # eboIntervalMaximum is something random between 1 and 4 minutes.
+        # it is the ceiling. Otherwise based on the number of failures to connect and 
+        # how long each attempt takes to fail.
+        next_try = min(max(attempt_duration * ebo,0.1), eboIntervalMaximum)
         self.next_connect_time = now + next_try
 
     def splitPick(self,message) -> int:

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -198,6 +198,7 @@ class AMQP(Moth):
         self.connection = None
         self.connection_id = None
         self.broker = None
+        self.next_message = 0
 
     def __connect(self, broker) -> bool:
         """
@@ -344,7 +345,9 @@ class AMQP(Moth):
 
         start = time.time()
         if start < self.next_connect_time:
-            logger.critical( f"too soon to connect again to {str(broker)} index={self.o['subscription_index']} will try in: {self.next_connect_time-start} seconds" )
+            if start > self.next_message:
+                logger.critical( f"too soon to connect again to {str(broker)} index={self.o['subscription_index']} will try in: {self.next_connect_time-start:.2f} seconds" )
+                self.next_message=start+5
             return
 
         # It does not really matter how it fails, the recovery approach is always the same:
@@ -418,8 +421,9 @@ class AMQP(Moth):
         start = time.time()
 
         if start < self.next_connect_time:
-
-            logger.critical( f"too soon to connect to {str(self.o['broker'])}. Will try again in: {self.next_connect_time-start} seconds" )
+            if start > self.next_message :
+                logger.critical( f"too soon to connect to {str(self.o['broker'])}. Will try again in: {self.next_connect_time-start:.2f} seconds" )
+                self.next_message=start+5
             return
 
         # It does not really matter how it fails, the recovery approach is always the same:
@@ -466,7 +470,7 @@ class AMQP(Moth):
 
         except Exception as err:
             logger.error(
-                "AMQP putSetup failed to connect or declare exchanges {}@{} on {}: {}"
+                "failed to connect or declare exchanges {}@{} on {}: {}"
                 .format(self.o['exchange'], self.o['broker'].url.username,
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
@@ -655,6 +659,8 @@ class AMQP(Moth):
             try:
                 self.close()
                 self.putSetup()
+                if (not self.connection) or (not self.connection.connected) or (not self.channel.is_open):
+                    return False
             except Exception as err:
                 logger.warning(f"failed, connection was closed/broken and could not be re-opened {exchange}: {err}")
                 logger.debug('Exception details: ', exc_info=True)

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -131,6 +131,7 @@ class MQTT(Moth):
 
         now = time.time()
         self.next_connect_time = now
+        self.next_message=0
         self.next_connect_failures = 0
 
         if 'qos' not in self.o:
@@ -402,7 +403,9 @@ class MQTT(Moth):
 
         start = time.time()
         if start < self.next_connect_time:
-            logger.critical( f"too soon to connect again to {str(broker)} index={self.o['subscription_index']} will try in: {self.next_connect_time-start} seconds" )
+            if start > self.next_message :
+                logger.critical( f"too soon to connect again to {str(broker)} index={self.o['subscription_index']} will try in: {self.next_connect_time-start:.2f} seconds" )
+                self.next_message=start+5
             return
 
         try:
@@ -481,7 +484,9 @@ class MQTT(Moth):
 
         start = time.time()
         if start < self.next_connect_time:
-            logger.critical( f"too soon to connect for publishing to {str(self.o['broker'])} will try in: {self.next_connect_time-start} seconds" )
+            if start > self.next_message: 
+                logger.critical( f"too soon to connect for publishing to {str(self.o['broker'])} will try in: {self.next_connect_time-start:.2f} seconds" )
+                self.next_message=start+5
             return
 
         try:
@@ -728,6 +733,8 @@ class MQTT(Moth):
 
         if not self.connected:
             self.putSetup()
+            if not self.connected:
+                return False
 
         # The caller probably doesn't expect the message to get modified by this method, so use a copy of the message
         body = copy.deepcopy(message)


### PR DESCRIPTION
close #1436

Proposed resolution for #1436 ... The backoff logic:

* backs off too quickly to maximum interval (10 minutes.)
* the maximum interval is too long.

corrections in this branch:
* it now waits at least 1 second before trying to connect again.
* it increases the interval at a rate of 1.2**number_of_attempts (base use to be 2) so the interval increases more slowly.
* the reconnection maximum interval is a value decided at start up as a random time between 1 and 4 minutes.

so if the broker goes down, and the connection attempt fails immediately, it should wait for:

* 1.2, 1.44, 1.73, 2.07, 2.49, 2.99, 3.58, 4.8, 5.16, 6.19, 7.43, 8.92, 10.7, 12.84, 15.41, 18.49 .... it will eventually get to a few minutes...
