### PR TITLE
Improve fileEvents documentation

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -756,8 +756,25 @@ fileEvents <event,event,...>
 
 A comma separated list of file event types to monitor.
 Available file events:  create, delete, link, modify, mkdir, rmdir
-to only add events to the current list start the event list with a plus sign (+).
-To remove them, prefix with a minus sign (-).
+
+There are three ways to use this option:
+
+        1. Add events to the current list. Start the event list with a plus sign (+).
+           i.e. fileEvents +create,modify
+           Resulting list: create, delete, link, modify, mkdir, rmdir
+
+        2. Remove events from the current list. Prefix with a minus sign (-).
+           i.e. fileEvents -create,modify
+           Resulting list: delete, link, mkdir, rmdir
+
+        3. Define your own list of events.
+           i.e. fileEvents create,modify
+           Resulting list: create, modify
+
+           We can also add a single event.
+           i.e. fileEvents create
+           Resulting list: create
+
 
 The *create*, *modify*, and *delete* events reflect what is expected: a file being created, modified, or deleted.
 If *link* is set, symbolic links will be posted as links so that consumers can choose

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -749,9 +749,27 @@ pour que les liaisons de sujet s'appliquent à la file d'attente spécifié.
 fileEvents <évènement, évènement,...>
 -------------------------------------
 
-ensemble séparée par des virgules de d'événements de fichiers à surveiller.
+Ensemble séparée par des virgules de d'événements de fichiers à surveiller.
 Événements de fichiers disponibles : *create, delete, link, modify, mkdir, rmdir*
-Si on commence la liste avec plus (+) ca signifie un rajout à l´ensemble actuel
+
+Nous pouvons faire ceci 3 façons:
+
+        1. On commence la liste avec plus (+). Ça signifie un rajout à l´ensemble actuel
+           i.e. fileEvents +create,modify
+           Liste résultante : create, delete, link, modify, mkdir, rmdir
+
+        2. Enlève un/des évènements de la liste présente. On termine la liste avec moins (-)
+           i.e. fileEvents -create,modify
+           Liste résultante : delete, link, mkdir, rmdir
+
+        3. On défini notre propre liste d'évènements.
+           i.e. fileEvents create,modify
+           Liste résultante : create,modify
+
+           On peut également spécifié un seul évènement.
+           i.e. fileEvents create
+           Liste résultante: create
+
 Les événements *create*, *modify* et *delete* reflètent ce qui est attendu : un fichier en cours de création,
 de modification ou de suppression.
 Si *link* est défini, des liens symboliques seront publiés sous forme de liens afin que les consommateurs puissent choisir

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -758,7 +758,7 @@ Nous pouvons faire ceci 3 façons:
            i.e. fileEvents +create,modify
            Liste résultante : create, delete, link, modify, mkdir, rmdir
 
-        2. Enlève un/des évènements de la liste présente. On termine la liste avec moins (-)
+        2. Enlève un/des évènements de la liste présente. On commence la liste avec moins (-)
            i.e. fileEvents -create,modify
            Liste résultante : delete, link, mkdir, rmdir
 


### PR DESCRIPTION
The current documentation doesn't explain clearly how `fileEvents` works.

I've added examples and added most use cases for the option to make it more clear.