### PR TITLE
Implement `amqp_queue_args`

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -427,6 +427,44 @@ If the check of the upstream server fails, or the retrieve itself has failed,
 then it puts the resource on the retry queue for later attempts.
 
 
+amqp_queue_args <list> (default: not set)
+-----------------------------------------
+
+*Only applies to subscriptions to AMQP brokers.*
+
+This option is used to define optional queue arguments. The arguments that can be
+defined depend on the broker software and version used. For
+example, `RabbitMQ <https://www.rabbitmq.com/docs/queues#optional-arguments>`_.
+
+Human-friendly values (e.g. ``1m`` for 1-minute) are **not supported**. You must
+use the unit expected by the broker.
+
+Note: any queue arguments that are already defined by other sr3 options that are
+also defined in ``amqp_queue_args`` will be **overriden** by the value from
+``amqp_queue_args``. This applies to:
+
+==================== =====================
+sr3 option           AMQP Queue Argument
+==================== =====================
+``expire``           ``x-expires``
+``messageAgeMax``    ``x-message-ttl``
+``queueType``        ``x-queue-type``
+==================== =====================
+
+Warning: no validation is performed on these arguments. sr3 does not know what
+arguments are supported by the broker, so it can't check if you have specified
+an unsupported option.
+
+For example: ::
+
+  # x-consumer-timeout: if an ack is not received within this timeframe, the broker
+  # will assume the message has been lost. (3600000 ms = 1 hour)
+  amqp_queue_args x-consumer-timeout=3600000
+
+  expire 5m
+  # this overrides the x-expires 5 minute expiration to 3600000 ms
+  amqp_queue_args x-expires=3600000
+
 attempts <count> (default: 3)
 -----------------------------
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -432,6 +432,43 @@ Si la vérification du serveur en amont échoue, ou si la récupération elle-m�
 alors la ressource est placée dans la file d'attente de nouvelles tentatives pour des tentatives ultérieures.
 
 
+amqp_queue_args <liste> (défaut: non défini)
+--------------------------------------------
+
+*S'applique uniquement aux abonnements aux serveurs AMQP.*
+
+Cette option permet de définir des arguments de file d'attente optionnels. Les arguments
+disponibles dépendent du logiciel et de la version du serveur AMQP utilisé. Par exemple,
+`RabbitMQ <https://www.rabbitmq.com/docs/queues#optional-arguments>`_.
+
+Les valeurs lisibles par l'utilisateur (par exemple, ``1m`` pour 1 minute) ne sont
+**pas prises en charge**. Vous devez utiliser l'unité attendue par le serveur.
+
+Remarque : tout argument de file d'attente déjà défini par d'autres options sr3 et
+également défini dans ``amqp_queue_args`` sera **remplaçant** la valeur de
+``amqp_queue_args``. Ceci s'applique à :
+
+=================== ===============================
+Option sr3          Argument de file d'attente AMQP
+=================== ===============================
+``expire``           ``x-expires``
+``messageAgeMax``    ``x-message-ttl``
+``queueType``        ``x-queue-type``
+=================== ===============================
+
+Avertissement : aucune validation n'est effectuée sur ces arguments. sr3 ne connaît pas les
+arguments pris en charge par le broker et ne peut donc pas vérifier si vous avez spécifié
+une option non prise en charge.
+
+Par exemple : ::
+
+  # x-consumer-timeout : si aucun accusé de réception n'est reçu dans ce délai, le broker
+  # considérera que le message a été perdu. (3600000 ms = 1 heure)
+  amqp_queue_args x-consumer-timeout=3600000
+
+  expire 5m
+  # Ceci remplace l'expiration de 5 minutes par 3600000 ms
+  amqp_queue_args x-expires=3600000
 
 attempts <count> (défaut: 3)
 -----------------------------

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -27,6 +27,7 @@ import sys
 import time
 import urllib, urllib.parse
 
+from ast import literal_eval
 from random import randint
 
 if sys.version_info[0] >= 3 and sys.version_info[1] < 8:
@@ -164,7 +165,7 @@ duration_options = [
     'runStateThreshold_idle', 'runStateThreshold_lag', 'retry_ttl', 'runStateThreshold_hung', 'sleep', 'timeout', 'varTimeOffset'
 ]
 
-list_options = [ 'path', 'vip' ]
+list_options = [ 'amqp_queue_args', 'path', 'vip' ]
 
 # set, valid values of the set.
 set_options = [ 'logEvents', 'fileEvents' ]
