### PR TITLE
Add new CLI option: clean-restart #1537

### DIFF
--- a/docs/source/Explanation/CommandLineGuide.rst
+++ b/docs/source/Explanation/CommandLineGuide.rst
@@ -60,6 +60,7 @@ The remaining actions manage the resources (exchanges, queues) used by the compo
 the broker, or manage the configurations.
 
  - cleanup:       deletes the component's resources on the server.
+ - clean-restart: stop, cleanup and then start the configuration.
  - declare:       creates the component's resources on the server.
  - add:           copy to the list of available configurations.
  - list:          list all the configurations available.

--- a/docs/source/Reference/sr3.1.rst
+++ b/docs/source/Reference/sr3.1.rst
@@ -61,6 +61,7 @@ The type of action to take. One of:
 
  - add:           copy to the list of available configurations.
  - cleanup:       deletes the component's resources on the server.
+ - clean-restart: stop, cleanup and then start the configuration.
  - convert:       copy configurations from v2 to sr3 location, updating on the way.
  - declare:       creates the component's resources on the server.
  - disable:       mark a configuration as ineligible to run.

--- a/docs/source/fr/Explication/GuideLigneDeCommande.rst
+++ b/docs/source/fr/Explication/GuideLigneDeCommande.rst
@@ -60,6 +60,7 @@ Les actions restantes gèrent les ressources (échanges, files d’attente) util
 le courtier ou pour gérer les configurations.
 
  - cleanup:       supprime les ressources du composant sur le serveur
+ - clean-restart: arrêter, nettoyer (cleanup) puis démarrer la configuration.
  - declare:       crée les ressources du composant sur le serveur.
  - add:           copie une configuration à la liste des configurations disponibles.
  - list:          Énumérer toutes les configurations disponibles.

--- a/docs/source/fr/Reference/sr3.1.rst
+++ b/docs/source/fr/Reference/sr3.1.rst
@@ -61,6 +61,7 @@ Les types d'actions disponible. Une seule parmi:
 
  - add:           copier a la liste de configurations disponible.
  - cleanup:       supprimer les ressources des composants sur le serveur.
+ - clean-restart: arrêter, nettoyer (cleanup) puis démarrer la configuration.
  - convert:       copie et mets à jour un ou plusieurs configuration de v2 dans le répertoire sr3.
  - declare:       crée les ressources d'un composant sur le serveur.
  - disbale:       marquer une configuration comme non-éligible à exécuter.

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -708,7 +708,7 @@ class Config:
     ]
 
     actions = [
-        'add', 'cleanup', 'convert', 'devsnap', 'declare', 'disable', 'dump', 'edit',
+        'add', 'cleanup', 'clean-restart', 'convert', 'devsnap', 'declare', 'disable', 'dump', 'edit',
         'enable', 'features', 'foreground', 'log', 'list', 'remove', 'restart', 'run', 'sanity',
         'setup', 'show', 'start', 'stop', 'status', 'overview'
     ]

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -165,7 +165,7 @@ class sr_GlobalState:
 
             # would like to forward things like --debug...
             for arg in sys.argv[1:-1]:
-                if arg in ['start', 'restart', 'run']:
+                if arg in ['start', 'clean-restart', 'restart', 'run']:
                     break
                 cmd.append(arg)
 
@@ -1796,11 +1796,8 @@ class sr_GlobalState:
             logging.error( f'{self.leftovers} configuration not found' )
             return
 
-        if len(self.filtered_configurations) > 1 :
-            if len(self.filtered_configurations) != self.options.dangerWillRobinson:
-                logging.error(
-                        f"specify --dangerWillRobinson=<number> of configs to cleanup (actual: {len(self.filtered_configurations)}, given: {self.options.dangerWillRobinson} ) when cleaning more than one")
-                return False
+        if not self.validate_dangerWillRobinson():
+            return False
 
         all_stopped=True
         for f in self.filtered_configurations:
@@ -3188,6 +3185,15 @@ class sr_GlobalState:
 
         return bad
 
+    def validate_dangerWillRobinson(self):
+        if len(self.filtered_configurations) > 1 :
+            if len(self.filtered_configurations) != self.options.dangerWillRobinson:
+                logging.error(
+                        f"specify --dangerWillRobinson=<number> of configs to cleanup (actual: {len(self.filtered_configurations)}, given: {self.options.dangerWillRobinson} ) when cleaning more than one")
+                return False
+        return True
+
+
     def _pid_running_foreground(self, pid):
         """Returns True if the specified pid is running in the foreground.
         Possible cases:
@@ -3343,7 +3349,7 @@ def main():
             logger.setLevel(logging.INFO)
 
     actions = [
-        'convert', 'declare', 'devsnap', 'dump', 'edit', 'features', 'log', 'overview', 'restart', 'run', 'sanity',
+        'clean-restart', 'convert', 'declare', 'devsnap', 'dump', 'edit', 'features', 'log', 'overview', 'restart', 'run', 'sanity',
         'setup', 'show', 'status', 'start', 'stop'
     ]
 
@@ -3434,6 +3440,16 @@ def main():
     elif action == 'restart':
         print('stopping: ', end='', flush=True)
         gs.stop()
+        print('starting: ', end='', flush=True)
+        gs.start()
+
+    elif action == 'clean-restart':
+        if not gs.validate_dangerWillRobinson():
+            sys.exit(1)
+        print('stopping: ', end='', flush=True)
+        gs.stop()
+        print('cleanup: ', end='', flush=True)
+        gs.cleanup()
         print('starting: ', end='', flush=True)
         gs.start()
 


### PR DESCRIPTION
* Add a new CLI option to do a `sr3 stop/cleanup/start` called `clean-restart`.
* I separated the `dangerWillRobinson` checks into its own method. `dangerWillRobinson` should be validated at the beginning of the `clean-restart` execution, otherwise the `stop` and `start` portion of the code will still execute.
* I added the reference to the new CLI option in the documentation.