### PR TITLE
match wait time between SIGTERM to 1/2 a batch.

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -563,8 +563,10 @@ class Flow:
         spamming = True
         last_gather_len = 0
         stopping = False
+        run_count=0   # the number of times the loop is run.
 
         while True:
+            run_count+=1
 
             if self._stop_requested:
                 if stopping:
@@ -631,6 +633,7 @@ class Flow:
             elapsed = now - last_time
 
             self.metrics['flow']['msgRate'] = current_rate
+            self.metrics['flow']['meanBatch'] = total_messages / run_count 
             self.metrics['flow']['msgRateCpu'] = total_messages / (self.metrics['flow']['cpuTime']+self.metrics['flow']['last_housekeeping_cpuTime'] )
 
             # trigger shutdown once gather is finished, where sleep < 0 (e.g. a post)

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2435,6 +2435,7 @@ class sr_GlobalState:
             signal_pid(pid, signal.SIGTERM)
             pids_signalled |= set([pid])
 
+        max_wait=1
         for f in self.filtered_configurations:
             (c, cfg) = f.split(os.sep)
 
@@ -2443,6 +2444,11 @@ class sr_GlobalState:
                 fg_instances.add(f"{c}/{cfg}")
                 logger.warning( f"skipping foreground flow: {c}/{cfg}")
                 continue
+
+            if hasattr(self.configs[c][cfg]['options'],'batch'):
+                batch=self.configs[c][cfg]['options'].batch
+            else:
+                batch=1
 
             if self.configs[c][cfg]['status'] in self.status_active:
 
@@ -2453,6 +2459,17 @@ class sr_GlobalState:
                 for i in self.states[c][cfg]['instance_pids']:
                     #print( "for %s/%s - %s signal_pid( %s, SIGTERM )" % \
                     #    ( c, cfg, i, self.states[c][cfg]['instance_pids'][i] ) )
+                    if 'instance_metrics' in self.states[c][cfg] and \
+                       'flow' in self.states[c][cfg]['instance_metrics'][i]:
+                        flow_metric=self.states[c][cfg]['instance_metrics'][i]['flow']
+                        if 'msgRate' in flow_metric and 'meanBatch' in flow_metric:
+                           batch=flow_metric['meanBatch']
+                           rate=flow_metric['msgRate']
+                           wait=batch/(2*rate)
+                           if wait > max_wait:
+                               max_wait = wait
+                               print( f"wait longer after SIGTERM based on mean batch/message rate *2: {batch:.2f}/{rate:.2f}*2 = {max_wait:.2f} seconds" )
+ 
                     p=self.states[c][cfg]['instance_pids'][i]
                     if p in self.procs:
                         if self.options.dry_run:
@@ -2468,7 +2485,7 @@ class sr_GlobalState:
             print('dry_run assumes everything works the first time')
             return 0
 
-        attempts = 0
+        attempts = 1
         attempts_max = 5
         now = time.time()
 
@@ -2481,8 +2498,8 @@ class sr_GlobalState:
                     signal_pid(pid, signal.SIGTERM)
                     pids_signalled |= set([pid])
 
-            ttw = 1 << attempts
-            print( f"Waiting {ttw} sec. to check if {running_pids} processes stopped (try: {attempts})" )
+            ttw = max_wait
+            print( f"Waiting {ttw:.2f} sec. to check if {running_pids} processes stopped (try: {attempts})" )
             time.sleep(ttw)
             # update to reflect killed processes.
             self._read_procs()


### PR DESCRIPTION
The other half of #1531 is that we consult the metrics available for all the flows being stopped.  We add a meanBatch metric, to the msgRate metrics to understand how long it should take for given flow to finish stopping. So it doesn't SIGKILL until a time that is >2.5 times the average time to process an entire batch has gone by.

It turned out much easier than the method described in the issue discussion.  Instead of having to use new statefiles, I was able to use existing metrics files.   Using the batch setting turned out to be bad, because often flow have very small batches, so the maximum given by the setting is far too long. Added a *meanBatch* to the flow metrics to understand how big the average batch is.   Use that new metric with the existing msgRate to say that:

* if stop is requested, it should not take more than the 2 1/2 times the average duration of processing a batch of messages.

Often this is a very short period of time, and it will result in *stop* running faster.
When dealing with very large file transfers, or large batches of files being transferred, this change will make it wait a more appropriate amount of time.