### PR TITLE
co-ordinate start/stop with sanity, add *new* and *inter*

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -627,7 +627,9 @@ will be:
 * reje:  all processes running, but too high percent of messages being rejected (runStateThreshold_reject )
 * rtry:  all processes running, but too large number of transfers failed and retrying (runStateThreshold_retry )
 * run:   all processes are running (and transferring, and not behind, and not slow... normal state.)
+* shut:  in the process of shutting down (stop or restart in progress.)
 * slow:  transfering less than minimum bytes/second ( runStateThreshold_slow )
+* star:  in the process of starting up (start or restart in progress.)
 * stop:  no processes are running. 
 * stby:  Standby mode: all processes running, but messages are being stored in the local download_retry queue.
 * wVip:  process doesn't have the vip (only applies when the vip option is specified in the config)

--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -622,10 +622,12 @@ will be:
 * down:  cannot connect or exchange data with remote data source or sink.
 * hung:  processes appear hung, not writing anything to logs.
 * idle:  all processes running, but no data or message transfers for too long (runStateThreshold_idle)
+* inte:  Interactive configuration, calls from CLI or scripts (not a daemon.)
 * lag:   all processes running, but messages being processed are too old ( runStateThreshold_lag )
 * part:  some processes are running, others are missing.
 * reje:  all processes running, but too high percent of messages being rejected (runStateThreshold_reject )
 * rtry:  all processes running, but too large number of transfers failed and retrying (runStateThreshold_retry )
+* new:   no state files exist for this configuration (fresh after *add* or *cleanup* )
 * run:   all processes are running (and transferring, and not behind, and not slow... normal state.)
 * shut:  in the process of shutting down (stop or restart in progress.)
 * slow:  transfering less than minimum bytes/second ( runStateThreshold_slow )

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -621,10 +621,12 @@ sera :
 * down : impossible de se connecter ou d'échanger des données avec une source ou un récepteur de données distant.
 * hung : les processus semblent bloqués et n'écrivent rien dans les journaux.
 * idle : tous les processus en cours d'exécution, mais ne transfert pas depuis trop longtemps (runStateThreshold_idle.)
+* inte : configuration à usage intéractif, n'éxecute pas comme un daëmon (processus de service en arrière plan.)
 * lag : tous les processus en cours d'exécution, mais les messages en cours de traitement sont trop anciens ( runStateThreshold_lag )
 * part: certains processus sont en cours d'exécution, d'autres manquent à l'appel.
 * reje : tous les processus en cours d'exécution, mais un pourcentage trop élevé de messages rejetés (runStateThreshold_reject )
 * rtry : tous les processus en cours d'exécution, mais un grand nombre de transferts échouent, causant d'autres tentatives (runStateThreshold_retry )
+* new : une configuration neuve (nouvellement installéé/créé, ou après un opeations *clean* )
 * run : tous les processus sont en cours d'exécution (et en transfert, et pas en retard, et pas lents... état normal.)
 * shut : en cours d'arrêt (stop ou restart en cours.)
 * slow : transfert de moins que le minimum d'octets/seconde ( runStateThreshold_slow )

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -626,7 +626,9 @@ sera :
 * reje : tous les processus en cours d'exécution, mais un pourcentage trop élevé de messages rejetés (runStateThreshold_reject )
 * rtry : tous les processus en cours d'exécution, mais un grand nombre de transferts échouent, causant d'autres tentatives (runStateThreshold_retry )
 * run : tous les processus sont en cours d'exécution (et en transfert, et pas en retard, et pas lents... état normal.)
+* shut : en cours d'arrêt (stop ou restart en cours.)
 * slow : transfert de moins que le minimum d'octets/seconde ( runStateThreshold_slow )
+* star : en cours de démarrage (start ou restart en cours.)
 * stby : Mode veille (Standby): tous les processus sont en cours d'exécution, mais les messages sont stockés dans la file d'attente download_retry locale.
 * stop : aucun processus n'est en cours d'exécution.
 Les colonnes à droite donnent plus d’informations, détaillant le nombre de processus en cours d’exécution à partir du nombre attendu.

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -55,7 +55,8 @@ class Poll(Flow):
 
         super().__init__(options)
 
-        if hasattr(self.o,'publishers') and hasattr(self.o,'subscriptions'):
+        if hasattr(self.o,'publishers') and hasattr(self.o,'subscriptions') and \
+            len(self.o.subscriptions) > 0 and len(self.o.publishers) > 0:
             px = self.o.publishers[0]['exchange'][0]
             sx = self.o.subscriptions[0]['bindings'][0]['exchange'] 
             if px != sx:

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -55,12 +55,13 @@ class Poll(Flow):
 
         super().__init__(options)
 
-        if hasattr(self.o,'post_exchange') and hasattr(self.o,'exchange'):
-            px = self.o.post_exchange if type(self.o.post_exchange) != list else self.o.post_exchange[0]
-            if px != self.o.exchange:
-                logger.warning( f"post_exchange: {px} is different from exchange: {self.o.exchange}. The settings need for multiple instances to share a poll." )
+        if hasattr(self.o,'publishers') and hasattr(self.o,'subscriptions'):
+            px = self.o.publishers[0]['exchange'][0]
+            sx = self.o.subscriptions[0]['bindings'][0]['exchange'] 
+            if px != sx:
+                logger.warning( f"post_exchange: {px} is different from exchange: {sx}. The settings need for multiple instances to share a poll." )
             else:
-                logger.info( f"Good! post_exchange: {px} and exchange: {self.o.exchange} match so multiple instances to share a poll." )
+                logger.debug( f"Good! post_exchange: {px} and exchange: {sx} match so multiple instances to share a poll." )
 
         if not 'scheduled' in ','.join(self.plugins['load']):
             self.plugins['load'].append('sarracenia.flowcb.scheduled.poll.Poll')

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -29,7 +29,7 @@ class Log(FlowCB):
         self.o.add_option('logEvents', 'set',
                           ['after_accept', 'on_housekeeping'])
         self.o.add_option('logMessageDump', 'flag', False)
-        logger.debug(f'{self.o.component} initialized with: logEvents: {self.o.logEvents},  logMessageDump: {self.o.logMessageDump}')
+        logger.debug(f'{self.o.component}/{self.o.config} initialized with: logEvents: {self.o.logEvents},  logMessageDump: {self.o.logMessageDump}')
         if self.o.component in ['sender']:
             self.action_verb = 'sent'
         elif self.o.component in ['subscribe', 'sarra' ]:

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -35,7 +35,7 @@ class Message(FlowCB):
             self.posters.append(sarracenia.moth.Moth.pubFactory(props))
             i+=1
         else:
