### PR TITLE
#1504 honor post_exchange in posting components as binding for subscr…

### DIFF
--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -22,6 +22,9 @@ class Subscription(dict):
                 exchange = 'xs_%s' % options.broker.url.username
 
             if options.component in [ 'poll', 'post', 'watch' ]:
+                if hasattr(options,'post_exchange') and options.post_exchange:
+                    exchange = options.post_exchange
+
                 if hasattr(options,'post_exchangeSuffix') and options.post_exchangeSuffix:
                     exchange += '_%s' % options.post_exchangeSuffix
 


### PR DESCRIPTION

The new *Subscription* class was missing code to honour the "post_exchange" argument when running poll,post, or watch (the posting components.)

