### PR TITLE
Issue1495 - Changes in checksum algorithm on download

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -554,7 +554,10 @@ class Message(dict):
         logger.debug( f"mtime persisted, calc_method: {calc_method}" )
 
         if calc_method[:4] == 'cod,' and len(calc_method) > 2:
-            sumstr = calc_method
+            sumstr = {
+                    'method' : 'cod',
+                    'value': calc_method[4:]
+                    }
         elif calc_method in [ 'md5name', 'invalid' ]:
             xattr.persist()  # persist the mtime, at least...
             return  # no checksum needed for md5name. 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2309,13 +2309,18 @@ class Flow:
             # FIXME  locking for i parts in temporary file ... should stay lock
             # and file_reassemble... take into account the locking
 
-            if self.o.identity_method.startswith('cod,'):
-                download_algo = self.o.identity_method[4:]
-            elif 'identity' in msg:
+            # First try to fetch identity from the incoming message
+            if 'identity' in msg:
                 if msg['identity']['method'] == 'cod':
                     download_algo = msg['identity']['value']
+                elif msg['identity']['method'].startswith('cod,'):
+                    download_algo = msg['identity']['method'][4:]
                 else:
-                    download_algo = msg['identity']['method']
+                    # Don't try re-calculating checksum if method doesn't include "cod"
+                    download_algo = None
+            # Assign whatever is set in the configuration if identity isn't found in incoming message.
+            elif self.o.identity_method != None:
+                download_algo = self.o.identity_method
             else:
                 download_algo = None
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2315,10 +2315,11 @@ class Flow:
                     download_algo = msg['identity']['value']
                 elif msg['identity']['method'].startswith('cod,'):
                     download_algo = msg['identity']['method'][4:]
+                # Algo not cod, get value from method field.
                 else:
-                    # Don't try re-calculating checksum if method doesn't include "cod"
-                    download_algo = None
-            # Assign whatever is set in the configuration if identity isn't found in incoming message.
+                    # We want to re-calculate the checksum to compare with the value that was advertised from the message.
+                    download_algo = msg['identity']['method']
+            # Assign whatever is set in the configuration if identity isn't found in the incoming message.
             elif self.o.identity_method != None:
                 download_algo = self.o.identity_method
             else:
@@ -2442,8 +2443,17 @@ class Flow:
                 msg['onfly_checksum'] = self.proto[self.scheme].get_sumstr()
                 msg['data_checksum'] = self.proto[self.scheme].data_checksum
 
-                if self.o.identity_method.startswith('cod,') and not accelerated:
+                if ('identity' in msg and msg['identity']['method'].startswith('cod') or ('identity' not in msg and 'cod' not in self.o.identity_method)) and not accelerated:
+                    # if 'identity' in msg and msg['identity']['value'] != msg['onfly_checksum']['value']:
+                    #     logger.warning("Onfly checksum differs from checksum found in sarracenia message. Will overwrite message with onfly_checksum value.")
+                    #     logger.debug(f"Onfly checksum: {msg['onfly_checksum']} ; Checksum from incoming sarracenia message {msg['identity']}")
                     msg['identity'] = msg['onfly_checksum']
+                # If no incoming checksum in message and have cod in options, add cod checksum to message.
+                elif 'identity' not in msg and 'cod' in self.o.identity_method:
+                    msg['identity'] = {
+                            'method' : 'cod',
+                            'value': download_algo[4:]
+                            }
 
                 msg['_deleteOnPost'] |= set(['onfly_checksum'])
                 msg['_deleteOnPost'] |= set(['data_checksum'])

--- a/tests/sarracenia/__init___test.py
+++ b/tests/sarracenia/__init___test.py
@@ -209,7 +209,7 @@ class Test_Message():
         options.identity_method = 'cod,testname'
         del(msg['identity'])
         msg.computeIdentity(path4, options)
-        assert msg['identity'] == 'cod,testname'
+        assert msg['identity'] == {'method': 'cod', 'value': 'testname'}
 
         try:
             import xattr


### PR DESCRIPTION
This PR addresses the use case initially presented in #1495 and proposes the following checksum algorithm upon download (this was tested with a watch + sarra on my test environment)

Identity in incoming message | Sarra component `identity_method`   | Behaviour during posting
-- | -- | --
cod,method | None | method checksum gets posted in the message. COD does its job.
cod,method1 | method2 | method1 checksum gets posted in the message. COD does its job.
cod,method1 | cod,method2 | method1 checksum gets posted in the message. identity_method in subscriber is ignored.
None | None | Advertise no checksum.
None | method | method checksum gets posted in the message.
None | cod,method | cod,method checksum gets posted in the message.
method1 | cod,method2 | method1 gets posted in the message. identity_method in subscriber is ignored.
method1 | method2 | method1 gets posted in the message
method | None | method gets posted in the message.

This behaviour gives priority in the checksum **from the incoming message**. If the identity is not provided in the message, we fallback to the method that is provided in the configuration.

This algorithm covers most of what @reidsunderland proposed in this comment , https://github.com/MetPX/sarracenia/issues/1495#issuecomment-3276667330. It follows the defaults he proposed for the `identityFromMessage` option. 

This PR doesn't give the flexibility with the configuration option `identityFromMessage`, but I think it should be easier to implement this option if ever we would want to later.

I also provided a patch for #1509 because I needed it for my tests.