-            logger.critical( f"Missing publishers.")
+            logger.error( f"no publishers for {self.o.component}/{self.o.config}")
 
 
     def post(self, worklist):

--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -34,8 +34,8 @@ class Message(FlowCB):
             # adjust settings post_xxx to be xxx, as Moth does not use post_ ones.
             self.posters.append(sarracenia.moth.Moth.pubFactory(props))
             i+=1
-        else:
-            logger.error( f"no publishers for {self.o.component}/{self.o.config}")
+        #else:
+        #    logger.error( f"no publishers for {self.o.component}/{self.o.config}")
 
 
     def post(self, worklist):

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -133,6 +133,8 @@ class instance:
             hostdir = None
 
         pidfilename = sarracenia.config.get_pid_filename( hostdir, component, config, cfg_preparse.no)
+        # leave some time between checks during instance startup.
+        instance_gap=0.10
 
         if not hasattr(cfg_preparse,
                        'no') and not (cfg_preparse.action == 'foreground'):
@@ -142,13 +144,13 @@ class instance:
             # worker instances need give lead instance time to write subscriptions/queueNames/bindings
             # FIXME: might be better to loop here until lead instance .pid file exists?
             leadpidfilename = sarracenia.config.get_pid_filename( hostdir, component, config, 1)
-            time.sleep(cfg_preparse.no)
+            time.sleep(1+cfg_preparse.no*instance_gap)
             while not os.path.isdir(os.path.dirname(leadpidfilename)):
                 logger.debug("waiting for lead instance to create state directory")
-                time.sleep(cfg_preparse.no)
+                time.sleep(cfg_preparse.no*instance_gap)
             while not os.path.isfile(leadpidfilename):
                 logger.debug("waiting for lead instance to create pid file: {leadpidfilename}")
-                time.sleep(cfg_preparse.no)
+                time.sleep(cfg_preparse.no*instance_gap)
 
 
         if (len(cfg_preparse.configurations) > 1 ) and \

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -144,7 +144,7 @@ class instance:
             # worker instances need give lead instance time to write subscriptions/queueNames/bindings
             # FIXME: might be better to loop here until lead instance .pid file exists?
             leadpidfilename = sarracenia.config.get_pid_filename( hostdir, component, config, 1)
-            time.sleep(1+cfg_preparse.no*instance_gap)
+            time.sleep(0.1+cfg_preparse.no*instance_gap)
             while not os.path.isdir(os.path.dirname(leadpidfilename)):
                 logger.debug("waiting for lead instance to create state directory")
                 time.sleep(cfg_preparse.no*instance_gap)

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2590,11 +2590,19 @@ class sr_GlobalState:
                 if not (c in self.states and cfg in self.states[c]):
                     continue
 
-                #find missing instances for this config.
-                missing_instances = sum(map(lambda x: c in x and cfg in x, self.missing))
+                #find running and missing instances for this config.
+                instance_pids=self.states[c][cfg]['instance_pids'].values()
+                missing_instances=[]
+                running_instances=[]
+                for p in instance_pids:
+                    if p in self.procs.keys():
+                        running_instances.append(p)
+                    else:
+                        missing_instances.append(p)
+
                 if self.configs[c][cfg]['status'] != 'stopped':
                     expected = self.configs[c][cfg]['instances']
-                    running = expected - missing_instances
+                    running = len(running_instances)
                     if running > 0:
                         configs_running += 1
                 else:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -590,12 +590,14 @@ class sr_GlobalState:
                         if os.path.exists("disabled"): # double check, if disabled should ignore state.
                             continue
 
+                        i_found=[]
                         for filename in os.listdir():
                             # look at pid files, find ones where process is missing.
                             if filename[-4:] == '.pid':
                                 i = self._instance_num_from_pidfile(filename, c, cfg)
                                 if i < 0:
                                     continue
+                                i_found.append(i)
                                 if i != 0:
                                     p = pathlib.Path(filename)
                                     if sys.version_info[0] > 3 or sys.version_info[
@@ -610,6 +612,12 @@ class sr_GlobalState:
                                             missing.append([c, cfg, i])
                                     else:
                                         missing.append([c, cfg, i])
+
+                        # find instances missing that don't have pid files.
+                        for i in range(1,self.configs[c][cfg]['instances']+1):
+                            if i not in i_found:
+                               missing.append([c, cfg, i])
+
                     os.chdir(c_dir) # back to component dir containing configs
                 os.chdir(dir) # back to dir containing components
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2407,7 +2407,13 @@ class sr_GlobalState:
                 running_pids += len(self.states[c][cfg]['instance_pids'])
 
             if (running_pids == 0) and len(self.strays)==0:
-                self._tag_progress( c, cfg, "shutdown", ending=True )
+                for f in self.filtered_configurations:
+                    (c, cfg) = f.split(os.sep)
+                    # exclude foreground instances unless --dangerWillRobinson specified
+                    if (not self.options.dangerWillRobinson) and self._cfg_running_foreground(c, cfg):
+                        fg_instances.add(f"{c}/{cfg}")
+                        continue
+                    self._tag_progress( c, cfg, "shutdown", ending=True )
                 print('All stopped after try %d' % attempts)
                 if len(fg_instances) > 0:
                     print(f"Foreground instances {fg_instances} are running and were not stopped.")

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -250,7 +250,7 @@ class sr_GlobalState:
             # on windows, it seems to fork .exe and then there is a -script.py which is the right pid
             # .e.g sr_subscribe.exe -> sr_subscribe-script.py ... If you kill the -script, the .exe goes away.
             return
-
+ 
         if p['name'].startswith('sr3_'):
             #print( f"starts with sr3_ cmdline={p['cmdline']}" )
             p['memory'] = p['memory_full_info']._asdict()
@@ -2320,7 +2320,14 @@ class sr_GlobalState:
 
             pid_count = self._pid_file_count(c,cfg)
             partial=False
+            if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): 
+                 continue
+
             while pid_count < self.configs[c][cfg]['options'].instances :
+
+                 if self.please_stop:
+                     return
+
                  partial=True
                  logger.debug( f"{pid_count}/{self.configs[c][cfg]['options'].instances} instances started." )
                  time.sleep(5)

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2346,6 +2346,7 @@ class sr_GlobalState:
                 continue
 
             self._tag_progress( c, cfg, "starting", ending=True )
+            self._tag_progress( c, cfg, "running", ending=False )
 
         print('( %d ) Done' % pcount)
 
@@ -2418,6 +2419,7 @@ class sr_GlobalState:
             if self.configs[c][cfg]['status'] in self.status_active:
 
                 if not self.options.dry_run:
+                    self._tag_progress( c, cfg, "running", ending=True )
                     self._tag_progress( c, cfg, "shutdown", ending=False )
 
                 for i in self.states[c][cfg]['instance_pids']:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2226,7 +2226,7 @@ class sr_GlobalState:
             if not self.options.dry_run:
                 self._start_missing()
         else:
