### PR TITLE
Remove comment from dd_citypage example

### DIFF
--- a/sarracenia/examples/subscribe/dd_aacn_bulletins.conf
+++ b/sarracenia/examples/subscribe/dd_aacn_bulletins.conf
@@ -1,0 +1,25 @@
+# Get the AACN01 bulletins
+ 
+broker amqps://anonymous:anonymous@dd.weather.gc.ca/
+
+# Using HPFX:
+# broker amqps://anonymous:anonymous@hpfx.collab.science.gc.ca
+
+subtopic *.WXO-DD.bulletins.alphanumeric.*.AA.CWAO.#
+
+# expire, in operations should be longer than longest expected interruption
+# lifetime of the queue on the server. For operational use, increase to 1d (1jour)
+expire 10m
+ 
+# instances, number of download processes to run. function of latency and bandwidth.
+# increase if you see lag.
+instances 2
+
+# only accept files matching the accept statement below, ignore others
+# accepter uniquement les fichiers correspondant à l'instruction accept ci-dessous, ignorer les autres
+acceptUnmatched False
+
+mirror True 
+
+directory /tmp/
+accept .*AACN01.*

--- a/sarracenia/examples/subscribe/dd_citypage.conf
+++ b/sarracenia/examples/subscribe/dd_citypage.conf
@@ -18,8 +18,6 @@ instances 2
 #   durée de vie du file d´attente sur le serveur.  Pour usage opérationnel, augmentez a 1d (1 jour.)
 expire 10m
 
-# need to avoid citypage/xml directory with data that gets corrupted. old feed still active
-# until mid 2025... after that, can replace all the subdirs with *
 subtopic *.WXO-DD.citypage_weather.AB.*
 subtopic *.WXO-DD.citypage_weather.BC.*
 subtopic *.WXO-DD.citypage_weather.HEF.*

--- a/sarracenia/examples/subscribe/dd_rdps.conf
+++ b/sarracenia/examples/subscribe/dd_rdps.conf
@@ -28,4 +28,9 @@ expire 10m
 # new topic... in 2025
 subtopic *.WXO-DD.model_gem_regional.10km.grib2.#
 
-director /tmp/dd_rdps
+# only accept files matching the accept statement below, ignore others
+# accepter uniquement les fichiers correspondant à l'instruction accept ci-dessous, ignorer les autres
+acceptUnmatched False
+
+directory /tmp/dd_rdps
+accept .*MSC_RDPS_(AirTemp_AGL-2m|WindSpeed_IsbL-0500|Pressure_Sfc)_RLatLon0.09_.*\.grib2


### PR DESCRIPTION
If a user uses `subtopic *.WXO-DD.citypage_weather.*.*` they will also get mp3 files: https://dd.weather.gc.ca/citypage_weather/mp3/

So I think it's better to permanently keep the example the way it is now.