### PR TITLE
#1478 Add support for inlining data to a sarracenia message from othe…

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -1112,22 +1112,33 @@ class Message(dict):
         Does not return any value.
         """
 
-        if 'size' in msg and msg['size'] >= options.inlineByteMax:
-            logger.warning(f"Not placing file contents in message due to file size being to big. File size {msg['size']}, inlineByteMax: {options.inlineByteMax}")
-            return
-        elif 'size' not in msg:
-            logger.warning(f"Cannot get file size. Won't write file contents in message as a consequence")
+        # Don't try to add data inline if it's already present.
+        if 'content' in msg:
             return
 
         try:
             content = msg.getContent()
+            sz = len(content)
+
+            # If there's not already a size in the message, give it an arbitrary value.
+            if 'size' not in msg:
+                msg['size'] = 0
+            # We want to update the message size with the recently fetched content.
+            if sz != msg['size']:
+                logger.warning(f"Size from getContent doesn't match previously assigned size. Reassigning size to {sz}")
+                msg['size'] = sz
+
+            if msg['size'] >= options.inlineByteMax:
+                logger.warning(f"Not placing file contents in message due to file size being to big. File size {msg['size']}, inlineByteMax: {options.inlineByteMax}")
+                return
+
         except Exception as e:
             logger.error(f"Couldn't fetch file contents with getContent. Error: {e}")
             logger.debug("Exception details:", exc_info=True)
+            return
 
         # We may want to call this method even if the file contents is already in the message to rewrite the entries.
-        if 'content' not in msg:
-            msg['content'] = {'value' : '' , 'encoding' : ''}
+        msg['content'] = {'value' : '' , 'encoding' : ''}
 
         try:
             msg['content']['value'] = content.decode('utf-8')

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -1102,6 +1102,47 @@ class Message(dict):
         with urllib.request.urlopen(retUrl) as response:
             return response.read()
 
+
+    def putContentInline(msg,options=None):
+        """
+        Embed file data inside a sarracenia message. Leverages the
+        getContent method to acquire the file data, then inserts it
+        in the sarracenia message when possible.
+
+        Does not return any value.
+        """
+
+        if 'size' in msg and msg['size'] >= options.inlineByteMax:
+            logger.warning(f"Not placing file contents in message due to file size being to big. File size {msg['size']}, inlineByteMax: {options.inlineByteMax}")
+            return
+        elif 'size' not in msg:
+            logger.warning(f"Cannot get file size. Won't write file contents in message as a consequence")
+            return
+
+        try:
+            content = msg.getContent()
+        except Exception as e:
+            logger.error(f"Couldn't fetch file contents with getContent. Error: {e}")
+            logger.debug("Exception details:", exc_info=True)
+
+        # We may want to call this method even if the file contents is already in the message to rewrite the entries.
+        if 'content' not in msg:
+            msg['content'] = {'value' : '' , 'encoding' : ''}
+
+        try:
+            msg['content']['value'] = content.decode('utf-8')
+            msg['content']['encoding'] = 'utf-8'
+        except UnicodeDecodeError:
+            # Assuming file is binary if can't decode in utf-8.
+            msg['content']['value'] = b64encode(content).decode('utf-8')
+            msg['content']['encoding'] = 'base64'
+        except Exception as e:
+            # The exception gives a nice explanation already
+            logger.error(f"Unable to add file content to message. Error: {e}")
+            logger.debug("Exception details:", exc_info=True)
+            del msg['content']
+
+
     def new_pathWrite(msg,options,data):
         """
            expects: msg['new_dir'] and msg['new_file'] to be set.

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -1120,16 +1120,16 @@ class Message(dict):
             content = msg.getContent()
             sz = len(content)
 
-            # If there's not already a size in the message, give it an arbitrary value.
-            if 'size' not in msg:
-                msg['size'] = 0
             # We want to update the message size with the recently fetched content.
-            if sz != msg['size']:
+            if 'size' not in msg:
+                logger.debug(f"Size in incoming message not found. Including new size: {sz}")
+                msg['size'] = sz
+            elif sz != msg['size']:
                 logger.warning(f"Size from getContent doesn't match previously assigned size. Reassigning size to {sz}")
                 msg['size'] = sz
 
             if msg['size'] >= options.inlineByteMax:
-                logger.warning(f"Not placing file contents in message due to file size being to big. File size {msg['size']}, inlineByteMax: {options.inlineByteMax}")
+                logger.warning(f"Not placing file contents in message due to file size being too big. File size {msg['size']}, inlineByteMax: {options.inlineByteMax}")
                 return
 
         except Exception as e:
@@ -1137,7 +1137,6 @@ class Message(dict):
             logger.debug("Exception details:", exc_info=True)
             return
 
-        # We may want to call this method even if the file contents is already in the message to rewrite the entries.
         msg['content'] = {'value' : '' , 'encoding' : ''}
 
         try:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -186,6 +186,9 @@ class Flow:
                 self.plugins['load'].append('sarracenia.flowcb.nodupe.redis.Redis')
             else:
                 self.plugins['load'].append('sarracenia.flowcb.nodupe.disk.Disk')
+
+        if hasattr(self.o, 'inline') and self.o.inline:
+            self.plugins['load'].append('sarracenia.flowcb.work.add_inline.Add_inline')
             
 
         if (( hasattr(self.o, 'delete_source') and self.o.delete_source ) or \

--- a/sarracenia/flowcb/work/add_inline.py
+++ b/sarracenia/flowcb/work/add_inline.py
@@ -1,0 +1,37 @@
+'''
+Description
+--------------------------------
+
+    Add file contents `inline` (or inside) the sarracenia message after work has been completed.
+    As of July 2025, sarracenia will only add the file contents in the sarracenia message 
+    from the built-in gather entry point (flowcb.gather.file.py). 
+
+    This plugin allows us to place the recently downloaded data into the sarracenia message. 
+    We'd want to do this in the case a client would prefer to have the data included in the message, 
+    instead of providing a link for downloading.
+
+Usage
+--------------------------------
+
+    This plugin is already being invoked from the list of flow callbacks when the ``inline`` option 
+    is set to True.
+    
+
+'''
+
+from sarracenia.flowcb import FlowCB
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Add_inline(FlowCB):
+    def __init__(self, options):
+        super().__init__(options,logger)
+        self.o = options
+
+    def after_work(self, worklist):
+
+        for msg in worklist.ok:
+            if 'content' not in msg:
+                msg.putContentInline(self.o)


### PR DESCRIPTION
…r components.

* I've only tested the functionality with a sarra component, and it seems to have worked well.
* I'm not sure what we should do if we can't find the size of the message? I just put in the code that we wouldn't add the file contents inside of the sarracenia message.
   * There might be a simple way (a method that already exists?) to get extract the file size.
* I know @petersilva mentionned using `putContent` as the method name, but I think `putContentInline` is better because the scope of the work is limited to the data only being inline.