### PR TITLE
Add CPU time threshold for #1528

### DIFF
--- a/docs/source/Explanation/SarraPluginDev.rst
+++ b/docs/source/Explanation/SarraPluginDev.rst
@@ -177,14 +177,23 @@ on their __init__() routines::
       """
            options can be declared in any plugin. There are various *kind* of options, where the declared type modifies the parsing.
            
-           'count'      integer count type. 
+           'count'      integer count type.
+           'octal'      base-8 (octal) integer type.
            'duration'   a floating point number indicating a quantity of seconds (0.001 is 1 milisecond)
-                        modified by a unit suffix ( m-minute, h-hour, w-week ) 
+                        modified by a unit suffix ( m-minute, h-hour, w-week )
            'flag'       boolean (True/False) option.
+           'float'      a simple floating point number.
+
            'list'       a list of string values, each succeeding occurrence catenates to the total.
                         all v2 plugin options are declared of type list.
+
+           'set'        a set of string values, each succeeding occurrence is unioned to the total.
+                        if all_values is provided, then constrain set to that.
+
            'size'       integer size. Suffixes k, m, and g for kilo, mega, and giga (base 2) multipliers.
-           'str'        an arbitrary string value, as will all of the above types, each succeeding occurrence overrides the previous one.
+
+           'str'        an arbitrary string value, as will all of the above types, each
+                        succeeding occurrence overrides the previous one.
            
       """
 

--- a/docs/source/fr/Explication/SarraPluginDev.rst
+++ b/docs/source/fr/Explication/SarraPluginDev.rst
@@ -164,15 +164,23 @@ ou flowcb accepte comme paramètre _options_ dans leurs routines __init__() ::
       """
            options can be declared in any plugin. There are various *kind* of options, where the declared type modifies the parsing.
            
-           'count'      integer count type. 
+           'count'      integer count type.
+           'octal'      base-8 (octal) integer type.
            'duration'   a floating point number indicating a quantity of seconds (0.001 is 1 milisecond)
-                        modified by a unit suffix ( m-minute, h-hour, w-week ) 
+                        modified by a unit suffix ( m-minute, h-hour, w-week )
            'flag'       boolean (True/False) option.
+           'float'      a simple floating point number.
+
            'list'       a list of string values, each succeeding occurrence catenates to the total.
                         all v2 plugin options are declared of type list.
+
+           'set'        a set of string values, each succeeding occurrence is unioned to the total.
+                        if all_values is provided, then constrain set to that.
+
            'size'       integer size. Suffixes k, m, and g for kilo, mega, and giga (base 2) multipliers.
-           'str'        an arbitrary string value, as will all of the above types, each succeeding occurrence overrides the previous one.
-           
+
+           'str'        an arbitrary string value, as will all of the above types, each
+                        succeeding occurrence overrides the previous one.
       """
 
 L’exemple ci-dessus définit une option "accel\_wget\_command"

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -50,11 +50,12 @@ class Resources(FlowCB):
     def __init__(self, options):
         super().__init__(options,logger)
         # Set option to neg value to determine if user set in config
+        self.o.add_option('CpuTimeMax', 'float', '0')
         self.o.add_option('MemoryMax', 'size', '0')
         self.o.add_option('MemoryBaseLineFile', 'count', 100)
         self.o.add_option('MemoryMultiplier', 'float', 3)
 
-        self.threshold = None
+        self.threshold_memory = None
         ''' Per-process maximum memory footprint that is considered too large, forcing a process restart.'''
         self.transferCount = 0
         self.msgCount = 0
@@ -66,15 +67,16 @@ class Resources(FlowCB):
             mem = 0
 
         ost = os.times()
+        cpu_system_time = ost.system
         logger.info(f"Current cpu_times: user={ost.user} system={ost.system}")
 
         # We must set a threshold **after** the config file has been parsed.
-        if self.threshold is None:
+        if self.threshold_memory is None:
             # If the config set something, use it.
             if self.o.MemoryMax != 0:
