### PR TITLE
Add fix for #1523

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -190,7 +190,7 @@ class Ftp(Transfer):
 
         try:
             old_ftp.quit()
-        except EOFError:
+        except (EOFError, ftplib.error_temp):
             # FTP quit will try to politely close the connection.
             # Sometimes the client will already have the connection closed.
             # We should close the connection permanently from our end when this happens.


### PR DESCRIPTION
The patch complies with ftplib's best practices. Execute a `close()`  after an exception is raised from `quit()`.

https://docs.python.org/3/library/ftplib.html#ftplib.FTP.quit