### PR TITLE
Fix msg['size'] not set after downloading

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -1192,8 +1192,8 @@ class Message(dict):
         opath=msg['new_dir'] + os.sep + msg['new_file']
 
         if not os.path.isdir(msg['new_dir']):
-            if self.o.permDirDefault != 0:
-                os.makedirs(msg['new_dir'],mode=self.o.permDirDefault, exist_ok=True)
+            if options.permDirDefault != 0:
+                os.makedirs(msg['new_dir'],mode=options.permDirDefault, exist_ok=True)
             else:
                 os.makedirs(msg['new_dir'], exist_ok=True)
 
@@ -1214,10 +1214,10 @@ class Message(dict):
         try:
             with open(opath, 'wb') as f:
                sz=f.write(data)
-            if self.o.permDefault != 0:
-                os.chmod(opath,mode=self.o.permDefault)
+            if options.permDefault != 0:
+                os.chmod(opath,mode=options.permDefault)
             msg['size'] = sz
-            msg.computeIdentity(opath,self.o,data=data)
+            msg.computeIdentity(opath,options,data=data)
         except Exception as ex:
             logger.error( f"problem with {opath}: {ex}" )
 

--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -506,7 +506,6 @@ class Message(dict):
         self['_format'] = 'v03'
         self['_deleteOnPost'] = set(['_format'])
 
-
     def computeIdentity(msg, path, o, offset=0, data=None) -> None:
         """
            check extended attributes for a cached identity sum calculation.
@@ -574,6 +573,9 @@ class Message(dict):
         else: # a "normal" calculation method, liks sha512, or md5
             sumalgo = sarracenia.identity.Identity.factory(calc_method)
             sumalgo.set_path(path)
+
+            if 'size' not in msg:
+                msg.setSize(path)
 
             # compute checksum
             if calc_method in ['md5', 'sha512']:
@@ -940,6 +942,13 @@ class Message(dict):
 
         msg['report'] = {'code': code, 'timeCompleted': nowstr(), 'message': text}
         msg['_deleteOnPost'] |= set(['report'])
+
+    def setSize(msg, path) -> None:
+        """ Attempt to set the size field in the message, from the provided file path. (File must exist on disk).
+            Can be used to fix an incorrect size in the message (any existing msg['size'] is ignored and replaced).
+        """
+        if os.path.exists(path):
+            msg['size'] = os.path.getsize(path)
 
     def updatePaths(msg, options, new_dir=None, new_file=None, publisher_index=0):
         """

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2088,9 +2088,10 @@ class Flow:
                 if ok == 1:
                     logger.debug("downloaded ok: %s" % new_path)
                     end_time=time.perf_counter()
-                    rate=msg['size']/(end_time-start_time)
                     msg.setReport(201, "Download successful" )
-                    msg['report']['rate']=rate
+                    if 'size' in msg:
+                        rate=msg['size']/(end_time-start_time)
+                        msg['report']['rate']=rate
                     # if content is present, but downloaded anyways, then it is no good, and should not be forwarded.
                     if 'content' in msg:
                         del msg['content']
@@ -2214,6 +2215,24 @@ class Flow:
                     logger.debug( "details:", exc_info=True )
 
                 if not ok: return 0
+
+            # try to fill in missing info in msg if they are not set by the plugin
+            # if they are already set, don't override, assume the plugin set them correctly
+            local_file = os.path.join(new_dir, new_file)
+            if 'identity' not in msg:
+                try:
+                    msg.computeIdentity(local_file)
+                except Exception as e:
+                    logger.warning(f"failed to set msg['identity']: {e}")
+                    logger.debug("Exception details:", exc_info=True)
+            if 'size' not in msg:
+                try:
+                    msg.setSize(local_file)
+                except Exception as e:
+                    logger.warning(f"failed to set msg['size']: {e}")
+                    logger.debug("Exception details:", exc_info=True)
+
+            # if we get here, download was successful
             return 1
 
         if self.o.dry_run:

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2221,7 +2221,7 @@ class Flow:
             local_file = os.path.join(new_dir, new_file)
             if 'identity' not in msg:
                 try:
-                    msg.computeIdentity(local_file)
+                    msg.computeIdentity(local_file, options)
                 except Exception as e:
                     logger.warning(f"failed to set msg['identity']: {e}")
                     logger.debug("Exception details:", exc_info=True)


### PR DESCRIPTION
If the incoming message does not have size set, and a download plugin is used to download the file, if the download plugin does not set the size itself, then the outgoing message will not have a size.

This will cause the rate calculation (#1532) to fail and crash the process.

This partially implements #1392 to fix that (it doesn't correct incorrect size/identity in the message as discussed in that issue, it just sets them when not present).

I also added an `if` to check that `msg['size']` exists before using it to calculate the rate, just in case.

I noticed a potential case in `computeIdentity` where `msg['size']` is used but may not exist, so I added a call to the new `msg.setSize(path)` method there too.

VSCode also identified a bug, where `self.o` wasn't defined in `msg.new_pathWrite(...)`, I fixed that in a separate commit. That method doesn't appear to be used.