### PR TITLE
always show filename option in masks

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1118,7 +1118,7 @@ class Config:
         s = 'accept' if accepting else 'reject'
         if pstrip : strip=pstrip
         strip = '' if strip == 0 else f' strip:{strip}'
-        fn = '' if (maskFileOption == 'WHATFN') else f' filename:{maskFileOption}'
+        fn = f' filename:{maskFileOption}'
         flatten = '' if flatten == '/' else f' flatten:{flatten}'
         w = 'with ' if fn or flatten or strip else ''
         args = '' if len(args) == 0 else ' args:' + str(args)


### PR DESCRIPTION
I think `filename WHATFN` used to be the default option, so I assume that is why there was a special case to not show it in the masks.

But the default filename is now None, and it's really confusing to not see WHATFN in the masks when running `sr3 show`. 

I didn't change the special case to None, I just got rid of it. I think it's less confusing to see exactly what the value is in every possible case.