### PR TITLE
More multi config unit tests

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1314,28 +1314,6 @@ class Config:
         return cd
 
     
-    def get_source_from_exchange(self,exchange):
-        #self.logger.debug("%s get_source_from_exchange %s" % (self.program_name,exchange))
-
-        source = None
-        if len(exchange) < 4 or not exchange.startswith('xs_') : return source
-
-        # check if source is a valid declared source user
-
-        len_u   = 0
-        try:
-                # look for user with role source
-                for u in self.declared_users :
-                    if self.declared_users[u] != 'source' : continue
-                    if exchange[3:].startswith(u) and len(u) > len_u :
-                       source = u
-                       len_u  = len(u)
-        except: pass
-
-        return source
-
- 
-
     def _merge_field(self, key, value):
         if key == 'masks':
             self.masks += value

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1383,27 +1383,6 @@ class Config:
             for k in oth.__dict__.keys():
                 self._override_field(k, self._varsub(getattr(oth, k)))
 
-    def _resolve_exchange(self):
-        """
-           based on the given configuration, fill in with defaults or guesses.
-           sets self.exchange.
-        """
-        if not hasattr(self, 'exchange') or self.exchange is None:
-            #if hasattr(self, 'post_broker') and self.post_broker is not None and self.post_broker.url is not None:
-            #    self.exchange = 'xs_%s' % self.post_broker.url.username
-            #else:
-            if not hasattr(self.broker.url,'username') or ( self.broker.url.username == 'anonymous' ):
-                self.exchange = 'xpublic'
-            else:
-                self.exchange = 'xs_%s' % self.broker.url.username
-
-            if hasattr(self, 'exchangeSuffix'):
-                self.exchange += '_%s' % self.exchangeSuffix
-
-            if hasattr(self, 'exchangeSplit') and hasattr(
-                    self, 'no') and (self.no > 0):
-                self.exchange += "%02d" % self.no
-
     def _parse_binding(self, subtopic_string):
         """
          FIXME: see original parse, with substitions for url encoding.
@@ -1414,7 +1393,6 @@ class Config:
             logger.error( f"{','.join(self.files)}:{self.lineno} broker needed before subtopic" )
             return
 
-        self._resolve_exchange()
         resolved_queueName = self._resolveQueueName(self.component,self.config)
 
         if type(subtopic_string) is str:
@@ -2098,7 +2076,6 @@ class Config:
                self.source = self.broker.url.username
 
         if self.broker and self.broker.url and self.broker.url.username:
-            self._resolve_exchange()
             resolved_queueName = self._resolveQueueName(component,cfg)
 
         valid_inlineEncodings = [ 'guess', 'text', 'binary' ]
@@ -2547,15 +2524,10 @@ class Config:
             if values == 'None':
                 namespace.subscriptions = []
 
-            namespace._resolve_exchange()
             resolved_qn = namespace._resolveQueueName(namespace.component,namespace.config)
 
             if not hasattr(namespace, 'broker'):
                 raise Exception('broker needed before subtopic')
-                return
-
-            if not hasattr(namespace, 'exchange'):
-                raise Exception('exchange needed before subtopic')
                 return
 
             if not hasattr(namespace, 'topicPrefix'):

--- a/sarracenia/config/publisher.py
+++ b/sarracenia/config/publisher.py
@@ -60,6 +60,13 @@ class Publisher(dict):
         else:
             self['format'] = 'v03'
 
+        if hasattr(options,'post_topicPrefix') and options.post_topicPrefix:
+            self['topicPrefix'] = options.post_topicPrefix
+        elif hasattr(options, 'topicPrefix') and options.topicPrefix:
+            self['topicPrefix'] = options.topicPrefix
+        else:
+            self['topicPrefix'] = None
+
         for a in [ 'baseDir', 'baseUrl', 'exchangeSplit', 'topicPrefix' ]:
             aa = "post_"+a
             if hasattr(options, aa):
@@ -75,8 +82,6 @@ class Publisher(dict):
                 u =  sarracenia.baseUrlParse(self['baseUrl'])
                 self['baseDir'] = u.path
 
-        if not hasattr(options, 'post_topicPrefix') and hasattr(options, 'topicPrefix'):
-            self['topicPrefix'] = options.topicPrefix
 
         for a in [ 'auto_delete', 'durable', 'exchangeDeclare', 'messageAgeMax', 
                   'messageDebugDump', 'persistent', 'timeout' ]:
@@ -84,6 +89,33 @@ class Publisher(dict):
                 self[a] = getattr(options,a)
         #logger.debug( f" {self} " )
 
+    def __eq__(self,other):
+
+        if 'broker' in self and 'broker' in other :
+            if ( str(self['broker']) != str(other['broker']) ):
+                return False
+        elif ('broker' in self) or ('broker' in other):
+            return False
+         
+        if 'exchange' in self and 'exchange' in other:
+            if ( self['exchange'] != other['exchange'] ):
+                return False
+        elif ('exchange' in self) or ('exchange' in other):
+                return False
+
+        if 'topicPrefix' in self and 'topicPrefix' in other:
+            if ( self['topicPrefix'] != other['topicPrefix'] ):
+                return False
+        elif ('topicPrefix' in self) or ('topicPrefix' in other):
+            return False
+
+        if 'format' in self and 'format' in other:
+            if ( self['format'] != other['format'] ):
+                return False
+        elif ('format' in self) or ('format' in other):
+            return False
+
+        return True
 
 class Publishers(list):
     # list of publishers
@@ -95,11 +127,7 @@ class Publishers(list):
             return
 
         for s in self:
-            if s == {} or not 'broker' in s or not 'exchange' in s:
-                continue
-
-            if ( str(s['broker']) == str(new_publisher['broker']) ) and \
-               ( s['exchange'] == new_publisher['exchange'] ):
+            if ( s == new_publisher ):
                 found=True
 
         if not found:

--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -21,11 +21,18 @@ class Subscription(dict):
             else:
                 exchange = 'xs_%s' % options.broker.url.username
 
-            if hasattr(options, 'exchangeSuffix'):
-                exchange += '_%s' % options.exchangeSuffix
+            if options.component in [ 'poll', 'post', 'watch' ]:
+                if hasattr(options,'post_exchangeSuffix') and options.post_exchangeSuffix:
+                    exchange += '_%s' % options.post_exchangeSuffix
 
-            if hasattr(options, 'exchangeSplit') and hasattr( options, 'no') and (options.no > 0):
-                exchange += "%02d" % options.no
+                if hasattr(options, 'post_exchangeSplit') and hasattr( options, 'no') and (options.no > 0):
+                    exchange += "%02d" % (options.no % options.post_exchangeSplit)
+            else:
+                if hasattr(options, 'exchangeSuffix'):
+                    exchange += '_%s' % options.exchangeSuffix
+
+                if hasattr(options, 'exchangeSplit') and hasattr( options, 'no') and (options.no > 0):
+                    exchange += "%02d" % (options.no % options.exchangeSplit)
 
         self['broker'] = options.broker
         self['bindings'] = [ { 'exchange': exchange, 'prefix': options.topicPrefix, 'sub': subtopic } ]

--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -12,8 +12,23 @@ class Subscription(dict):
 
     def __init__(self, options, queueName_template, queueName, subtopic):
 
+        exchange=None
+        if hasattr(options,'exchange') and options.exchange:
+            exchange=options.exchange
+        else:
+            if not hasattr(options.broker.url,'username') or ( options.broker.url.username == 'anonymous' ):
+                exchange = 'xpublic'
+            else:
+                exchange = 'xs_%s' % options.broker.url.username
+
+            if hasattr(options, 'exchangeSuffix'):
+                exchange += '_%s' % options.exchangeSuffix
+
+            if hasattr(options, 'exchangeSplit') and hasattr( options, 'no') and (options.no > 0):
+                exchange += "%02d" % options.no
+
         self['broker'] = options.broker
-        self['bindings'] = [ { 'exchange': options.exchange, 'prefix': options.topicPrefix, 'sub': subtopic } ]
+        self['bindings'] = [ { 'exchange': exchange, 'prefix': options.topicPrefix, 'sub': subtopic } ]
 
         self['queue']={ 'name': queueName, 'template': queueName_template, 'cleanup_needed': None }
         for a in [ 'queueBind', 'queueDeclare' ]:

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -408,17 +408,17 @@ def test_multi():
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "subtopic *.WXO-DD.bulletins.alphanumeric.#" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "directory /tmp/dual_amis/" )
 
-     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tsource@localhost/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tsource@localhost" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseUrl http://localhost/" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseDir /tmp/dual_amis/" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_topicPrefix v02.post" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_format v02" )
-     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tsource@localhost/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tsource@localhost" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseUrl http://localhost/" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseDir /tmp/dual_amis/" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "topicPrefix v03" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_format v03" )
-     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tfeed@fractal/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tfeed@fractal" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseUrl file:" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseDir /" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_format v02" )
@@ -445,7 +445,7 @@ def test_multi():
                  'auto_delete': False,
                  'baseDir': '/tmp/dual_amis/',
                  'baseUrl': 'http://localhost/',
-                 'broker': 'amqp://tsource@localhost/',
+                 'broker': 'amqp://tsource@localhost',
                  'durable': True,
                  'exchange': ['xs_tsource'],
                  'exchangeDeclare': True,

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -403,3 +403,51 @@ def test_broker_finalize():
      assert( hasattr(options,'retry_path') )
      assert( hasattr(options,'novipFilename') )
      assert( hasattr(options,'publishers') )
+
+
+def test_multi():
+
+     options = copy.deepcopy(sarracenia.config.default_config())
+     options.component = 'subscribe'
+     options.config = 'multi1'
+     options.action = 'start'
+
+     options.credentials.add( 'amqp://tsource:passthepoi@localhost' )
+     options.credentials.add( 'amqp://tfeed:passthepoi@localhost' )
+
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "broker amqps://dd.weather.gc.ca/")
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "topicPrefix v02.post" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "subtopic *.WXO-DD.bulletins.alphanumeric.#" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "broker amqps://hpfx.collab.science.gc.ca/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "subtopic *.WXO-DD.bulletins.alphanumeric.#" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "directory /tmp/dual_amis/" )
+
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tsource@localhost/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseUrl http://localhost/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseDir /tmp/dual_amis/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_topicPrefix v02.post" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_format v02" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tsource@localhost/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseUrl http://localhost/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseDir /tmp/dual_amis/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "topicPrefix v03" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_format v03" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_broker amqp://tfeed@fractal/" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseUrl file:" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_baseDir /" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_format v02" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_exchangeSuffix hoho" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "post_exchangeSplit 6" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "" )
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "" )
+
+     options.finalize()
+
+     options.dump()
+
+     assert( len(options.subscriptions) == 2 )
+
+     assert( len(options.publishers) == 3 )
+
+
+

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -439,7 +439,8 @@ def test_multi():
      assert( options.publishers[1]['exchange'] == [ 'xs_tsource' ] )
      assert( options.publishers[2]['exchange'] == [ 'xs_tsource_hoho00', 'xs_tsource_hoho01', 'xs_tsource_hoho02','xs_tsource_hoho03','xs_tsource_hoho04','xs_tsource_hoho05' ] )
 
-     #assert( 1 == 0 )
+     options.publishers[0]['broker'] = str(options.publishers[0]['broker'])
+
      assert( options.publishers[0] == { \
                  'auto_delete': False,
                  'baseDir': '/tmp/dual_amis/',
@@ -450,7 +451,7 @@ def test_multi():
                  'exchangeDeclare': True,
                  'format': 'v02',
                  'messageAgeMax': 0,
-                 'messageDebugDump': True,
+                 'messageDebugDump': False,
                  'persistent': True,
                  'timeout': 300,
                  'topicPrefix': ['v02', 'post']} )

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -439,6 +439,7 @@ def test_multi():
      assert( options.publishers[1]['exchange'] == [ 'xs_tsource' ] )
      assert( options.publishers[2]['exchange'] == [ 'xs_tsource_hoho00', 'xs_tsource_hoho01', 'xs_tsource_hoho02','xs_tsource_hoho03','xs_tsource_hoho04','xs_tsource_hoho05' ] )
 
+     #assert( 1 == 0 )
      assert( options.publishers[0] == { \
                  'auto_delete': False,
                  'baseDir': '/tmp/dual_amis/',
@@ -454,4 +455,46 @@ def test_multi():
                  'timeout': 300,
                  'topicPrefix': ['v02', 'post']} )
 
+     assert( options.subscriptions[0]['bindings']  == [{'exchange': 'xpublic', \
+                                  'prefix': ['v02', 'post'],
+                                  'sub': ['*.WXO-DD.bulletins.alphanumeric.#']}] )
 
+     assert( options.subscriptions[0]['queue']  == {'auto_delete': False, \
+                              'bind': True,
+                              'cleanup_needed': None,
+                              'declare': True,
+                              'durable': True,
+                              'expire': 25200.0,
+                              'name': 'q_anonymous.subscribe.multi1',
+                              'prefetch': 25,
+                              'template': 'q_${BROKER_USER}.${COMPONENT}.${CONFIG}',
+                              'tlsRigour': 'normal'} )
+
+     assert( options.subscriptions[0]['bindings']  == [{'exchange': 'xpublic',
+                                  'prefix': ['v02', 'post'],
+                                  'sub': ['*.WXO-DD.bulletins.alphanumeric.#']}] )
+
+
+     """
+
+                    {'baseDir': None, 
+                    'bindings': [{'exchange': 'xpublic',
+                                  'prefix': ['v02', 'post'],
+                                  'sub': ['*.WXO-DD.bulletins.alphanumeric.#']}],
+                    'broker': 'amqps://anonymous@dd.weather.gc.ca/',
+                   {'baseDir': None,
+                    'bindings': [{'exchange': 'xpublic',
+                                  'prefix': ['v02', 'post'],
+                                  'sub': ['*.WXO-DD.bulletins.alphanumeric.#']}],
+                    'broker': 'amqps://anonymous@hpfx.collab.science.gc.ca/',
+                    'queue': {'auto_delete': False,
+                              'bind': True,
+                              'cleanup_needed': None,
+                              'declare': True,
+                              'durable': True,
+                              'expire': 25200.0,
+                              'name': 'q_anonymous.subscribe.multi1',
+                              'prefetch': 25,
+                              'template': 'q_${BROKER_USER}.${COMPONENT}.${CONFIG}',
+                              'tlsRigour': 'normal'}}] )
+     """

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -297,22 +297,6 @@ def test_read_line_add_option():
      logger.info( f" {options.flag_one=} " )
      assert( options.flag_one == True  )
 
-def test_source_from_exchange():
-
-     options = copy.deepcopy(sarracenia.config.default_config())
-
-     # crasher input:
-     options.parse_line( "subscribe", "ex1", "subscribe/ex1", 1, "declare source tsource" )
-     assert( 'tsource' in options.declared_users )
-     assert( options.declared_users['tsource'] == 'source' )
-
-     options.parse_line( "subscribe", "ex1", "subscribe/ex1", 1, "exchange xs_tsource_favourite" )
-     
-     assert( options.exchange == 'xs_tsource_favourite' )
-
-     source = options.get_source_from_exchange(options.exchange)
-     assert( source == 'tsource' )
-
 def test_subscription():
 
      o = copy.deepcopy(sarracenia.config.default_config())
@@ -395,7 +379,8 @@ def test_broker_finalize():
      assert( options.queueName.startswith('q_${BROKER_USER}.${COMPONENT}')  )
      assert( options.directory == os.path.expanduser( '~/ex1' ) )
      assert( len(options.subscriptions) == 1 )
-     assert( options.exchange == 'xs_bunnypeer' )
+     assert( len(options.subscriptions[0]['bindings']) == 1 )
+     assert( options.subscriptions[0]['bindings'][0]['exchange'] == 'xs_bunnypeer' )
      assert( options.post_exchange == 'xs_bunnypeer' )
      assert( hasattr(options,'nodupe_ttl') )
      assert( hasattr(options,'metricsFilename') )
@@ -448,6 +433,10 @@ def test_multi():
      assert( len(options.subscriptions) == 2 )
 
      assert( len(options.publishers) == 3 )
+
+     assert( options.publishers[0]['exchange'] == [ 'xs_tsource' ] )
+     assert( options.publishers[1]['exchange'] == [ 'xs_tsource' ] )
+     assert( options.publishers[2]['exchange'] == [ 'xs_tsource_hoho00', 'xs_tsource_hoho01', 'xs_tsource_hoho02','xs_tsource_hoho03','xs_tsource_hoho04','xs_tsource_hoho05' ] )
 
 
 

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -401,6 +401,7 @@ def test_multi():
      options.credentials.add( 'amqp://tfeed:passthepoi@localhost' )
 
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "broker amqps://dd.weather.gc.ca/")
+     options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "queueName q_${BROKER_USER}.${COMPONENT}.${CONFIG}")
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "topicPrefix v02.post" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "subtopic *.WXO-DD.bulletins.alphanumeric.#" )
      options.parse_line(  "subscribe", "multi1", "subscribe/multi1", 1, "broker amqps://hpfx.collab.science.gc.ca/" )
@@ -438,5 +439,19 @@ def test_multi():
      assert( options.publishers[1]['exchange'] == [ 'xs_tsource' ] )
      assert( options.publishers[2]['exchange'] == [ 'xs_tsource_hoho00', 'xs_tsource_hoho01', 'xs_tsource_hoho02','xs_tsource_hoho03','xs_tsource_hoho04','xs_tsource_hoho05' ] )
 
+     assert( options.publishers[0] == { \
+                 'auto_delete': False,
+                 'baseDir': '/tmp/dual_amis/',
+                 'baseUrl': 'http://localhost/',
+                 'broker': 'amqp://tsource@localhost/',
+                 'durable': True,
+                 'exchange': ['xs_tsource'],
+                 'exchangeDeclare': True,
+                 'format': 'v02',
+                 'messageAgeMax': 0,
+                 'messageDebugDump': True,
+                 'persistent': True,
+                 'timeout': 300,
+                 'topicPrefix': ['v02', 'post']} )
 
 


### PR DESCRIPTION
close #1450 

* remove some dead code: config/get_source_from_exchange (isn't called anywhere.) 
* move exchange resolution into subscribtion.  There seem to be some cases where setting the global *exchange* config option pollutes other subscriptions (some configurations get exchanges resolved for different subscriptions mixed together.)
* make a publisher comparator __eq__ that compares more fields so that publishers no longer match when format, or topicPrefix don't.
* added some unit tests for multi subscriber/publisher cases.
