### PR TITLE
Issue1525 fix AMQP not obeying tlsRigour

### DIFF
--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -140,10 +140,11 @@ class DiskQueue():
             self.new_fp = open(self.new_path, 'a')
 
         for message in message_list:
-            logger.debug("DEBUG add to new file %s %s" %
-                         (os.path.basename(self.new_path), message))
+            #logger.debug("DEBUG add to new file %s %s" %
+            #             (os.path.basename(self.new_path), message))
             self.new_fp.write(self.msgToJSON(message))
             self.msg_count_new += 1
+            logger.debug( f"DEBUG new file {os.path.basename(self.new_path)} +1 = {self.msg_count_new}" )
         self.new_fp.flush()
 
     def cleanup(self):
@@ -433,7 +434,7 @@ class DiskQueue():
                 fp, message = self.msg_get_from_file(fp, self.new_path)
                 if not message: break
                 i = i + 1
-                logger.debug("DEBUG message %s" % message)
+                #logger.debug("DEBUG message %s" % message)
                 if not self.needs_requeuing(message): continue
 
                 #logger.debug("MG DEBUG flush retry to state %s" % message)

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import ssl
 import sys
 import time
 from sarracenia.featuredetection import features
@@ -303,6 +304,7 @@ class Moth():
             cls_subclasses = cls_subclasses.union(Moth.findAllSubclasses(sc))
         return cls_subclasses
 
+
     def __init__(self, props=None, is_subscriber=True) -> None:
         """
            If is_subscriber=True, then this is a consuming instance.
@@ -405,6 +407,66 @@ class Moth():
         """
         logger.error("implementation missing!")
         return False
