### PR TITLE
Fix #1444

### DIFF
--- a/sarracenia/config/publisher.py
+++ b/sarracenia/config/publisher.py
@@ -65,7 +65,7 @@ class Publisher(dict):
             if hasattr(options, aa):
                 self[a] = getattr(options,aa)
 
-        if not 'post_baseUrl' in a and hasattr(options,'pollUrl') and options.pollUrl:
+        if not 'baseUrl' in self and hasattr(options,'pollUrl') and options.pollUrl:
             self['baseUrl'] = options.pollUrl
 
         if not 'baseDir' in self and not self.baseDir:


### PR DESCRIPTION
Previously we would compare `post_baseUrl` with `a`, but there's a problems with this.

`a` will always be `topicPrefix` because its the last element of the list in the for loop, which doesnt make sense.