-            print('no missing processes found')
+            logger.info('no missing processes found')
 
  
         if len(self.strays) > 0:
@@ -2236,7 +2236,7 @@ class sr_GlobalState:
                 if not self.options.dry_run:
                     signal_pid(pid, signal.SIGTERM)
         else:
-            print('no stray processes found')
+            logger.info('no stray processes found')
 
         #It is enough to have it *features* not needed in sanity.
         #for l in sarracenia.features.keys():
@@ -3420,6 +3420,7 @@ def main():
     elif action == 'sanity':
         print('sanity: ', end='', flush=True)
         gs.sanity()
+        print('')
 
     if action == 'show':
         gs.config_show()

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -455,6 +455,9 @@ class sr_GlobalState:
             return
         os.chdir(dir1)
 
+        # some operating is pending, unwise to make changes.
+        self.flux={}
+
         for c in self.components:
             if c not in self.configs:
                 continue
@@ -481,6 +484,13 @@ class sr_GlobalState:
                             s = Subscriptions()
                             self.states[c][cfg]['subscriptions'] = s.read( \
                                 self.configs[c][cfg]['options'], 'subscriptions.json')
+
+                        if os.path.exists('starting'):
+                            self.states[c][cfg]['status'] = 'starting'
+                            self.flux[ f"{c}/{cfg}" ] = 'starting'
+                        elif os.path.exists('shutdown'):
+                            self.states[c][cfg]['status'] = 'shutdown'
+                            self.flux[ f"{c}/{cfg}" ] = 'shutdown'
 
                         for pathname in os.listdir():
                             p = pathlib.Path(pathname)
@@ -853,6 +863,10 @@ class sr_GlobalState:
                     continue
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'disabled'):
                     self.configs[c][cfg]['status'] = 'disabled'
+                if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'starting'):
+                    self.configs[c][cfg]['status'] = 'starting'
+                if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'shutdown'):
+                    self.configs[c][cfg]['status'] = 'shutdown'
                 if 'instance_metrics' in self.states[c][cfg]:
                     if 'housekeeping' in self.configs[c][cfg]:
                         expiry = now - self.configs[c][cfg]['housekeeping']*1.5
@@ -1020,7 +1034,11 @@ class sr_GlobalState:
                                 hung_instances += 1
                                 self.states[c][cfg]['hung_instances'].append(i)
 
-                    flow_status = 'unknown' if self.configs[c][cfg]['status'] != 'disabled' else 'disabled'
+                    if self.configs[c][cfg]['status'] in [ 'disabled', 'starting', 'shutdown' ]:
+                        flow_status = self.configs[c][cfg]['status']
+                    else:
+                        flow_status = 'unknown'
+ 
                     if hasattr(self.configs[c][cfg]['options'],'download') and self.configs[c][cfg]['options'].download and \
                          (self.states[c][cfg]['metrics']['retry']+self.states[c][cfg]['metrics']['messagesQueued'] > 0 ) :
                         if not self.states[c][cfg]['metrics']['transferConnected']:
@@ -1039,7 +1057,8 @@ class sr_GlobalState:
                             if self.configs[c][cfg]['status'] != 'disabled':
                                 flow_status = 'stopped'
                         else:
-                            if observed_instances > 0:
+                            if observed_instances > 0 and flow_status not in ['starting','shutdown']:
+                                logger.critical( f" {flow_status=} " )
                                 flow_status = 'partial'
                                 for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                     if not i in self.states[c][cfg]['instance_pids']:
@@ -1049,7 +1068,8 @@ class sr_GlobalState:
                                     if len(self.states[c][cfg]['instance_pids']) == 0 :
                                         flow_status = 'stopped' 
                                     else:
-                                        flow_status = 'missing' 
+                                        if flow_status not in [ 'starting', 'shutdown' ]:
+                                            flow_status = 'missing' 
                                         if not i in self.states[c][cfg]['instance_pids']:
                                              self.states[c][cfg]['missing_instances'].append(i)
                     elif observed_instances == 0:
@@ -1260,7 +1280,7 @@ class sr_GlobalState:
             'sender', 'shovel', 'subscribe', 'watch', 'winnow'
         ]
         # active means >= 1 process exists on the node.
-        self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'waitVip' ]
+        self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip' ]
         self.status_values = self.status_active + [ 'disabled', 'include', 'missing', 'stopped', 'unknown' ]
 
         self.bin_dir = os.path.dirname(os.path.realpath(__file__))
@@ -1290,6 +1310,7 @@ class sr_GlobalState:
         os.chdir(self.invoking_directory)
 
     def _start_missing(self):
+        max_instance=0
         for instance in self.missing:
             if self.please_stop:
                 break
@@ -1299,7 +1320,11 @@ class sr_GlobalState:
             component_path = self._find_component_path(c)
             if component_path == '':
                 continue
+            if max_instance < i:
+                max_instance=i 
             self._launch_instance(component_path, c, cfg, i)
+        time.sleep(0.2+max_instance*0.1)
+        
 
     def _stop_signal(self, signum, stack):
         logging.info('signal %d received' % signum)
@@ -1563,24 +1588,7 @@ class sr_GlobalState:
                 logging.error("cannot disable %s while it is running! " % f)
                 continue
 
-            if self.configs[c][cfg]['options'].statehost:
-                state_file_dir = self.user_cache_dir + os.sep + self.hostdir + os.sep + f.replace('/', os.sep)
-            else:
-                state_file_dir = self.user_cache_dir + os.sep + f.replace('/', os.sep)
-
-            if not os.path.isdir(state_file_dir):
-                os.makedirs(state_file_dir, exist_ok=True)
-
-            state_file_disabled = state_file_dir + os.sep + 'disabled'
-            
-            if os.path.exists(state_file_disabled):
-                logging.error("%s is already disabled! " % f)
-                continue
-
-            with open(state_file_disabled, 'w') as f:
-                f.write('')
-            logging.info(c + '/' + cfg)
-
+            self._tag_progress( c, cfg, "disabled", ending=False )
 
     def edit(self):
 
@@ -2133,6 +2141,13 @@ class sr_GlobalState:
             logging.error( f"{self.leftovers} configuration not found" )
             return
 
+        if self.flux:
+            if len(self.flux) > 10:
+                logging.warning( f"Not interfering with more than 10 operations in progress" )
+            else:
+                logging.warning( f"Not interfering with operations in progress: {self.flux}" )
+            return
+
         pcount = 0
         kill_hung=[]
         for f in self.filtered_configurations:
@@ -2177,6 +2192,7 @@ class sr_GlobalState:
         else:
             print('no missing processes found')
 
