### PR TITLE
fix #1453 - crash in sender when local file not found

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2432,7 +2432,10 @@ class Flow:
         # older versions don't include the contentType, so patch it here.
         if features['filetypes']['present'] and \
            ('contentType' not in msg) and (not 'fileOp' in msg):
-            msg['contentType'] = magic.from_file(local_path,mime=True)
+            try:
+                msg['contentType'] = magic.from_file(local_path,mime=True)
+            except Exception as e:
+                logger.error(f"could not set contentType because {e}")
 
         local_dir = os.path.dirname(local_path).replace('\\', '/')
         local_file = os.path.basename(local_path).replace('\\', '/')
@@ -2639,9 +2642,8 @@ class Flow:
 
             # the file does not exist... warn, sleep and return false for the next attempt
             if not os.path.exists(local_file):
-                logger.warning(
-                    "product collision or base_dir not set, file %s does not exist"
-                    % local_file)
+                logger.error(
+                    f"file {local_file} does not exist in local dir {local_dir}, can't send (baseDir not set?)")
                 time.sleep(0.01)
                 return 0
             elif 'size' not in msg:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2435,7 +2435,7 @@ class Flow:
             try:
                 msg['contentType'] = magic.from_file(local_path,mime=True)
             except Exception as e:
-                logger.error(f"could not set contentType because {e}")
+                logger.warning(f"could not set contentType from local file {local_path} because {e}")
 
         local_dir = os.path.dirname(local_path).replace('\\', '/')
         local_file = os.path.basename(local_path).replace('\\', '/')


### PR DESCRIPTION
I also changed the message when the local file is not found (this check happens after trying to set contentType). I think error makes more sense than warning there, because all other send failures are logged as errors. It now logs the path to help the user debug config problems.

I based issue_1453 off the stable branch in case we need to do another 3.00.xx release, but it looks like there's no merge conflicts to merge it into development