### PR TITLE
fix #1472 add missing _isRetry flag for retried messages

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -1152,3 +1152,6 @@ class Message(dict):
             msg.computeIdentity(opath,self.o,data=data)
         except Exception as ex:
             logger.error( f"problem with {opath}: {ex}" )
+
+    def isRetry(msg):
+        return '_isRetry' in msg and msg['_isRetry']

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -1155,3 +1155,15 @@ class Message(dict):
 
     def isRetry(msg):
         return '_isRetry' in msg and msg['_isRetry']
+
+    def retryCount(msg):
+        """ return the number of times the message has been retried.
+            0 if the message has never been retried.
+        """
+        rcount = 0
+        if '_isRetry' in msg:
+            if type(msg['_isRetry']) == int:
+                rcount = msg['_isRetry']
+            else:
+                rcount = 1 if msg['_isRetry'] else 0
+        return rcount

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -611,7 +611,7 @@ class Flow:
                 #               worklist.ok by retry.py, even when last_poll_gather_len is 0
                 elif self.o.component == 'poll':
                     # get rid of non-retry messages from worklist.ok, we only want to post retries
-                    new_ok = [ msg for msg in self.worklist.ok if ('_isRetry' in msg and msg['_isRetry']) ]
+                    new_ok = [ msg for msg in self.worklist.ok if msg.isRetry() ]
                     self.worklist.ok = new_ok
                     self.post(now)
 
@@ -885,7 +885,7 @@ class Flow:
         #   a) messages that are not retries when retry_refilter is disabled
         #   b) all messages, when retry_refilter is enabled
         retry_refilter = hasattr(self.o, 'retry_refilter') and self.o.retry_refilter
-        msg_is_not_retry = retry_refilter or ('_isRetry' not in msg or ('_isRetry' in msg and not msg['_isRetry']))
+        msg_is_not_retry = retry_refilter or not msg.isRetry()
 
         if 'fileOp' in msg and msg_is_not_retry:
             msg['post_fileOp'] = copy.deepcopy(msg['fileOp'])

--- a/sarracenia/flowcb/accept/testretry.py
+++ b/sarracenia/flowcb/accept/testretry.py
@@ -36,7 +36,7 @@ class TestRetry(FlowCB):
             # retry message : recover it
             # update: this is set somewhere as true in /diskqueue.py, should think about initializing first so we
             # dont have to test for existence
-            if '_isRetry' in message and message['_isRetry']:
+            if message.isRetry():
                 self.o.sendTo = self.sendTo
                 ok, self.o.details = self.o.credentials.get(self.sendTo)
 

--- a/sarracenia/flowcb/accept/testretry.py
+++ b/sarracenia/flowcb/accept/testretry.py
@@ -36,9 +36,7 @@ class TestRetry(FlowCB):
             # retry message : recover it
             # update: this is set somewhere as true in /diskqueue.py, should think about initializing first so we
             # dont have to test for existence
-            # 2022-06-10: isRetry was removed. Maybe can check if the message has msg_baseUrl_bad?
-            #             see issues #466 and #527.
-            if 'isRetry' in message and message['isRetry']:
+            if '_isRetry' in message and message['_isRetry']:
                 self.o.sendTo = self.sendTo
                 ok, self.o.details = self.o.credentials.get(self.sendTo)
 

--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -177,7 +177,7 @@ class Log(FlowCB):
         for msg in worklist.incoming:
 
             lag = now - timestr2flt(msg['pubTime'])
-            if not ( '_isRetry' in msg and msg['_isRetry']):
+            if not msg.isRetry():
                self.lagTotal += lag
                if lag > self.lagMax:
                    self.lagMax = lag

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -176,7 +176,7 @@ class Disk(NoDupe):
                     worklist.rejected.append(m)
                     continue
 
-            if '_isRetry' in m or self.check_message(m):
+            if m.isRetry() or self.check_message(m):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])

--- a/sarracenia/flowcb/nodupe/redis.py
+++ b/sarracenia/flowcb/nodupe/redis.py
@@ -173,7 +173,7 @@ class Redis(NoDupe):
                     worklist.rejected.append(m)
                     continue
 
-            if '_isRetry' in m or self._is_new(m):
+            if m.isRetry() or self._is_new(m):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -114,6 +114,12 @@ class Retry(FlowCB):
 
         mlist = self.download_retry.get(qty)
 
+        for m in mlist:
+             m['_isRetry'] = True
+             if '_deleteOnPost' not in m:
+                 m['_deleteOnPost'] = set()
+             m['_deleteOnPost'].add('_isRetry')
+
         #logger.debug("loading from %s: qty=%d ... got: %d " % (self.download_retry_name, qty, len(mlist)))
         if len(mlist) > 0:
             worklist.incoming.extend(mlist)

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -42,6 +42,9 @@ class Retry(FlowCB):
     * the DiskQueue or RedisQueue classes are used to store the retries, and it handles
       expiry on each housekeeping event.
 