+ 
         if len(self.strays) > 0:
             print('killing strays...')
             for pid in self.strays:
@@ -2248,12 +2264,31 @@ class sr_GlobalState:
             if component_path == '':
                 continue
 
+            max_instances=0
             if self.configs[c][cfg]['status'] in [ 'missing', 'stopped']:
                 numi = self.configs[c][cfg]['instances']
+                if numi > max_instances:
+                    max_instances=numi
+                self._tag_progress( c, cfg, "starting", ending=False )
                 for i in range(1, numi + 1):
                     if pcount % 10 == 0: print('.', end='', flush=True)
                     pcount += 1
                     self._launch_instance(component_path, c, cfg, i)
+ 
+        instance_gap=0.10
+        time.sleep(0.2+max_instances*instance_gap) 
+
+        for f in self.filtered_configurations:
+            (c, cfg) = f.split(os.sep)
+
+            # skip posts that cannot run as daemons
+            if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): continue
+
+            component_path = self._find_component_path(c)
+            if component_path == '':
+                continue
+
+            self._tag_progress( c, cfg, "starting", ending=True )
 
         print('( %d ) Done' % pcount)
 
@@ -2312,6 +2347,10 @@ class sr_GlobalState:
                 continue
 
             if self.configs[c][cfg]['status'] in self.status_active:
+
+                if not self.options.dry_run:
+                    self._tag_progress( c, cfg, "shutdown", ending=False )
+
                 for i in self.states[c][cfg]['instance_pids']:
                     #print( "for %s/%s - %s signal_pid( %s, SIGTERM )" % \
                     #    ( c, cfg, i, self.states[c][cfg]['instance_pids'][i] ) )
@@ -2363,6 +2402,7 @@ class sr_GlobalState:
                 running_pids += len(self.states[c][cfg]['instance_pids'])
 
             if (running_pids == 0) and len(self.strays)==0:
+                self._tag_progress( c, cfg, "shutdown", ending=True )
                 print('All stopped after try %d' % attempts)
                 if len(fg_instances) > 0:
                     print(f"Foreground instances {fg_instances} are running and were not stopped.")
@@ -2407,10 +2447,13 @@ class sr_GlobalState:
             if (not self.options.dangerWillRobinson) and self._cfg_running_foreground(c, cfg):
                 fg_instances.add(f"{c}/{cfg}")
                 continue
+
             if self.configs[c][cfg]['status'] in self.status_active:
                 for i in self.states[c][cfg]['instance_pids']:
                     print("failed to kill: %s/%s instance: %s, pid: %s )" %
                           (c, cfg, i, self.states[c][cfg]['instance_pids'][i]))
+
+            self._tag_progress( c, cfg, "shutdown", ending=True )
 
         if len(self.procs) == 0:
             print('All stopped after KILL')
@@ -3098,6 +3141,38 @@ class sr_GlobalState:
             logger.error(f"Failed to determine instance # for {component}/{cfg} {pathname}")
             i = -1
         return i
+
+    def _tag_progress( self, c: str, cfg: str, what_is_in_progress: str, ending: bool ):
+        """ mark a configuration as being in flux, to disable sr3 sanity.
+            Do that by creating a file in the state directory. 
+
+            sample call: _tag_progress( "subscribe", "amis", "shutdown", False ) ...
+ 
+            results in a file named: *~/.cache/sr3/subscribe/amis/shutdown* being created.
+
+            if the *ending* argument is true, then the corresponding state file is removed
+            to indicate that the operation completed.
+        """
+        if 'options' in self.configs[c][cfg] and self.configs[c][cfg]['options'].statehost:
+            state_dir=self.user_cache_dir + os.sep + self.hostdir + os.sep + c + os.sep + cfg
+        else:
+            state_dir=self.user_cache_dir + os.sep + c + os.sep + cfg
+
+        fname =  f"{state_dir}{os.sep}{what_is_in_progress}"
+        if ending:
+            if os.path.exists(fname):
+                os.unlink( fname )
+        else:
+            if not os.path.exists(state_dir):
+                 os.makedirs(state_dir, exist_ok=True)
+
+            if os.path.exists( fname ):
+                 logger.error( f" {c}/{cfg} already tagged: {what_is_in_progress}" )
+                 return
+
+            with open(fname, "w") as f:
+                f.write(nowstr())
+
 
 
 def main():

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -229,6 +229,10 @@ class sr_GlobalState:
         if self.me != p['username'] :
             return
 
+        # defunct children waiting reap have no command line.
+        if not p['cmdline']:
+            return
+
         # process name 'python3' is not helpful, so overwrite...
         if 'python' in p['name']:
             if len(p['cmdline']) < 2:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2314,6 +2314,7 @@ class sr_GlobalState:
                 return
 
         pcount = 0
+        max_instances=0
         for f in self.filtered_configurations:
 
             (c, cfg) = f.split(os.sep)
@@ -2325,7 +2326,6 @@ class sr_GlobalState:
             if component_path == '':
                 continue
 
-            max_instances=0
             if self.configs[c][cfg]['status'] in [ 'missing', 'interactive','new','stopped']:
                 numi = self.configs[c][cfg]['instances']
                 if numi > max_instances:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -600,6 +600,12 @@ class sr_GlobalState:
                         if os.path.exists("disabled"): # double check, if disabled should ignore state.
                             continue
 
+                        if not 'status' in self.configs[c][cfg]:
+                            continue
+
+                        if self.configs[c][cfg]['status'] in [ 'stopped', 'disabled', 'stopping', 'starting' ]:
+                            continue
+
                         i_found=[]
                         for filename in os.listdir():
                             # look at pid files, find ones where process is missing.
@@ -1058,7 +1064,6 @@ class sr_GlobalState:
                                 flow_status = 'stopped'
                         else:
                             if observed_instances > 0 and flow_status not in ['starting','shutdown']:
-                                logger.critical( f" {flow_status=} " )
                                 flow_status = 'partial'
                                 for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                     if not i in self.states[c][cfg]['instance_pids']:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2158,6 +2158,8 @@ class sr_GlobalState:
                 logging.warning( f"Not interfering with operations in progress: {self.flux}" )
             return
 
+        self._tag_sanity(ending=False)
+
         pcount = 0
         kill_hung=[]
         for f in self.filtered_configurations:
@@ -2182,8 +2184,8 @@ class sr_GlobalState:
             for pid in kill_hung:
                 signal_pid(pid, signal.SIGKILL)
             time.sleep(5)
-            self._read_procs()
             # next step should identify the missing instances and start them up.
+            self._read_procs()
 
         if pcount != 0:
             self._find_missing_instances()
@@ -2236,7 +2238,20 @@ class sr_GlobalState:
                 flow.runCallbacksTime('on_sanity')
                 del flow
                 flow=None
