### PR TITLE
Fix `sr3 start/restart` not ignoring disabled configs

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2322,11 +2322,14 @@ class sr_GlobalState:
             # skip posts that cannot run as daemons
             if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): continue
 
+            # Skip disabled configurations
+            if self.configs[c][cfg]['status'] in ['disabled']: continue
+
             component_path = self._find_component_path(c)
             if component_path == '':
                 continue
 
-            if self.configs[c][cfg]['status'] in [ 'missing', 'interactive','new','stopped']:
+            if self.configs[c][cfg]['status'] in [ 'missing', 'interactive', 'new', 'stopped']:
                 numi = self.configs[c][cfg]['instances']
                 if numi > max_instances:
                     max_instances=numi
@@ -2347,7 +2350,9 @@ class sr_GlobalState:
             if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): 
                  continue
 
-            while pid_count < self.configs[c][cfg]['options'].instances :
+            if self.configs[c][cfg]['status'] in ['disabled']: continue
+
+            while pid_count < self.configs[c][cfg]['options'].instances:
 
                  if self.please_stop:
                      return
@@ -2358,6 +2363,7 @@ class sr_GlobalState:
                  pid_count = self._pid_file_count(c,cfg)
 
             logger.debug( f"{c}/{cfg}: {pid_count}/{self.configs[c][cfg]['options'].instances} instances started." )
+
             # skip posts that cannot run as daemons
             if c in ['post', 'cpost'] and not self._post_can_be_daemon(c, cfg): continue
 


### PR DESCRIPTION
Doing a `sr3 restart` with no configs specified would not ignore disabled configurations. I think this wasn't tested during the flow tests because the flow tests specify each configuration individually in the start/stop commands.

There's already a guard in the start command, but it only applies when a configuration is specified from the CLI.

https://github.com/MetPX/sarracenia/blob/0af7dfe01b0d91c7331c6c65db7c7f96a65f9a25/sarracenia/sr.py#L2303-L2314

I added some new guards to address the problem in the new logic.