### PR TITLE
retry failed fileOps

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -858,7 +858,7 @@ class Flow:
             if self.o.post_baseDir:
                 new_dir = self.o.variableExpansion(self.o.post_baseDir, msg)
         d=None
-       
+
         if 'subcription_index' in msg:
             old_baseDir = self.o.subscriptions[msg['subscription_index']]['baseDir']
         else:
@@ -874,7 +874,13 @@ class Flow:
         # to get something to restore for downstream consumers, need to put the original
         # names back.
 
-        if 'fileOp' in msg:
+        # only do the fileOp path adjustments for
+        #   a) messages that are not retries when retry_refilter is disabled
+        #   b) all messages, when retry_refilter is enabled
+        retry_refilter = hasattr(self.o, 'retry_refilter') and self.o.retry_refilter
+        msg_is_not_retry = retry_refilter or ('_isRetry' not in msg or ('_isRetry' in msg and not msg['_isRetry']))
+
+        if 'fileOp' in msg and msg_is_not_retry:
             msg['post_fileOp'] = copy.deepcopy(msg['fileOp'])
             msg['_deleteOnPost'] |= set( [ 'post_fileOp' ] )
 
@@ -889,7 +895,7 @@ class Flow:
             if strip < len(token):
                 token = token[strip:]
 
-            if 'fileOp' in msg:
+            if 'fileOp' in msg and msg_is_not_retry:
                 """
                    files are written with cwd being the directory containing the file written.
                    when stripping the root of the tree off, the path must be rendered relative to the
@@ -897,7 +903,7 @@ class Flow:
                 """
                 for f in ['link', 'hlink', 'rename']:
                     if f in msg['fileOp']:
-                        fopv = msg['fileOp'][f].split('/') 
+                        fopv = msg['fileOp'][f].split('/')
                         # an absolute path file posted is relative to '/' (in relPath) but the values in
                         # the link and rename fields may be absolute, requiring and adjustment when stripping
                         if fopv[0] == '':
@@ -1644,9 +1650,7 @@ class Flow:
         ok = True
         # it turns out that links that exist but point to non-existent files return exists: False.
         if not os.path.islink(old) and not os.path.exists(old):
-            logger.info(
-                "old file %s not found, if destination (%s) missing, then fall back to copy"
-                % (old, path))
+            logger.info("old file %s not found, can't rename to %s" % (old, path))
             # if the destination file exists, assume rename already happenned,
             # otherwis return false so that caller falls back to downloading/sending the file.
             # return os.path.isfile(path) 
@@ -1759,13 +1763,158 @@ class Flow:
 
         return ok
 