+
+        self._tag_sanity(ending=True)
         
+    def _pid_file_count(self,c,cfg) -> int:
+        d = self.user_cache_dir 
+        if self.configs[c][cfg]['options'].statehost:
+            d += os.sep + self.hostdir
+        d += os.sep + c + os.sep + cfg
+        if os.path.exists(d):
+            return sum( [ i[-4:] == '.pid' for i in os.listdir(d) ] )
+        else:
+            return 0
+
+
     def start(self):
         """ Starting all components
 
@@ -2247,6 +2262,18 @@ class sr_GlobalState:
             logging.error( f"{self.leftovers} configuration not found" )
             return
         
+        count=0
+        while self._check_sanitizing():
+            if self.please_stop:
+                return
+            if count % 10 == 0:
+                logger.info( "sanitizing in progress, please wait." )
+            count += 1
+            time.sleep(1)
+ 
+        if count > 0:
+            logger.info( "sanitize complete, proceeding with start" )
+
         has_disabled_config = False
 
         # if any configs are disabled, don't start any
@@ -2286,11 +2313,20 @@ class sr_GlobalState:
                     self._launch_instance(component_path, c, cfg, i)
  
         instance_gap=0.10
-        time.sleep(0.2+max_instances*instance_gap) 
+        time.sleep(1+max_instances*instance_gap) 
 
         for f in self.filtered_configurations:
             (c, cfg) = f.split(os.sep)
 
+            pid_count = self._pid_file_count(c,cfg)
+            partial=False
+            while pid_count < self.configs[c][cfg]['options'].instances :
+                 partial=True
+                 logger.debug( f"{pid_count}/{self.configs[c][cfg]['options'].instances} instances started." )
+                 time.sleep(5)
+                 pid_count = self._pid_file_count(c,cfg)
+
+            logger.debug( f"{c}/{cfg}: {pid_count}/{self.configs[c][cfg]['options'].instances} instances started." )
             # skip posts that cannot run as daemons
             if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): continue
 
@@ -2330,6 +2366,18 @@ class sr_GlobalState:
         if len(self.leftovers) > 0 and not self._action_all_configs:
             logging.error( f"{self.leftovers} configuration not found" )
             return
+
+        count=0
+        while self._check_sanitizing():
+            if self.please_stop:
+                return
+            if count % 10 == 0:
+                logger.info( "sanitizing in progress, please wait.." )
+            count += 1
+            time.sleep(1)
+
+        if count > 0:
+            logger.info( "sanitize complete, proceeding with stop" )
 
         self._clean_missing_proc_state()
 
@@ -3157,6 +3205,40 @@ class sr_GlobalState:
             i = -1
         return i
 
+    def _check_sanitizing(self) -> bool:
+        """
+           return true if sr3 sanity is running somewhere... 
+        """
+
+        d1 = self.user_cache_dir
+
+        d2 = d1 + os.sep + self.hostdir
+
+        sanitizing=False
+        for d in [ d1, d2 ]:
+            f = d + os.sep + "sanitizing"
+            if os.path.exists(f):
+                sanitizing=True
+        return sanitizing
+
+    def _tag_sanity( self, ending: bool ):
+
+        dir_list = [ self.user_cache_dir + os.sep + self.hostdir, self.user_cache_dir ]
+
+        for d in dir_list:
+            if not os.path.exists( d ):
+                 os.makedirs(d, exist_ok=True)
+            
+            fname = d + os.sep + "sanitizing"
+
+            if ending:
+                if os.path.exists(fname):
+                    os.unlink( fname )
+            else:
+                with open(fname, "w") as f:
+                    f.write(nowstr())
+                    
+            
     def _tag_progress( self, c: str, cfg: str, what_is_in_progress: str, ending: bool ):
         """ mark a configuration as being in flux, to disable sr3 sanity.
             Do that by creating a file in the state directory. 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -882,6 +882,8 @@ class sr_GlobalState:
                     self.configs[c][cfg]['status'] = 'starting'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'shutdown'):
                     self.configs[c][cfg]['status'] = 'shutdown'
+                if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'running'):
+                    self.configs[c][cfg]['status'] = 'running'
                 if 'instance_metrics' in self.states[c][cfg]:
                     if 'housekeeping' in self.configs[c][cfg]:
                         expiry = now - self.configs[c][cfg]['housekeeping']*1.5
@@ -1049,7 +1051,7 @@ class sr_GlobalState:
                                 hung_instances += 1
                                 self.states[c][cfg]['hung_instances'].append(i)
 
-                    if self.configs[c][cfg]['status'] in [ 'disabled', 'starting', 'shutdown' ]:
+                    if self.configs[c][cfg]['status'] in [ 'disabled', 'starting', 'shutdown', 'running' ]:
                         flow_status = self.configs[c][cfg]['status']
                     else:
                         flow_status = 'unknown'
@@ -1079,7 +1081,7 @@ class sr_GlobalState:
                                          self.states[c][cfg]['missing_instances'].append(i)
                             else:
                                 if self.configs[c][cfg]['status'] != 'disabled':
-                                    if len(self.states[c][cfg]['instance_pids']) == 0 :
+                                    if flow_status != 'running' and len(self.states[c][cfg]['instance_pids']) == 0 :
                                         flow_status = 'stopped' 
                                     else:
                                         if flow_status not in [ 'starting', 'shutdown' ]:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -483,7 +483,7 @@ class sr_GlobalState:
                         self.states[c][cfg] = {}
                         self.states[c][cfg]['instance_pids'] = {}
                         self.states[c][cfg]['queueName'] = None
-                        self.configs[c][cfg]['status'] = 'new'
+                        self.configs[c][cfg]['status'] = 'stopped'
                         if c in self.configs:
                             if cfg not in self.configs[c]:
                                 self.states[c][cfg]['status'] = 'removed'
@@ -505,8 +505,14 @@ class sr_GlobalState:
                             self.states[c][cfg]['status'] = 'shutdown'
                             self.flux[ f"{c}/{cfg}" ] = 'shutdown'
 
-                        for pathname in os.listdir():
+                        state_files = os.listdir() 
+                        if len(state_files) == 0:
+                            self.configs[c][cfg]['status'] = 'new'
+                            continue
+
+                        for pathname in state_files:
                             p = pathlib.Path(pathname)
+                            pathcount += 1
                             if p.suffix in ['.pid', '.qname', '.state', '.noVip']:
                                 if sys.version_info[0] > 3 or sys.version_info[
                                         1] > 4:
@@ -538,7 +544,6 @@ class sr_GlobalState:
                                         self.states[c][cfg]['instance_metrics'][i]['status'] = { 'mtime':os.stat(p).st_mtime }
                                     except:
                                         logger.error( f"corrupt metrics file {pathname}: {t}" )