+
+    def _sslClientSetup(self,client=None) -> int:
+        """
+          Initializse client SSL context, must be called after self.client is instantiated.
+          return port number for connection.
+      
+        """
+        if not client and hasattr(self,'client'):
+            client=self.client
+
+        if self.is_subscriber and 'subscriptions' in self.o and self.o['subscriptions']:
+            s=self.o['subscriptions'][self.o['subscription_index']]
+            queue=s['queue']
+            broker=s['broker']
+        else:
+            broker=self.o['broker']
+            queue=self.o
+
+        if broker.url.scheme[-1] == 's':
+            if broker.url.scheme[0] in [ 'a' ]:
+                port = 5671
+            else:
+                port = 8883
+            if 'tlsRigour' in queue:
+                queue['tlsRigour'] = queue['tlsRigour'].lower()
+            elif 'tlsRigour' in self.o:
+                queue['tlsRigour'] = self.o['tlsRigour'].lower()
+            else:
+                queue['tlsRigour'] = 'normal'
+
+            if queue['tlsRigour'] == 'lax':
+                self.tlsctx = ssl.create_default_context()
+                self.tlsctx.check_hostname = False
+                self.tlsctx.verify_mode = ssl.CERT_NONE
+
+            elif queue['tlsRigour'] == 'strict':
+                self.tlsctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
+                self.tlsctx.options |= ssl.OP_NO_TLSv1
+                self.tlsctx.options |= ssl.OP_NO_TLSv1_1
+                self.tlsctx.check_hostname = True
+                self.tlsctx.verify_mode = ssl.CERT_REQUIRED
+                self.tlsctx.load_default_certs()
+                # TODO Find a way to reintroduce certificate revocation (CRL) in the future
+                #  self.tlsctx.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
+                #  https://github.com/MetPX/sarracenia/issues/330
+            elif queue['tlsRigour'] == 'normal':
+                self.tlsctx = ssl.create_default_context()
+            else:
+                self.logger.warning(
+                    f"option tlsRigour must be one of: lax, normal, strict")
+        else:
+            self.tlsctx=None
+            if broker.url.scheme[0] in [ 'a' ]:
+                port = 5672
+            else:
+                port = 1883
+
+        if broker.url.port:
+            port = broker.url.port
+        return port
 
     def metricsReset(self) -> None:
         self.metrics['disconnectLast'] = 0

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -209,14 +209,9 @@ class AMQP(Moth):
           Expect caller to handle errors.
         """
         if broker.url.hostname:
-            host = broker.url.hostname
-            if broker.url.port is None:
-                if (broker.url.scheme[-1] == 's'):
-                    host += ':5671'
-                else:
-                    host += ':5672'
-            else:
-                host += ':{}'.format(broker.url.port)
+            host = f"{broker.url.hostname}:{self._sslClientSetup()}"
+
+
         else:
             logger.critical( f"invalid broker specification: {broker} " )
             return False
@@ -234,7 +229,7 @@ class AMQP(Moth):
                                               broker.url.password),
                                           login_method=broker.login_method,
                                           virtual_host=vhost,
-                                          ssl=(broker.url.scheme[-1] == 's'),
+                                          ssl=self.tlsctx,
                                           client_properties={'product':'MetPX Sarracenia (sr3)',
                                                              'product_version':sarracenia.__version__,
                                                             }

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -34,7 +34,6 @@ import sarracenia
 from sarracenia.postformat import PostFormat
 from sarracenia.moth import Moth
 import os
-import ssl
 import threading
 import time
 from urllib.parse import unquote
@@ -204,6 +203,12 @@ class MQTT(Moth):
       
         logger.warning("note: mqtt support is newish, not very well tested")
 
+    def _sslClientSetup(self,client=None) -> int:
+        port=super()._sslClientSetup()
+        if self.tlsctx:
+            self.client.tls_set_context(self.tlsctx)
+        return port
+   
     def __sub_on_disconnect(client, userdata, mid, reason_code, properties=None):
         userdata.metricsDisconnect()
         logger.debug(reason_code)
@@ -300,61 +305,6 @@ class MQTT(Moth):
             userdata.unexpected_publishes.append(mid)
             logger.warning( f"BUG: ack for message we do not know we published. mid={mid}" )
 
-    def __sslClientSetup(self,client=None) -> int:
-        """
-          Initializse client SSL context, must be called after self.client is instantiated.
-          return port number for connection.
-      
-        """
-        if not client and hasattr(self,'client'):
-            client=self.client
-
-        if self.is_subscriber and 'subscriptions' in self.o and self.o['subscriptions']:
-            s=self.o['subscriptions'][self.o['subscription_index']]
-            queue=s['queue']
-            broker=s['broker']
-        else:
-            broker=self.o['broker']
-            queue=self.o
-
-        if broker.url.scheme[-1] == 's':
-            port = 8883
-            if 'tlsRigour' in queue:
-                queue['tlsRigour'] = queue['tlsRigour'].lower()
-            elif 'tlsRigour' in self.o: 
-                queue['tlsRigour'] = self.o['tlsRigour'].lower()
-            else:
-                queue['tlsRigour'] = 'normal'
-
-            if queue['tlsRigour'] == 'lax':
-                self.tlsctx = ssl.create_default_context()
-                self.tlsctx.check_hostname = False
-                self.tlsctx.verify_mode = ssl.CERT_NONE
-
-            elif queue['tlsRigour'] == 'strict':
-                self.tlsctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
-                self.tlsctx.options |= ssl.OP_NO_TLSv1
-                self.tlsctx.options |= ssl.OP_NO_TLSv1_1
-                self.tlsctx.check_hostname = True
-                self.tlsctx.verify_mode = ssl.CERT_REQUIRED
-                self.tlsctx.load_default_certs()
-                # TODO Find a way to reintroduce certificate revocation (CRL) in the future
-                #  self.tlsctx.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
-                #  https://github.com/MetPX/sarracenia/issues/330
-            elif queue['tlsRigour'] == 'normal':
-                self.tlsctx = ssl.create_default_context()
-            else:
-                self.logger.warning(
-                    f"option tlsRigour must be one of: lax, normal, strict")
-
-            client.tls_set_context(self.tlsctx)
-        else:
-            port = 1883
-
-        if broker.url.port:
-            port = broker.url.port
-        return port
-
     def __clientSetup(self, cid) -> paho.mqtt.client.Client:
 
         s=self.o['subscriptions'][self.o['subscription_index']]
@@ -428,7 +378,7 @@ class MQTT(Moth):
             logger.info( f"is no around? {self.o['no']} " )
             if ('no' in self.o) and self.o['no'] > 0: # instances 'started'
                 self.client = self.__clientSetup(cid)
-                self.client.connect( broker.url.hostname, port=self.__sslClientSetup(), \
+                self.client.connect( broker.url.hostname, port=self._sslClientSetup(),
                        clean_start=False, properties=props )
                 self.client.enable_logger(logger)
                 self.client.loop_start()
@@ -452,7 +402,7 @@ class MQTT(Moth):
                     logger.info( f"declare session for instances {icid}" )
                     self.client = self.__clientSetup(icid)
                     self.client.on_connect = MQTT.__sub_on_connect
-                    self.client.connect( broker.url.hostname, port=self.__sslClientSetup(self.client), \
+                    self.client.connect( broker.url.hostname, port=self._sslClientSetup(),
                        clean_start=False, properties=props )
                     while (self.connect_in_progress) or (self.subscribe_in_progress > 0):
                         logger.info( f"waiting ({ebo} seconds) for broker to confirm subscription is set up.")
@@ -518,7 +468,7 @@ class MQTT(Moth):
                                         unquote(self.o['broker'].url.password))
             self.connect_in_progress = True
             res = self.client.connect_async(self.o['broker'].url.hostname,
-                                      port=self.__sslClientSetup(),
+                                      port=self._sslClientSetup(),
                                      properties=props)
             logger.info( f"connecting to {self.o['broker'].url.hostname}, res={res}" )
  
@@ -577,7 +527,7 @@ class MQTT(Moth):
                 icid= queue['name'] + "_i%02d" % i
                 logger.info( f"cleanup session {icid}" )
                 myclient = self.__clientSetup( icid )
-                myclient.connect( broker.url.hostname, port=self.__sslClientSetup(myclient), \
+                myclient.connect( broker.url.hostname, port=self._sslClientSetup(myclient),
                    clean_start=False, properties=props )
                 while self.connect_in_progress:
                     myclient.loop(0.1)


### PR DESCRIPTION
The functionality to have message queuing protocols was already present in the MQTT driver.
The AMQP protocol code, which is over 10 years old, was from a time when the *ssl* argument to the routine creating a connection accepted only a boolean, I think... or maybe it was just ok to give a boolean, and I (or Michel?) didn't bother at the time.

Anyways, nowadays, the AMQP routine accepts a TLS Context as an argument, so we can provide that similarly to how it is done for MQTT.  It is so similar, that we just move the code from mqtt.py to the parent moth class, and call it from both.

There's a weirdness where in AMQP they want to call the SSL routine *tls_set_context(s...* on the context, so if it is done before, AMQP barfs.  MQTT needed a little extra to keep the call in for it (hence the override in the child class.)

Anyways, it should do what is expected.