+    def do_fileOp(self, msg, new_path) -> bool:
+        """ for a message with a fileOp, do whatever action is specified by the fileOp field.
+            This code used to be in do_download, but that method was really long so it was moved here.
+            Returns: bool - True when the message has been fully processed and there's nothing left to do.
+                            False when there's still processing left to do with the message (i.e. need to
+                                execute the rest of the do_download code.)
+        """
+
+        if 'fileOp' not in msg:
+            return False # fall through to download
+
+        ok = False
+        attempt = 1
+
+        # retry fileOps multiple times, mostly to handle race conditions
+        while not ok and attempt <= self.o.attempts:
+
+            if attempt > 1:
+                logger.warning(f"previous fileOp {msg['fileOp']} -> {new_path} attempt failed, trying again, attempt {attempt}/{self.o.attempts}")
+
+            ## RENAME
+            if 'rename' in msg['fileOp']:
+
+                if 'renameUnlink' in msg:
+                    # if remove fails, assume it's because the file to be renamed is already gone
+                    self.removeOneFile(msg['fileOp']['rename'])
+                    msg.setReport(201, 'old unlinked %s' % msg['fileOp']['rename'])
+                    self.worklist.ok.append(msg)
+                    self.metrics['flow']['transferRxFiles'] += 1
+                    self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                    return False # fall through to download
+
+                else:
+                    # actual rename...
+                    ok = self.renameOneItem(msg['fileOp']['rename'], new_path)
+
+                    # if rename succeeds, fall through to download object (return False) to find if the file renamed
+                    # actually matches the one advertised, and potentially download it.
+                    if ok:
+                        msg.setReport(201, 'renamed')
+                        self.worklist.ok.append(msg)
+                        self.metrics['flow']['transferRxFiles'] += 1
+                        self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                        # When it's a broken symlink, the upstream doesn't exist and we can't compare. The download
+                        # will always fail. So return True and *don't fall through* to download for symlinks.
+                        return ('link' in msg['fileOp'])
+
+                    # if rename of *file* fails, fall through to download
+                    elif 'link' not in msg['fileOp'] and 'hlink' not in msg['fileOp']:
+                        return False # fall through to download
+
+                    # else: rename of link fails, retry until it succeeds (or expires from retry)
+
+            ## REMOVE DIRECTORY
+            elif ('directory' in msg['fileOp']) and ('remove' in msg['fileOp'] ):
+                if  'rmdir' not in self.o.fileEvents:
+                    self.reject(msg, 202, "skipping rmdir %s" % new_path)
+                    return True # done fileOp processing, continue
+
+                if self.removeOneFile(new_path):
+                    msg.setReport(201, 'rmdired')
+                    self.worklist.ok.append(msg)
+                    self.metrics['flow']['transferRxFiles'] += 1
+                    self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                    return True # done fileOp processing, continue
+                # else: retry directory removal to handle race conditions where the files
+                #       inside the directory haven't been deleted *yet* (issue #1377)
+                #self.reject(msg, 500, "rmdir %s failed" % new_path)
+
+
+            ## REMOVE FILE
+            elif ('remove' in msg['fileOp']):
+                if 'delete' not in self.o.fileEvents:
+                    self.reject(msg, 202, "skipping delete %s" % new_path)
+                    return True # done fileOp processing, continue
+
+                if self.removeOneFile(new_path):
+                    msg.setReport(201, 'removed')
+                    self.worklist.ok.append(msg)
+                    self.metrics['flow']['transferRxFiles'] += 1
+                    self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                    return True # done fileOp processing, continue
+                else:
+                    #FIXME: should this really be queued for retry? or just permanently failed?
+                    # in rejected to avoid retry, but wondering if failed and deferred
+                    # should be separate lists in worklist...
+                    # RS (FIXME note above is Peter's): it's hard to know what to do with failed file deletions. There
+                    # is a potential race condition when a file is created then deleted shortly after. If the delete
+                    # is processed out of order (before file is created), then retrying the deletion would be good. 
+                    # But that could cause problems in other situations: if a file is created, deleted, then created
+                    # again. In this case,  it's better to ignore the remove failure (reject the msg) because the new
+                    # file will overwrite the old one that got left on disk.
+                    self.reject(msg, 500, "remove %s failed" % new_path)
+                    return True # don't continue to download, don't retry, see above comment.
+
+            # no elif because if rename fails and operation is an mkdir or a symlink..
+            # need to retry as ordinary creation, similar to normal file copy case.
+            ## MKDIR
+            if 'directory' in msg['fileOp'] and 'remove' not in msg['fileOp']:
+                if 'mkdir' not in self.o.fileEvents:
+                    self.reject(msg, 202, "skipping mkdir %s" % new_path)
+                    return True # done fileOp processing, continue
+
+                if self.mkdir(msg):
+                    msg.setReport(201, 'made directory')
+                    self.worklist.ok.append(msg)
+                    self.metrics['flow']['transferRxFiles'] += 1
+                    self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                    return True # done fileOp processing, continue
+                # retry when mkdir fails
+                # PREVIOUS BEHAVIOUR: ignore and move on
+                # self.reject(msg, 500, "mkdir %s failed" % msg['new_file'])
+
+            ## LINK
+            # ignore link renames here, we want them to retry if they fail
+            elif ('link' in msg['fileOp'] or 'hlink' in msg['fileOp']) and 'rename' not in msg['fileOp']:
+                if 'link' not in self.o.fileEvents:
+                    self.reject(msg, 202, "skipping link %s" % new_path)
+                    return True # done fileOp processing, continue
+
+                if self.link1file(msg):
+                    msg.setReport(201, 'linked')
+                    self.worklist.ok.append(msg)
+                    self.metrics['flow']['transferRxFiles'] += 1
+                    self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
+                    return True # done fileOp processing, continue
+                else:
+                    # as above...
+                    # hard link creation failure: continue to download, symlink failure: reject and ignore
+                    if 'hlink' not in msg['fileOp']:
+                        self.reject(msg, 500, "link %s failed" % msg['fileOp'])
+                        return True # done fileOp processing, continue RS TODO are you sure?
+                    logger.info( f"since hard link failed, fall back to copying from source" )
+                    return False # fall through to download code
+
+            attempt += 1
+
+        # once attempts is exceeded, queue for retry later by putting the msg into worklist.failed
+        if not ok and attempt > self.o.attempts:
+            logger.error(f"fileOp {msg['fileOp']} -> {new_path} failed after {attempt-1}/{self.o.attempts} attempts, queueing for retry later")
+            self.worklist.failed.append(msg)
+            return True # done fileOp processing in this batch, msg in worklist.failed and will be retried later
+        else:
+            logger.debug("fileOp succeeded on the last attempt")
+
+
     def do_download(self) -> None:
         """
            do download work for self.worklist.incoming, placing files:
                 successfully downloaded in worklist.ok
                 temporary failures in worklist.failed
                 permanent failures (or files not to be downloaded) in worklist.rejected
-
         """
 
         if not self.o.download:
@@ -1804,8 +1953,8 @@ class Flow:
 
                 try:
                     logger.debug( f"missing destination directories, makedirs: {msg['new_dir']} " )
-                    self.worklist.directories_ok.append(msg['new_dir'])
                     os.makedirs(msg['new_dir'], self.o.permDirDefault, True)
+                    self.worklist.directories_ok.append(msg['new_dir'])
                 except Exception as ex:
                     logger.warning("making %s: %s" % (msg['new_dir'], ex))
                     logger.debug('Exception details:', exc_info=True)
@@ -1819,101 +1968,14 @@ class Flow:
             except Exception as e:
                 logger.error(f"failed to chdir ({e}), possible race condition, deferring transfer of {new_path}")
                 logger.debug("Exception details:", exc_info=True)
+                #RS TODO RETRY HERE?
                 self.worklist.failed.append(msg)
                 continue
 
             if 'fileOp' in msg :
-                if 'rename' in msg['fileOp']:
-
-                    if 'renameUnlink' in msg:
-                        self.removeOneFile(msg['fileOp']['rename'])
-                        msg.setReport(201, 'old unlinked %s' % msg['fileOp']['rename'])
-                        self.worklist.ok.append(msg)
-                        self.metrics['flow']['transferRxFiles'] += 1
-                        self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
-
-                    else:
-                        # actual rename...
-                        ok = self.renameOneItem(msg['fileOp']['rename'], new_path)
-                        # if rename succeeds, fall through to download object to find if the file renamed
-                        # actually matches the one advertised, and potentially download it.
-                        # if rename fails, recover by falling through to download the data anyways.
-                        if ok:
-                            self.worklist.ok.append(msg)
-                            self.metrics['flow']['transferRxFiles'] += 1
-                            msg.setReport(201, 'renamed')
-                            self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
-                            continue
-
-                elif ('directory' in msg['fileOp']) and ('remove' in msg['fileOp'] ): 
-                    if  'rmdir' not in self.o.fileEvents:
-                        self.reject(msg, 202, "skipping rmdir %s" % new_path)
-                        continue
-
-                    if self.removeOneFile(new_path):
-                        msg.setReport(201, 'rmdired')
-                        self.worklist.ok.append(msg)
-                        self.metrics['flow']['transferRxFiles'] += 1
-                        self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
-                    else:
-                        #FIXME: should this really be queued for retry? or just permanently failed?
-                        # in rejected to avoid retry, but wondering if failed and deferred
-                        # should be separate lists in worklist...
-                        self.reject(msg, 500, "rmdir %s failed" % new_path)
+                if self.do_fileOp(msg, new_path):
                     continue
