### PR TITLE
make rejected log (when report is set) match accepted/other rejected log

### DIFF
--- a/sarracenia/flowcb/log.py
+++ b/sarracenia/flowcb/log.py
@@ -161,9 +161,8 @@ class Log(FlowCB):
         if set(['reject']) & self.o.logEvents:
             for msg in worklist.rejected:
                 if 'report' in msg:
-                    logger.info(
-                        "%s rejected: %d %s " %
-                        (msg['relPath'], msg['report']['code'], msg['report']['message']))
+                    logger.info("rejected: %s (%d: %s)" % (
+                        self._messageAcceptStr(msg), msg['report']['code'], msg['report']['message']))
                 else:
                     logger.info("rejected: %s " % self._messageAcceptStr(msg))
         


### PR DESCRIPTION
This inconsistency bothered me, but it was also problematic because it prevented us from seeing the baseUrl in the rejected messages, which is often important.

Accepted log messages look like this:

```
2025-08-27 18:18:34,528 [INFO] sarracenia.flowcb.log after_accept accepted: (lag: 0.18 )  exchange: xs_WINNOW subtopic: dms-dev.nws.observation.atmospheric.surface_weather.avipads_hourly-1.0-ascii.product-wxo_xml-1.0 a file with baseUrl: http://server1:8180 relPath: /data/nws/observation/atmospheric/surface_weather/avipads_hourly-1.0-ascii/product-wxo_xml-1.0/202508271815/konz/none/auto/nws/orig sundew_extension: DMS:CMC:AVIPADS-HOURLYOBS:XML: rename: konz.202508271815.hourly_avipads.xml~20250827181500000-orig id: b482d15 size: 3038
```

Rejected log messages used to look like this:

```
2025-08-27 00:00:46,426 [INFO] sarracenia.flowcb.log after_accept /data/msc/observation/atmospheric/surface_weather/avipads_hourly-1.0-ascii/product-wxo_xml-1.0/202508262357/8501106/yca/nl/auto/nc/orig rejected: 304 Not modified 1 (nodupe check)
```

Now rejected log messages look almost the same as accepted. This lets us see the baseUrl, rename field, etc. It still includes the report code and message at the end. 

```
2025-08-27 18:21:38,527 [INFO] sarracenia.flowcb.log after_accept rejected:  exchange: xs_WINNOW subtopic: dms-dev.nws.observation.atmospheric.surface_weather.avipads_hourly-1.0-ascii.product-wxo_xml-1.0 a file with baseUrl: http://server2:8180 relPath: /data/nws/observation/atmospheric/surface_weather/avipads_hourly-1.0-ascii/product-wxo_xml-1.0/202508271815/konz/none/auto/nws/orig sundew_extension: DMS:CMC:AVIPADS-HOURLYOBS:XML: rename: konz.202508271815.hourly_avipads.xml~20250827181500000-orig id: b482d15 size: 3038  (304: Not modified 1 (nodupe check))