### PR TITLE
wmo2msc fixes

### DIFF
--- a/sarracenia/flowcb/filter/wmo2msc.py
+++ b/sarracenia/flowcb/filter/wmo2msc.py
@@ -312,10 +312,9 @@ class Wmo2msc(FlowCB):
                 d.write(self.bintxt)
                 d.close()
 
-            # need to recalculate checksum (identity) and update size when file is converted
-            if self.o.filter_wmo2msc_convert:
-                message.computeIdentity(output_file, self.o, offset=0, data=self.bintxt)
-                msg['size'] = len(self.bintxt)
+            # need to recalculate checksum (identity) and update size
+            message.computeIdentity(output_file, self.o, offset=0, data=self.bintxt)
+            msg['size'] = len(self.bintxt)
 
             logger.info('%s -> %s (%s)' % (input_file, output_file, fmt))
 

--- a/sarracenia/flowcb/filter/wmo2msc.py
+++ b/sarracenia/flowcb/filter/wmo2msc.py
@@ -312,9 +312,10 @@ class Wmo2msc(FlowCB):
                 d.write(self.bintxt)
                 d.close()
 
-            # need to recalculate checksum (identity) when file is converted
+            # need to recalculate checksum (identity) and update size when file is converted
             if self.o.filter_wmo2msc_convert:
                 message.computeIdentity(output_file, self.o, offset=0, data=self.bintxt)
+                msg['size'] = len(self.bintxt)
 
             logger.info('%s -> %s (%s)' % (input_file, output_file, fmt))
 


### PR DESCRIPTION
This PR is more work on the wmo2msc plugin. I accidentally pushed the initial changes directly to development, but they can be seen here: https://github.com/MetPX/sarracenia/commit/e8cec2007b148aee847ac8c5469c36400b6d2948#r165823070

@andreleblanc11 noticed that the size in the message also needs to be updated after converting.

Then I realized that even when we have conversion disabled, some things still get replaced anyways (binary bulletins always have `\r` removed), so now it always updates the size and recalculates the checksum.