-
-                elif ('remove' in msg['fileOp']):
-                    if 'delete' not in self.o.fileEvents:
-                        self.reject(msg, 202, "skipping delete %s" % new_path)
-                        continue
-
-                    if self.removeOneFile(new_path):
-                        msg.setReport(201, 'removed')
-                        self.worklist.ok.append(msg)
-                        self.metrics['flow']['transferRxFiles'] += 1
-                        self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
-                    else:
-                        #FIXME: should this really be queued for retry? or just permanently failed?
-                        # in rejected to avoid retry, but wondering if failed and deferred
-                        # should be separate lists in worklist...
-                        self.reject(msg, 500, "remove %s failed" % new_path)
-                    continue
-
-                # no elif because if rename fails and operation is an mkdir or a symlink..
-                # need to retry as ordinary creation, similar to normal file copy case.
-                if 'directory' in msg['fileOp']:
-                    if 'mkdir' not in self.o.fileEvents:
-                        self.reject(msg, 202, "skipping mkdir %s" % new_path)
-                        continue
-
-                    if self.mkdir(msg):
-                        msg.setReport(201, 'made directory')
-                        self.worklist.ok.append(msg)
-                        self.metrics['flow']['transferRxFiles'] += 1
-                        self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
-                    else:
-                        # as above...
-                        self.reject(msg, 500, "mkdir %s failed" % msg['new_file'])
-                    continue
-
-                elif 'link' in msg['fileOp'] or 'hlink' in msg['fileOp']:
-                    if 'link' not in self.o.fileEvents:
-                        self.reject(msg, 202, "skipping link %s" % new_path)
-                        continue
-
-                    if self.link1file(msg):
-                        msg.setReport(201, 'linked')
-                        self.worklist.ok.append(msg)
-                        self.metrics['flow']['transferRxFiles'] += 1
-                        self.metrics['flow']['transferRxLast'] = msg['report']['timeCompleted']
-                        continue
-                    else:
-                        # as above...
-                        if 'hlink' not in msg['fileOp']:
-                            self.reject(msg, 500, "link %s failed" % msg['fileOp'])
-                            continue
-
-                        logger.info( f"since hard link failed, fall back to copying from source" )
+                # else fall through to download
 
             # all non-files taken care of above... rest of routine is normal file download.
 

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -55,8 +55,8 @@ class Retry(FlowCB):
 
         self.o.add_option( 'retry_driver', 'str', 'disk')
 
-        # retry_refilter False -- rety to send with existing processing.
-        # retry_refilter True -- re-ingest and re-apply processing (if it has changed.)
+        # retry_refilter False -- retry to send with existing processing.
+        # retry_refilter True  -- re-ingest and re-apply processing (if it has changed.)
         self.o.add_option( 'retry_refilter', 'flag', False)
 
         #queuedriver = os.getenv('SR3_QUEUEDRIVER', 'disk')


### PR DESCRIPTION
Fix #1366 and fix #1377 by retrying fileOps that fail. 

The changed behaviour is described in the comments.

The main changes are:

- When a directory removal fails, it retries (previously we'd ignore the error and reject the message).
   - This fixes the problem where a directory removal fails because it's not empty yet, because other instances have not yet deleted the files/subdirectories inside it.
- When link renames fail, also retry them, assuming the link has not been created yet. Previously we'd ignore the error and fall through to "downloading" the link from the source. This could leave behind temporary links as described in #1366.

Flakey broker fails with 36/37, but I think that's because of other changes?

I'll also have a PR coming for sarrac that adds tests to simulate these cases.