-                self.threshold = self.o.MemoryMax
+                self.threshold_memory = self.o.MemoryMax
 
-            if self.threshold is None:
+            if self.threshold_memory is None:
                 # No user input set, now to figure out what our baseline memory usage is at a steady state
                 #   Process MemoryBaseLineFile(s)+ then get a memory reading before setting memory restart threshold.
                 if (self.transferCount < self.o.MemoryBaseLineFile) and (
@@ -86,16 +88,28 @@ class Resources(FlowCB):
                         f"before self-setting threshold")
                     return True
 
-                self.threshold = int(self.o.MemoryMultiplier * mem)
+                self.threshold_memory = int(self.o.MemoryMultiplier * mem)
 
-            logger.info(f"Memory threshold set to: {naturalSize(self.threshold)}")
+
+            logger.info(f"Memory threshold set to: {naturalSize(self.threshold_memory)}")
 
         logger.info(
             f"Current Memory usage: {naturalSize(mem)} / "
-            f"{naturalSize(self.threshold)} = {(mem/self.threshold):.2%}"
+            f"{naturalSize(self.threshold_memory)} = {(mem/self.threshold_memory):.2%}"
         )
 
-        if mem > self.threshold:
+        if self.o.CpuTimeMax != 0:
+            logger.info(f"Current CPU time usage: {cpu_system_time}. CPU time threshold: {self.o.CpuTimeMax}.")
+
+        if mem > self.threshold_memory:
+            logger.info(
+                f"Memory threshold surpassed! Triggering a restart for '{sys.argv}' via '{sys.executable}'"
+            )
+            self.restart()
+        elif self.o.CpuTimeMax != 0 and cpu_system_time > self.o.CpuTimeMax:
+            logger.info(
+                f"CPU threshold surpassed! Triggering a restart for '{sys.argv}' via '{sys.executable}'"
+            )
             self.restart()
         # self.restart()
 
@@ -106,9 +120,6 @@ class Resources(FlowCB):
         Do an in-place restart of the current process (keeps pid).
         Gets a new memory stack/heap, keeps all file descriptors but replaces the buffers.
         """
-        logger.info(
-            f"Memory threshold surpassed! Triggering a restart for '{sys.argv}' via '{sys.executable}'"
-        )
         # First arg must be the program to be run (absolute path to program)
         # Second arg has to be python for windows, see how this affects the linux side of things..
         # Third arg is the name of the program you wish to run (should be full path to script) plus all the args.
@@ -134,10 +145,10 @@ class Resources(FlowCB):
 
     def after_work(self, worklist):
         self.transferCount += len(worklist.ok)
-        # if self.threshold is not None:
+        # if self.threshold_memory is not None:
         #    TODO: Remove this callback when issue #444 is implemented
 
     def after_accept(self, worklist):
         self.msgCount += len(worklist.incoming)
-        # if self.threshold is not None:
+        # if self.threshold_memory is not None:
         #    TODO: Remove this callback when issue #444 is implemented


### PR DESCRIPTION
* Also add most recent add_option option types in some documentation pages.
( I didn't bother with the french translation. It was already un-translated before)

***

I added the CPU threshold. It tracks the system CPU time of the process, and will restart it if `CpuTimeMax` is reached.
If `CpuTimeMax` is omitted, the restart logic gets also omitted.

I tried to take leverage of the psutils library and use [cpu_percent](https://psutil.readthedocs.io/en/latest/#psutil.Process.cpu_percent) during my initial testings. However, I couldn't get it to output any value other then 0.0%.

```
>>> while True:
...     print(p.cpu_percent(interval=0.1))
...     for S in range(0,10000000):
...             S += 0.1
...
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
0.0
^C
```

I think my tests were valid. The CPU usage of the process was logging ~90% from a `ps aux` run. 

Tracking the CPU times I think is still good. The processes that are more CPU intensive will get restarted quicker. The tricky part might be to get the right value to set as a maximum on our affected clusters. 