+    * ``_isRetry`` in the message is a count of how many times a retry has been 
+      attempted for that file.
+
     """
     def __init__(self, options) -> None:
 
@@ -87,8 +90,7 @@ class Retry(FlowCB):
                     continue
                 if k in m and (k in m['_deleteOnPost'] or k.startswith('new_')):
                     del m[k]
-            m['_isRetry'] = True
-            m['_deleteOnPost'] = set( [ '_isRetry' ] )
+            self.__set_isRetry(m)
 
 
         return (True, message_list)
@@ -118,10 +120,7 @@ class Retry(FlowCB):
         mlist = self.download_retry.get(qty)
 
         for m in mlist:
-             m['_isRetry'] = True
-             if '_deleteOnPost' not in m:
-                 m['_deleteOnPost'] = set()
-             m['_deleteOnPost'].add('_isRetry')
+            self.__set_isRetry(m)
 
         #logger.debug("loading from %s: qty=%d ... got: %d " % (self.download_retry_name, qty, len(mlist)))
         if len(mlist) > 0:
@@ -169,10 +168,7 @@ class Retry(FlowCB):
             return
 
         for m in worklist.failed:
-             m['_isRetry'] = True
-             if '_deleteOnPost' not in m:
-                 m['_deleteOnPost'] = set()
-             m['_deleteOnPost'].add('_isRetry')
+            self.__set_isRetry(m)
 
         self.post_retry.put(worklist.failed)
         worklist.failed=[]
@@ -218,3 +214,13 @@ class Retry(FlowCB):
     def on_stop(self) -> None:
         self.download_retry.close()
         self.post_retry.close()
+
+    def __set_isRetry(self, msg):
+        if '_isRetry' not in msg or ('_isRetry' in msg and type(msg['_isRetry']) != int):
+            msg['_isRetry'] = 1
+        else:
+            msg['_isRetry'] += 1
+
+        if '_deleteOnPost' not in msg:
+            msg['_deleteOnPost'] = set()
+        msg['_deleteOnPost'].add('_isRetry')

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -81,11 +81,14 @@ class Retry(FlowCB):
 
         # eliminate calculated values so it is refiltered from scratch.
         for m in message_list:
-             for k in list(m.keys()):
-                 if k in m and (k in m['_deleteOnPost'] or k.startswith('new_')):
-                     del m[k]
-             m['_isRetry'] = True
-             m['_deleteOnPost'] = set( [ '_isRetry' ] )
+            for k in list(m.keys()):
+                # can't delete local_offset, it is set in the moth classes and is required for downloads to work
+                if k == 'local_offset':
+                    continue
+                if k in m and (k in m['_deleteOnPost'] or k.startswith('new_')):
+                    del m[k]
+            m['_isRetry'] = True
+            m['_deleteOnPost'] = set( [ '_isRetry' ] )
 
 
         return (True, message_list)

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -153,7 +153,7 @@ class Message:
        
         self.headers = h
         self.hdrstr = str(h)
-        self.isRetry = ('_isRetry' in h and h['_isRetry'])
+        self.isRetry = bool(h.isRetry())
 
         # from sr_message/sr_new ...
         self.local_offset = 0

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -153,7 +153,7 @@ class Message:
        
         self.headers = h
         self.hdrstr = str(h)
-        self.isRetry = False
+        self.isRetry = ('_isRetry' in h and h['_isRetry'])
 
         # from sr_message/sr_new ...
         self.local_offset = 0


### PR DESCRIPTION
When retry_refilter is False and the after_accept entry point of retry.py was used, `_isRetry` did not get set on the messages to be retried. 

When testing this to confirm it didn't break retry_refilter, I found an unrelated problem with retry_refilter. It would crash with this error:

```
2025-07-24 20:22:49,933 [DEBUG] 3038018 sarracenia.flow download https_transport remote cd to /20250724/WXO-DD/citypage_weather/mp3/SK
2025-07-24 20:22:49,933 [DEBUG] 3038018 sarracenia.transfer.https cd sr_http cd /20250724/WXO-DD/citypage_weather/mp3/SK
2025-07-24 20:22:49,933 [DEBUG] 3038018 sarracenia.flow download Exception details:
Traceback (most recent call last):
  File "/net/local/home/sunderlandr/sr3/sarracenia/flow/__init__.py", line 2303, in download
    (urlstr, remote_offset, block_length-1, new_inflight_path, msg['local_offset'],
KeyError: 'local_offset'
2025-07-24 20:22:49,933 [WARNING] 3038018 sarracenia.flow download failed to write s0000300_sa_f.mp3: 'local_offset'
2025-07-24 20:22:49,933 [DEBUG] 3038018 sarracenia.transfer.https close sr_http close
2025-07-24 20:22:49,933 [DEBUG] 3038018 sarracenia.transfer.https init sr_http init
2025-07-24 20:22:49,933 [INFO] 3038018 sarracenia.flow do_download attempt 3 failed to download https://dd1.weather.gc.ca//20250724/WXO-DD/citypage_weather/mp3/SK/s0000300_sa_f.mp3 to /tmp/citypage/s0000300_sa_f.mp3
```

local_offset is required for downloads to work properly and it is set in the message by the moth classes, e.g.: 
https://github.com/MetPX/sarracenia/blob/6bbd6904d4666bca4880ef87c2900abd873db8a7/sarracenia/moth/amqp.py#L151-L152

but retry.py in retry_refilter mode deletes all the delete_on_post values from the message, including local_offset, which causes the crash.

I fixed it by not deleting `_isRetry` in that case, but I wonder if it would be best to initially set local_offset = 0 somewhere else in the code? It feels weird having that happen in moth...