@@ -180,8 +181,8 @@ perm_options = [ 'permDefault', 'permDirDefault','permLog']
 
 # options that apply to queues, and so must appear before subtopic resolves queues characteristics.
 #
-queue_options = [ 'auto_delete', 'broker', 'clean_session', 'durable', 'exchange', 'exchangeSuffix',  \
-                  'expire', 'max_inflight_messages', 'max_queued_messages',  'prefetch',  \
+queue_options = [ 'amqp_queue_args', 'auto_delete', 'broker', 'clean_session', 'durable', 'exchange',   \
+                  'exchangeSuffix', 'expire', 'max_inflight_messages', 'max_queued_messages',  'prefetch',  \
                  'qos', 'queueBind',  'queueDeclare' , 'receiveMaximum', 'tlsRigour']
 
 size_options = ['accelThreshold', 'blockSize', 'bufSize', 'byteRateMax', 'fileSizeMax', 'inlineByteMax']
@@ -648,6 +649,15 @@ def config_path(subdir, config, mandatory=True, ctype='conf'):
 
     return False, config
 
+def guess_type(value:str):
+    """ try to parse a string into any type (int, float, string, etc.).
+        return the original string if anything goes wrong.
+    """
+    try:
+        value = literal_eval(value)
+    except Exception as e:
+        logger.debug(e)
+    return value
 
 class Config:
     r"""

--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -61,6 +61,9 @@ class Subscription(dict):
             aqa = getattr(options, a)
             aqa_dict = {}
             for arg in aqa:
+                if '=' not in arg:
+                    logger.error(f"invalid amqp_queue_args line: {arg} (key and value must be separated by =)")
+                    continue
                 k, v = arg.split('=', maxsplit=1)
                 v = sarracenia.config.guess_type(v.strip())
                 aqa_dict[k] = v

--- a/sarracenia/config/subscription.py
+++ b/sarracenia/config/subscription.py
@@ -3,10 +3,11 @@ import copy
 import json
 import os
 
+import sarracenia.config
+
 import logging
 
 logger = logging.getLogger(__name__)
-
 
 class Subscription(dict):
 
@@ -50,6 +51,21 @@ class Subscription(dict):
                 'max_queued_messages',  'prefetch', 'qos', 'receiveMaximum', 'tlsRigour', 'topic' ]:
             if hasattr(options, a):
                 self['queue'][a] = getattr(options,a)
+
+        # parse list option amqp_queue_args, e.g.:
+        #   amqp_queue_args x-consumer-timeout=12345
+        a = 'amqp_queue_args'
+        if hasattr(options, a):
+            if not self['broker'].url.scheme.lower().startswith('amqp'):
+                logger.warning(f"{a} option is set, but broker scheme is not AMQP(S): {self['broker']}")
+            aqa = getattr(options, a)
+            aqa_dict = {}
+            for arg in aqa:
+                k, v = arg.split('=', maxsplit=1)
+                v = sarracenia.config.guess_type(v.strip())
+                aqa_dict[k] = v
+            self['queue'][a] = aqa_dict
+
         self['baseDir'] = options.baseDir
 
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -314,6 +314,9 @@ class AMQP(Moth):
                 if 'type' in queue and queue['type'] is not None:
                     x = queue['type']
                     if x in ['classic', 'quorum', 'stream']: args['x-queue-type'] = x
+                # values in amqp_queue_args will override any values that were just set above
+                if 'amqp_queue_args' in queue and queue['amqp_queue_args'] is not None:
+                    args.update(queue['amqp_queue_args'])
 
                 #FIXME: convert expire, message_ttl to proper units.
                 if self.o['dry_run']:

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -516,3 +516,9 @@ def test_multi():
                               'template': 'q_${BROKER_USER}.${COMPONENT}.${CONFIG}',
                               'tlsRigour': 'normal'}}] )
      """
+
+def test_guess_type():
+     assert type(sarracenia.config.guess_type('123')) == int
+     assert type(sarracenia.config.guess_type('abc')) == str
+     assert type(sarracenia.config.guess_type('3.14')) == float
+     assert type(sarracenia.config.guess_type('')) == str


### PR DESCRIPTION
We needed a way to increase the consumer timeout. This was discussed in #1501 and we decided the best way was to implement a generic way to set any AMQP queue argument. This should be more future proof than adding extra sr3 options each time we need to use a new AMQP option