### PR TITLE
fix error from unit tests about bad escape

### DIFF
--- a/sarracenia/flowcb/scheduled/poll.py
+++ b/sarracenia/flowcb/scheduled/poll.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     flow.o.scheduled_interval= 5
     flow.o.pollUrl = "https://dd.weather.gc.ca/bulletins/alphanumeric/"
     if sys.platform.startswith( "win" ):
-        flow.o.directory = "C:\\temp\poll"
+        flow.o.directory = "C:\\temp\\poll"
     else:
         flow.o.directory = "/tmp/scheduled_poll/${%Y%m%d}"
     logging.basicConfig(level=logging.DEBUG)

--- a/sarracenia/sr3_rotateLogsManually.py
+++ b/sarracenia/sr3_rotateLogsManually.py
@@ -20,7 +20,7 @@ if len(sys.argv) > 1:
 timesuffix=str(datetime.datetime.now()).replace(' ','_').replace(':','_')[0:19]
 logdir=sarracenia.config.user_cache_dir('sr3','MetPX') + os.sep + 'log'
 print( f"log directory is: {logdir}")
-current_log_pattern=re.compile(".*\.log$")
+current_log_pattern=re.compile(".*\\.log$")
 current_logs=[]
 old_to_delete=[]
 old_logs=[]


### PR DESCRIPTION
noticed a complaint in failing unit tests of a different PR

if you look in the log of the Unit Test Action, you'll see this erroe:

```

78 <unknown>:37: SyntaxWarning: invalid escape sequence '\p'
79 sarracenia/flowcb/scheduled/poll.py:37: SyntaxWarning: invalid escape sequence '\p'
80 flow.o.directory = "C:\\temp\poll"
81 <unknown>:23: SyntaxWarning: invalid escape sequence '\.'
82 sarracenia/sr3_rotateLogsManually.py:23: SyntaxWarning: invalid escape sequence '\.'
83 current_log_pattern=re.compile(".*\.log$")

```

The sub-dir needs a second backslash to escape it.
