### PR TITLE
Add metrics when checking if instance is hung #1480

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -540,7 +540,7 @@ class sr_GlobalState:
                                         self.states[c][cfg]['instance_metrics'] = {}
                                     try:
                                         self.states[c][cfg]['instance_metrics'][i] = json.loads(t)
-                                        self.states[c][cfg]['instance_metrics'][i]['status'] = { 'mtime':os.stat(p).st_mtime }
+                                        self.states[c][cfg]['instance_metrics'][i]['status'] = { 'mtime':ageOfFile(p) }
                                     except:
                                         logger.error( f"corrupt metrics file {pathname}: {t}" )
 
@@ -578,7 +578,7 @@ class sr_GlobalState:
                     t = f.read().strip()
 
                 self.states[c][cfg]['instance_metrics'][i] = json.loads(t)
-                self.states[c][cfg]['instance_metrics'][i]['status'] = { 'mtime':os.stat(p).st_mtime }
+                self.states[c][cfg]['instance_metrics'][i]['status'] = { 'mtime':ageOfFile(p) }
             except:
                 logger.error( f"corrupt metrics file {dir1+os.sep+l}: {t}" )
 
@@ -1062,10 +1062,15 @@ class sr_GlobalState:
                             resource_usage[ 'system_cpu' ] += self.procs[pid]['cpu']['system'] 
                             self.resources[ 'system_cpu' ] += self.procs[pid]['cpu']['system'] 
 
+                            # GitHub 1480 - Add metrics check to verify if instance is hung
                             if ('logAge' in self.states[c][cfg]) and (i in self.states[c][cfg]['logAge'] ) and \
-                                    ( self.states[c][cfg]['logAge'][i] > self.configs[c][cfg]['options'].runStateThreshold_hung ):
-                                hung_instances += 1
-                                self.states[c][cfg]['hung_instances'].append(i)
+                                    (('instance_metrics' in self.states[c][cfg]) and (i in self.states[c][cfg]['instance_metrics'] ) and \
+                                    ('status' in self.states[c][cfg]['instance_metrics'][i] )):
+                                # Metrics file and log file need to both be outdated to have an instance be marked as hung
+                                if ( now - self.states[c][cfg]['instance_metrics'][i]['status']['mtime'] > self.configs[c][cfg]['options'].runStateThreshold_hung ) and \
+                                    ( self.states[c][cfg]['logAge'][i] > self.configs[c][cfg]['options'].runStateThreshold_hung):
+                                    hung_instances += 1
+                                    self.states[c][cfg]['hung_instances'].append(i)
 
                     if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'starting', 'shutdown', 'running' ]:
                         flow_status = self.configs[c][cfg]['status']


### PR DESCRIPTION
* Hung instances only get flagged when both the log file and the metrics file aren't updating. The example config below pulls data from `dd.weather.gc.ca` and has `logLevel error` in its options. 

```
leblanca@dirt22-3:~/.cache/sr3/log$ sr3 show subscribe/issue1480 | grep hung
'runStateThreshold_hung': 450,

leblanca@dirt22-3:~/.cache/sr3/log$ date
Mon Aug 25 05:43:50 PM UTC 2025

# No errors in logs
leblanca@dirt22-3:~/.cache/sr3/log$ ls -al subscribe_issue1480_0*.log
-rw------- 1 leblanca leblanca 182356 Aug 25 17:34 subscribe_issue1480_01.log
-rw------- 1 leblanca leblanca 176293 Aug 25 17:34 subscribe_issue1480_02.log
-rw------- 1 leblanca leblanca 160432 Aug 25 17:34 subscribe_issue1480_03.log
-rw------- 1 leblanca leblanca 156813 Aug 25 17:34 subscribe_issue1480_04.log
-rw------- 1 leblanca leblanca 200669 Aug 25 17:34 subscribe_issue1480_05.log

leblanca@dirt22-3:~/.cache/sr3/metrics$ ls -al subscribe_issue1480_0*.json
-rw-r--r-- 1 leblanca leblanca 1092 Aug 25 17:43 subscribe_issue1480_01.json
-rw-r--r-- 1 leblanca leblanca 1072 Aug 25 17:43 subscribe_issue1480_02.json
-rw-r--r-- 1 leblanca leblanca 1053 Aug 25 17:43 subscribe_issue1480_03.json
-rw-r--r-- 1 leblanca leblanca 1069 Aug 25 17:43 subscribe_issue1480_04.json
-rw-r--r-- 1 leblanca leblanca 1056 Aug 25 17:43 subscribe_issue1480_05.json


leblanca@dirt22-3:~/.cache/sr3/log$ sr3 status | grep issue1480
subscribe/issue1480               idle    5/5    0    0    3.16s     1.06s    0.0%     0m/s   1.6KiB/s

# When the metrics file is older then runStateThreshold_hung, the hung status is properly set

leblanca@dirt22-3:~/.cache/sr3/metrics$ touch -t 202508251600.00 subscribe_issue1480_01.json && sr3 status | grep issue1480
subscribe/issue1480               hung    5/5    0    0    2.60s     4.68s    0.0%     0m/s   1.3KiB/s
```