### PR TITLE
Be able to rename the attachment

### DIFF
--- a/sarracenia/flowcb/send/email.py
+++ b/sarracenia/flowcb/send/email.py
@@ -160,7 +160,7 @@ class Email(FlowCB):
                 emsg.attach(emsg_text)
                 with open(ipath, 'rb') as fp:
                     attachment_data = fp.read()
-                attachment = MIMEApplication(attachment_data, name=os.path.basename(ipath))
+                attachment = MIMEApplication(attachment_data, name=msg['new_file'])
                 # Add the attachment data to the email
                 emsg.attach(attachment)
             else:


### PR DESCRIPTION
If we don't use msg['new_file'] we can't rename the attached file. The source file is always used.

I tested with `filename WHATFN` with a file that had sundew headers and it worked.