-
 
     def _read_metrics_dir(self,metrics_parent_dir):
         # read in metrics files

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -512,7 +512,6 @@ class sr_GlobalState:
 
                         for pathname in state_files:
                             p = pathlib.Path(pathname)
-                            pathcount += 1
                             if p.suffix in ['.pid', '.qname', '.state', '.noVip']:
                                 if sys.version_info[0] > 3 or sys.version_info[
                                         1] > 4:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -472,7 +472,11 @@ class sr_GlobalState:
                     else:
                         state_dir=self.user_cache_dir + os.sep + c + os.sep + cfg
 
-                    if os.path.isdir(state_dir):
+                    if not os.path.isdir(state_dir):
+                        if c in self.configs and cfg in self.configs[c]:
+                            if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): 
+                                 self.configs[c][cfg]['status'] = 'interactive'
+                    else:
                         os.chdir(state_dir)
                         self.states[c][cfg] = {}
                         self.states[c][cfg]['instance_pids'] = {}
@@ -489,6 +493,8 @@ class sr_GlobalState:
                             self.states[c][cfg]['subscriptions'] = s.read( \
                                 self.configs[c][cfg]['options'], 'subscriptions.json')
 
+                        if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): 
+                            self.configs[c][cfg]['status'] = 'interactive'
                         if os.path.exists('starting'):
                             self.states[c][cfg]['status'] = 'starting'
                             self.flux[ f"{c}/{cfg}" ] = 'starting'
@@ -609,7 +615,7 @@ class sr_GlobalState:
                         if not 'status' in self.configs[c][cfg]:
                             continue
 
-                        if self.configs[c][cfg]['status'] in [ 'stopped', 'disabled', 'stopping', 'starting' ]:
+                        if self.configs[c][cfg]['status'] in [ 'stopped', 'disabled', 'interactive', 'stopping', 'starting' ]:
                             continue
 
                         if hasattr(self.configs[c][cfg]['options'],'statehost') and (statehost != self.configs[c][cfg]['options'].statehost):
@@ -876,8 +882,11 @@ class sr_GlobalState:
                     self.states[c][cfg]['status'] = 'stopped'
                     self.states[c][cfg]['has_state'] = False
                     continue
+
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'disabled'):
                     self.configs[c][cfg]['status'] = 'disabled'
+                if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): 
+                    self.configs[c][cfg]['status'] = 'interactive'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'starting'):
                     self.configs[c][cfg]['status'] = 'starting'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'shutdown'):
@@ -1051,7 +1060,7 @@ class sr_GlobalState:
                                 hung_instances += 1
                                 self.states[c][cfg]['hung_instances'].append(i)
 
-                    if self.configs[c][cfg]['status'] in [ 'disabled', 'starting', 'shutdown', 'running' ]:
+                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'starting', 'shutdown', 'running' ]:
                         flow_status = self.configs[c][cfg]['status']
                     else:
                         flow_status = 'unknown'
@@ -1071,7 +1080,7 @@ class sr_GlobalState:
                          flow_status = 'hung'
                     elif observed_instances < int(self.configs[c][cfg]['instances']):
                         if (c == 'post') and (('sleep' not in self.states[c][cfg]) or self.states[c][cfg]['sleep'] <= 0):
-                            if self.configs[c][cfg]['status'] != 'disabled':
+                            if self.configs[c][cfg]['status'] not in [ 'disabled', 'interactive' ]:
                                 flow_status = 'stopped'
                         else:
                             if observed_instances > 0 and flow_status not in ['starting','shutdown']:
@@ -1081,15 +1090,17 @@ class sr_GlobalState:
                                          self.states[c][cfg]['missing_instances'].append(i)
                             else:
                                 if self.configs[c][cfg]['status'] != 'disabled':
-                                    if flow_status != 'running' and len(self.states[c][cfg]['instance_pids']) == 0 :
+                                    if flow_status not in [ 'running', 'interactive'] and len(self.states[c][cfg]['instance_pids']) == 0 :
                                         flow_status = 'stopped' 
                                     else:
-                                        if flow_status not in [ 'starting', 'shutdown' ]:
+                                        if flow_status not in [ 'starting', 'shutdown', 'interactive' ]:
                                             flow_status = 'missing' 
-                                        if not i in self.states[c][cfg]['instance_pids']:
-                                             self.states[c][cfg]['missing_instances'].append(i)
+                                        for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
+                                            if not i in self.states[c][cfg]['instance_pids']:
+                                                 self.states[c][cfg]['missing_instances'].append(i)
                     elif observed_instances == 0:
-                        flow_status = "stopped" if len(self.states[c][cfg]['instance_pids']) == 0 else "missing"
+                        if flow_status not in ['interactive']:
+                            flow_status = "stopped" if len(self.states[c][cfg]['instance_pids']) == 0 else "missing"
                     elif self.states[c][cfg]['noVip']:
                         flow_status = 'waitVip'
                     elif self.states[c][cfg]['metrics']['byteRate'] < self.configs[c][cfg]['options'].runStateThreshold_slow:
@@ -1297,7 +1308,7 @@ class sr_GlobalState:
         ]
         # active means >= 1 process exists on the node.
         self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip' ]
-        self.status_values = self.status_active + [ 'disabled', 'include', 'missing', 'stopped', 'unknown' ]
+        self.status_values = self.status_active + [ 'disabled', 'include', 'interactive', 'missing', 'stopped', 'unknown' ]
 
         self.bin_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -1724,7 +1735,7 @@ class sr_GlobalState:
             if component_path == '':
                 continue
 
-            if self.configs[c][cfg]['status'] in ['stopped','missing']:
+            if self.configs[c][cfg]['status'] in ['stopped','interactive','missing']:
                 numi = self.configs[c][cfg]['instances']
                 for i in range(1, numi + 1):
                     if pcount % 10 == 0: print('.', end='', flush=True)
@@ -2308,7 +2319,7 @@ class sr_GlobalState:
                 continue
 
             max_instances=0
-            if self.configs[c][cfg]['status'] in [ 'missing', 'stopped']:
+            if self.configs[c][cfg]['status'] in [ 'missing', 'interactive','stopped']:
                 numi = self.configs[c][cfg]['instances']
                 if numi > max_instances:
                     max_instances=numi

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -317,7 +317,7 @@ class sr_GlobalState:
                     numi = 0
                     if cfg[-5:] == '.conf':
                         cbase = cfg[0:-5]
-                        state = 'stopped'
+                        state = 'new'
                     elif cfg[-4:] == '.inc':
                         cbase = cfg[0:-5]
                         state = 'include'
