### PR TITLE
systemd exitType=cgroup means it does not look dead

### DIFF
--- a/debian/metpx-sr3.service
+++ b/debian/metpx-sr3.service
@@ -12,6 +12,7 @@ Requires=network-online.target
 
 [Service]
 Type=forking
+exitType=cgroup
 ExecStart=/usr/bin/sr3 start
 User=sarra
 Group=sarra

--- a/debian/metpx-sr3.user.service
+++ b/debian/metpx-sr3.user.service
@@ -21,6 +21,8 @@ After=network.target
 
 [Service]
 Type=forking
+exitType=cgroup
+
 ExecStart=/usr/bin/sr3 start
 
 ExecReload=/usr/bin/sr3 reload


### PR DESCRIPTION

helps with one complaint about systemd integration.
systemd will now list the thing as running as long as the cgroup is around... sometimes it seems to mark
it inactive (dead.)
