### PR TITLE
MessageRate should be measured post filtering.

### DIFF
--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -39,15 +39,21 @@ Installation Instructions
 git
 ---
 
+3.02.00
+-------
+
+*CHANGE*: ``messageRateMax`` now applies *after* accept/reject filtering. In previous versions, it limited the message
+rate *before* filtering.
+
 3.01.00
 -------
 
 *NOTICE*: can now subscribe to multiple brokers, and publish to multiple post_brokers with a single configuration.
 
 *CHANGE*: python API *bindings* being replaced by *subscriptions.* API is quite different, see examples.
-*Subscriptions* enables multi-queue and multi-broker support for subscribing. 
+*Subscriptions* enables multi-queue and multi-broker support for subscribing.
 
-*CHANGE*: python API post_ settings being replaced by *publishers.* need to build 
+*CHANGE*: python API ``post_`` settings being replaced by *publishers.* need to build
 sarracenia.config.publisher.Publisher structure now to publish messages.  It enables publishing
 to multiple destinations.
 

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1227,8 +1227,8 @@ messageRateMax <float> (default: 0)
 -----------------------------------
 
 if **messageRateMax** is greater than zero, the flow attempts to respect this delivery
-speed in terms of messages per second. Note that the throttle is on messages obtained or generated
-per second, prior to accept/reject filtering. the flow will sleep to limit the processing rate.
+speed in terms of messages per second. Note that the throttle is applied to the message rate
+*after* accept/reject filtering. The flow will sleep to limit the processing rate.
 
 
 messageRateMin <float> (default: 0)

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -38,12 +38,29 @@ Instructions d’installation
 git
 ---
 
-3.0.59
-------
+3.02.00
+-------
+
+*CHANGEMENT*: ``messageRateMax`` s'applique désormais *après* le filtrage d'acceptation/rejet.
+Dans les versions précédentes, il limitait le débit des messages *avant* le filtrage.
 
 
-*CHANGEMENT* : les *bindings* de l'API Python sont remplacées par des *subscriptions*. L'API est très différente, voir les exemples.
-Les *subscriptions* permettent l'usage  de plusieurs files d'attente et de plusieurs courtiers pour les abonnements.
+3.01.00
+-------
+
+*NOTICE* : vous pouvez désormais vous abonner à plusieurs courtiers et publier sur plusieurs
+post_brokers avec une seule configuration.
+
+*CHANGEMENT* : Les liaisons de l'API Python sont remplacées par les abonnements.
+L'API est très différente ; consultez les exemples.
+Les abonnements permettent la gestion de plusieurs files d'attente et de plusieurs courtiers.
+
+*CHANGEMENT* : Les paramètres ``post_`` de l'API Python sont remplacés par les ``publisher``s.
+Il est désormais nécessaire de créer la structure ``sarracenia.config.publisher.Publisher``
+pour publier des messages. Cela permet la publication vers plusieurs destinations.
+
+*CHANGEMENT* : L'API Python *sarracenia.moth.default_options* est remplacée par *sarracenia.moth.default_options()*.
+Cette méthode génère une copie modifiable des paramètres par défaut, au lieu du fichier options d'origine.
 
 
 3.0.58

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1213,9 +1213,9 @@ Ceci est normalement utilisé pour le débogage uniquement.
 messageRateMax <float> (défaut: 0)
 ----------------------------------
 
-Si **messageRateMax** est supérieur à zéro, le flux essaye de respecter cette vitesse de livraison en termes de
-messages d´annonce par seconde. Notez que la limitation est sur les messages d´annonce obtenus ou générés par seconde, avant le
-filtrage accept/reject. Le flux va dormir pour limiter le taux de traitement.
+Si **messageRateMax** est supérieur à zéro, le flux essaie de respecter cette vitesse de livraison en termes de
+messages annoncés par seconde. Notez que la limitation est sur le taux de messages après le
+filtrage accepter/rejeter. Le flux va dormir pour limiter le taux de traitement.
 
 
 messageRateMin <float> (défaut: 0)

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -562,6 +562,7 @@ class Flow:
 
         spamming = True
         last_gather_len = 0
+        after_filter_len = 0
         stopping = False
 
         while True:
@@ -600,6 +601,7 @@ class Flow:
                     spamming = False
 
                 self.filter()
+                after_filter_len=len(self.worklist.incoming)+len(self.worklist.ok)
 
                 self.work()
 
@@ -620,7 +622,7 @@ class Flow:
 
             now = nowflt()
             run_time = now - start_time
-            total_messages += last_gather_len
+            total_messages += after_filter_len
 
             # trigger shutdown when messageCountMax is reached
             if (self.o.messageCountMax > 0) and (total_messages > self.o.messageCountMax):


### PR DESCRIPTION
close #1181 

As per discussion in #1181 about messageRateMax.
It was concluded that some of the difficulty was because we were applying rate to the raw input, where that rate is kind of irrelevant when dealing with very high rejection rates (which are quite common for polls in particular, or any case where there is redundant sources for the same information.)