@@ -476,11 +476,14 @@ class sr_GlobalState:
                         if c in self.configs and cfg in self.configs[c]:
                             if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): 
                                  self.configs[c][cfg]['status'] = 'interactive'
+                            else:
+                                 self.configs[c][cfg]['status'] = 'new'
                     else:
                         os.chdir(state_dir)
                         self.states[c][cfg] = {}
                         self.states[c][cfg]['instance_pids'] = {}
                         self.states[c][cfg]['queueName'] = None
+                        self.configs[c][cfg]['status'] = 'new'
                         if c in self.configs:
                             if cfg not in self.configs[c]:
                                 self.states[c][cfg]['status'] = 'removed'
@@ -615,7 +618,7 @@ class sr_GlobalState:
                         if not 'status' in self.configs[c][cfg]:
                             continue
 
-                        if self.configs[c][cfg]['status'] in [ 'stopped', 'disabled', 'interactive', 'stopping', 'starting' ]:
+                        if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'stopped', 'stopping', 'starting' ]:
                             continue
 
                         if hasattr(self.configs[c][cfg]['options'],'statehost') and (statehost != self.configs[c][cfg]['options'].statehost):
@@ -879,7 +882,7 @@ class sr_GlobalState:
                     self.states[c][cfg] = {}
                     self.states[c][cfg]['instance_pids'] = {}
                     self.states[c][cfg]['queueName'] = None
-                    self.states[c][cfg]['status'] = 'stopped'
+                    self.states[c][cfg]['status'] = 'new'
                     self.states[c][cfg]['has_state'] = False
                     continue
 
@@ -1060,7 +1063,7 @@ class sr_GlobalState:
                                 hung_instances += 1
                                 self.states[c][cfg]['hung_instances'].append(i)
 
-                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'starting', 'shutdown', 'running' ]:
+                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'starting', 'shutdown', 'running' ]:
                         flow_status = self.configs[c][cfg]['status']
                     else:
                         flow_status = 'unknown'
@@ -1080,7 +1083,7 @@ class sr_GlobalState:
                          flow_status = 'hung'
                     elif observed_instances < int(self.configs[c][cfg]['instances']):
                         if (c == 'post') and (('sleep' not in self.states[c][cfg]) or self.states[c][cfg]['sleep'] <= 0):
-                            if self.configs[c][cfg]['status'] not in [ 'disabled', 'interactive' ]:
+                            if self.configs[c][cfg]['status'] not in [ 'disabled', 'new', 'interactive' ]:
                                 flow_status = 'stopped'
                         else:
                             if observed_instances > 0 and flow_status not in ['starting','shutdown']:
@@ -1090,17 +1093,17 @@ class sr_GlobalState:
                                          self.states[c][cfg]['missing_instances'].append(i)
                             else:
                                 if self.configs[c][cfg]['status'] != 'disabled':
-                                    if flow_status not in [ 'running', 'interactive'] and len(self.states[c][cfg]['instance_pids']) == 0 :
+                                    if flow_status not in [ 'interactive', 'new', 'running'] and len(self.states[c][cfg]['instance_pids']) == 0 :
                                         flow_status = 'stopped' 
                                     else:
-                                        if flow_status not in [ 'starting', 'shutdown', 'interactive' ]:
+                                        if flow_status not in [ 'interactive', 'new', 'shutdown', 'starting' ]:
                                             flow_status = 'missing' 
                                         for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                             if not i in self.states[c][cfg]['instance_pids']:
                                                  self.states[c][cfg]['missing_instances'].append(i)
                     elif observed_instances == 0:
-                        if flow_status not in ['interactive']:
-                            flow_status = "stopped" if len(self.states[c][cfg]['instance_pids']) == 0 else "missing"
+                        if flow_status not in ['interactive','new']:
+                            flow_status = 'stopped' if len(self.states[c][cfg]['instance_pids']) == 0 else "missing"
                     elif self.states[c][cfg]['noVip']:
                         flow_status = 'waitVip'
                     elif self.states[c][cfg]['metrics']['byteRate'] < self.configs[c][cfg]['options'].runStateThreshold_slow:
@@ -1308,7 +1311,7 @@ class sr_GlobalState:
         ]
         # active means >= 1 process exists on the node.
         self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip' ]
-        self.status_values = self.status_active + [ 'disabled', 'include', 'interactive', 'missing', 'stopped', 'unknown' ]
+        self.status_values = self.status_active + [ 'disabled', 'include', 'interactive', 'missing', 'new', 'stopped', 'unknown' ]
 
         self.bin_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -1735,7 +1738,7 @@ class sr_GlobalState:
             if component_path == '':
                 continue
 
-            if self.configs[c][cfg]['status'] in ['stopped','interactive','missing']:
+            if self.configs[c][cfg]['status'] in ['stopped','new','interactive','missing']:
                 numi = self.configs[c][cfg]['instances']
                 for i in range(1, numi + 1):
                     if pcount % 10 == 0: print('.', end='', flush=True)
@@ -2319,7 +2322,7 @@ class sr_GlobalState:
                 continue
 
             max_instances=0
-            if self.configs[c][cfg]['status'] in [ 'missing', 'interactive','stopped']:
+            if self.configs[c][cfg]['status'] in [ 'missing', 'interactive','new','stopped']:
                 numi = self.configs[c][cfg]['instances']
                 if numi > max_instances:
                     max_instances=numi
@@ -2742,7 +2745,7 @@ class sr_GlobalState:
                         else:
                             missing_instances.append(p)
 
-                if self.configs[c][cfg]['status'] != 'stopped':
+                if self.configs[c][cfg]['status'] not in [ 'stopped', 'new' ]:
                     expected = self.configs[c][cfg]['instances']
                     running = len(running_instances)
                     if running > 0:
@@ -3117,7 +3120,7 @@ class sr_GlobalState:
                 if not (c in self.states and cfg in self.states[c]):
                     continue
 
-                if self.configs[c][cfg]['status'] != 'stopped':
+                if self.configs[c][cfg]['status'] not in [ 'stopped', 'new' ]:
                     m = sum(map(
                         lambda x: c in x and cfg in x,
                         self.missing))  #perhaps expensive, but I am lazy FIXME

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2591,14 +2591,16 @@ class sr_GlobalState:
                     continue
 
                 #find running and missing instances for this config.
-                instance_pids=self.states[c][cfg]['instance_pids'].values()
                 missing_instances=[]
                 running_instances=[]
-                for p in instance_pids:
-                    if p in self.procs.keys():
-                        running_instances.append(p)
-                    else:
-                        missing_instances.append(p)
+                if 'instance_pids' in self.states[c][cfg]:
+                    instance_pids=self.states[c][cfg]['instance_pids'].values()
+
+                    for p in instance_pids:
+                        if p in self.procs.keys():
+                            running_instances.append(p)
+                        else:
+                            missing_instances.append(p)
 
                 if self.configs[c][cfg]['status'] != 'stopped':
                     expected = self.configs[c][cfg]['instances']

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2411,7 +2411,6 @@ class sr_GlobalState:
                     (c, cfg) = f.split(os.sep)
                     # exclude foreground instances unless --dangerWillRobinson specified
                     if (not self.options.dangerWillRobinson) and self._cfg_running_foreground(c, cfg):
-                        fg_instances.add(f"{c}/{cfg}")
                         continue
                     self._tag_progress( c, cfg, "shutdown", ending=True )
                 print('All stopped after try %d' % attempts)

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -576,8 +576,10 @@ class sr_GlobalState:
         self._read_metrics_dir(self.user_cache_dir)
         self._read_metrics_dir(self.user_cache_dir + os.sep + self.hostdir)
 
-    def _find_missing_instances_dir(self, dir):
+    def _find_missing_instances_dir(self, dir, statehost=False):
         """ find processes which are no longer running, based on pidfiles in state, and procs.
+
+            check each configurations statehost setting, compare it to given parameter.
         """
         missing = []
         if not os.path.isdir(dir):
@@ -604,6 +606,9 @@ class sr_GlobalState:
                             continue
 
                         if self.configs[c][cfg]['status'] in [ 'stopped', 'disabled', 'stopping', 'starting' ]:
+                            continue
+
+                        if hasattr(self.configs[c][cfg]['options'],'statehost') and (statehost != self.configs[c][cfg]['options'].statehost):
                             continue
 
                         i_found=[]
@@ -641,9 +646,9 @@ class sr_GlobalState:
 
     def _find_missing_instances(self):
         self.missing = []
-        self._find_missing_instances_dir(self.user_cache_dir)
+        self._find_missing_instances_dir(self.user_cache_dir, False)
         self._find_missing_instances_dir(self.user_cache_dir + os.sep +
-                                         self.hostdir)
+                                         self.hostdir, True)
 
     def _clean_missing_proc_state_dir(self, dir):
         """ remove state pid files for process which are not running

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -441,6 +441,7 @@ def test_multi():
 
      options.publishers[0]['broker'] = str(options.publishers[0]['broker'])
 
+
      assert( options.publishers[0] == { \
                  'auto_delete': False,
                  'baseDir': '/tmp/dual_amis/',
@@ -460,16 +461,20 @@ def test_multi():
                                   'prefix': ['v02', 'post'],
                                   'sub': ['*.WXO-DD.bulletins.alphanumeric.#']}] )
 
-     assert( options.subscriptions[0]['queue']  == {'auto_delete': False, \
+     default_options = sarracenia.config.default_config()
+
+     subscriber_queue = {'auto_delete': False, \
                               'bind': True,
                               'cleanup_needed': None,
                               'declare': True,
                               'durable': True,
-                              'expire': 25200.0,
+                              'expire': default_options.expire,
                               'name': 'q_anonymous.subscribe.multi1',
                               'prefetch': 25,
                               'template': 'q_${BROKER_USER}.${COMPONENT}.${CONFIG}',
-                              'tlsRigour': 'normal'} )
+                              'tlsRigour': 'normal'}
+
+     assert( options.subscriptions[0]['queue']  == subscriber_queue )
 
      assert( options.subscriptions[0]['bindings']  == [{'exchange': 'xpublic',
                                   'prefix': ['v02', 'post'],


### PR DESCRIPTION
close #1069 
close #1439 

This PR makes progress on #1439, but does not address the originally reported issue of interaction between systemd initiated flows and manually initiated ones, as well as those initiated by sr3 sanity.
It completely ignores that issue, and I opened #1461 to deal with that problem.

The other half of #1439 is a general problem made obvious by this report that if *sr3 sanity* is running at the same time as maintenance activities occur, like *sr3 start*, or *sr3 stop*, then race conditions can result in undefined results where sr3 sanity kills or starts the wrong processes, or *start* or *stop* operations have unexpected or incomplete results.   That's what this PR addresses.

The improvements in this PR:

* there were some delay timers (now called *instance_gap* in the code) that would wait a long time while starting things up.  Those have been shortened, so startup should be much quicker.
* new flow states: *starting* and *stopping* are introduced.  *sr3 sanity* will not make any changes when any flow is in one of those states.
* new flow state: *new* introduced to identify a flow that has no state files, as would be the case when it is *added*, or after a *clean* operation.
* new flow state: *interactive* introduced to identify flows that don't normally run as daemons.
* global flag *sanitizing* introduced to the root of the state directory so that any *start* or *stop* operations will block before starting.  They will loop waiting for the sanitizing to be complete.
* when executing *sr3 start*, it used to launch the processes and exit.  Now instead it looks in the state file for the requisite number of pid files to indicate successful start up, and only exits after that is complete (to prevent a santizing run from happenning before the pid files are created.)
* Before, when all instances of a flow had crashed, sr3 decides the flow is stopped, so *status* reported it as *stopped* and *sanity* would not restart it.  In this branch, added a *running* statefile to the state directory, to differentiate between *stopped* versus running, but all instances have crashed.
* during development, encountered orphan *sr3_cpump* processes (exit status not read by parent pid.) that cause sr3 to crash, because lots of attributes (e.g. 'cmdline' ) are None.  So now filter out defunct processes from flow management.
* the *statehost* variable was not being used to understand where the state files of a given configuration were.  This would result in *sanity* starting up processes to replace existing functional ones.

## Initial unit testing: make everything slow...

Guaranteed overlap in between maintenance activities ( *start*, *stop*, and *sanity*) by adding sleeps so that each one takes a really long time.  Saw all the ways they could interfere with each other and results.  started by testing
with a single flow (sr3 add subscribe/dual_amis) then using the *static_flow*
suite of flows.  Once that seemed functional, moved on to:

## ran *sr3 sanity* every 3 seconds throughout the flow_tests.

ran static, flakey, dynamic, flow tests on local PC.  Also had
*watch -n 0.5 sr3 status* running to see what it was reporting 
at all times.

## Results:

* prior to this work:
   * running sr3 sanity would sometimes break things (timing sensitivity.)
   * running sr3 sanity would sometimes start wrong things (statehost out of sync.)
   * running sr3 sanity would sometimes not start things it should (all instances crashed.)
   * flow_tests would fail when *sr3 sanity* was run in the background.
   
* with this branch:
   * there is no known, reproducible condition where sr3 sanity does not do the right thing.
   * start, stop, sanitize actions co-ordinate to avoid undefined behaviour.
   * all flow_tests succeed regardless or sr3 sanity being run continuously throughout.
   * sr3 status now shows additional flow states:  new, interactive, starting, stopping.
  

