### PR TITLE
Add new statefile for OOM restarting use case #1439

### DIFF
--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -34,7 +34,7 @@ Returns:
 
 import logging
 
-import os, socket
+import os, socket, time, random
 from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime, user_cache_dir, nowstr
 from sarracenia.featuredetection import features
@@ -58,6 +58,7 @@ class Resources(FlowCB):
         ''' Per-process maximum memory footprint that is considered too large, forcing a process restart.'''
         self.transferCount = 0
         self.msgCount = 0
+        self.randomSleep = 1 + round(random.random(), 2)
 
     def on_housekeeping(self):
         if features['process']['present']:
@@ -117,8 +118,17 @@ class Resources(FlowCB):
         # Before triggering a restart, add a state file to prevent other processes to stop/start it at the same time.
         self.state_file = self.o.cfg_run_dir + os.sep + 'resources_restart'
 
-        with open(self.state_file, "w") as f:
-            f.write(nowstr())
+        file_not_ready = True
+
+        # If another process is performing a OOM restart, wait until it is complete before creating a new state file to avoid a race-condition.
+        while file_not_ready:
+            if not os.path.exists(self.state_file):
+                file_not_ready = False
+                with open(self.state_file, "w") as f:
+                    f.write(nowstr())
+            else:
+                logger.info(f"State file already exists : {self.state_file}. Waiting {self.randomSleep} seconds.")
+                time.sleep(self.randomSleep)
 
 
         if sys.platform.startswith(('linux', 'cygwin', 'darwin', 'aix')):

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -115,12 +115,7 @@ class Resources(FlowCB):
         #   The star unpacks the sys.argv list into the remaining function args
 
         # Before triggering a restart, add a state file to prevent other processes to stop/start it at the same time.
-        self.user_cache_dir = user_cache_dir('sr3', 'MetPX')
-        self.hostdir = socket.getfqdn().split('.')[0]
-        if self.o.statehost:
-            self.state_file = self.user_cache_dir + os.sep + self.hostdir + os.sep + self.o.component + os.sep + self.o.config + os.sep + 'oom_restarting'
-        else:
-            self.state_file = self.user_cache_dir + os.sep + self.o.component + os.sep + self.o.config + os.sep + 'oom_restarting'
+        self.state_file = self.o.cfg_run_dir + os.sep + 'resources_restart'
 
         with open(self.state_file, "w") as f:
             f.write(nowstr())

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -34,9 +34,9 @@ Returns:
 
 import logging
 
-import os
+import os, socket
 from sarracenia.flowcb import FlowCB
-from sarracenia import naturalSize, naturalTime
+from sarracenia import naturalSize, naturalTime, user_cache_dir, nowstr
 from sarracenia.featuredetection import features
 
 if features['process']['present']:
@@ -113,6 +113,18 @@ class Resources(FlowCB):
         # Second arg has to be python for windows, see how this affects the linux side of things..
         # Third arg is the name of the program you wish to run (should be full path to script) plus all the args.
         #   The star unpacks the sys.argv list into the remaining function args
+
+        # Before triggering a restart, add a state file to prevent other processes to stop/start it at the same time.
+        self.user_cache_dir = user_cache_dir('sr3', 'MetPX')
+        self.hostdir = socket.getfqdn().split('.')[0]
+        if self.o.statehost:
+            self.state_file = self.user_cache_dir + os.sep + self.hostdir + os.sep + self.o.component + os.sep + self.o.config + os.sep + 'oom_restarting'
+        else:
+            self.state_file = self.user_cache_dir + os.sep + self.o.component + os.sep + self.o.config + os.sep + 'oom_restarting'
+
+        with open(self.state_file, "w") as f:
+            f.write(nowstr())
+
 
         if sys.platform.startswith(('linux', 'cygwin', 'darwin', 'aix')):
             # Unix* (Linux / Windows/Cygwin / MacOS / AIX) Specific restart

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -173,8 +173,7 @@ class instance:
             metricsfilename = sarracenia.config.get_metrics_filename( hostdir, component, config, cfg_preparse.no)
 
             # If OOM restart is invoked, remove state file now.
-            cache_dir = sarracenia.config.get_user_cache_dir(hostdir)
-            oom_state_file = cache_dir + os.sep + component + os.sep + config + os.sep + 'oom_restarting'
+            oom_state_file = cfg_preparse.cfg_run_dir + os.sep + 'resources_restart'
             if os.path.isfile(oom_state_file):
                 os.unlink(oom_state_file)
 

--- a/sarracenia/instance.py
+++ b/sarracenia/instance.py
@@ -172,6 +172,12 @@ class instance:
 
             metricsfilename = sarracenia.config.get_metrics_filename( hostdir, component, config, cfg_preparse.no)
 
+            # If OOM restart is invoked, remove state file now.
+            cache_dir = sarracenia.config.get_user_cache_dir(hostdir)
+            oom_state_file = cache_dir + os.sep + component + os.sep + config + os.sep + 'oom_restarting'
+            if os.path.isfile(oom_state_file):
+                os.unlink(oom_state_file)
+
             dir_not_there = not os.path.exists(os.path.dirname(metricsfilename))
             while dir_not_there:
                 try:

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -504,6 +504,9 @@ class sr_GlobalState:
                         elif os.path.exists('shutdown'):
                             self.states[c][cfg]['status'] = 'shutdown'
                             self.flux[ f"{c}/{cfg}" ] = 'shutdown'
+                        elif os.path.exists('oom_restarting'):
+                            self.states[c][cfg]['status'] = 'oom_restarting'
+                            self.flux[ f"{c}/{cfg}" ] = 'oom_restarting'
 
                         state_files = os.listdir() 
                         if len(state_files) == 0:
@@ -622,7 +625,7 @@ class sr_GlobalState:
                         if not 'status' in self.configs[c][cfg]:
                             continue
 
-                        if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'stopped', 'stopping', 'starting' ]:
+                        if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'stopped', 'stopping', 'starting', 'oom_restarting']:
                             continue
 
                         if hasattr(self.configs[c][cfg]['options'],'statehost') and (statehost != self.configs[c][cfg]['options'].statehost):
@@ -896,6 +899,8 @@ class sr_GlobalState:
                     self.configs[c][cfg]['status'] = 'interactive'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'starting'):
                     self.configs[c][cfg]['status'] = 'starting'
+                if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'oom_restarting'):
+                    self.configs[c][cfg]['status'] = 'oom_restarting'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'shutdown'):
                     self.configs[c][cfg]['status'] = 'shutdown'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'running'):
@@ -1072,7 +1077,7 @@ class sr_GlobalState:
                                     hung_instances += 1
                                     self.states[c][cfg]['hung_instances'].append(i)
 
-                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'starting', 'shutdown', 'running' ]:
+                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'starting', 'shutdown', 'running', 'oom_restarting']:
                         flow_status = self.configs[c][cfg]['status']
                     else:
                         flow_status = 'unknown'
@@ -1095,7 +1100,7 @@ class sr_GlobalState:
                             if self.configs[c][cfg]['status'] not in [ 'disabled', 'new', 'interactive' ]:
                                 flow_status = 'stopped'
                         else:
-                            if observed_instances > 0 and flow_status not in ['starting','shutdown']:
+                            if observed_instances > 0 and flow_status not in ['starting','shutdown','oom_restarting']:
                                 flow_status = 'partial'
                                 for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                     if not i in self.states[c][cfg]['instance_pids']:
@@ -1105,7 +1110,7 @@ class sr_GlobalState:
                                     if flow_status not in [ 'interactive', 'new', 'running'] and len(self.states[c][cfg]['instance_pids']) == 0 :
                                         flow_status = 'stopped' 
                                     else:
-                                        if flow_status not in [ 'interactive', 'new', 'shutdown', 'starting' ]:
+                                        if flow_status not in [ 'interactive', 'new', 'shutdown', 'starting' , 'oom_restarting']:
                                             flow_status = 'missing' 
                                         for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                             if not i in self.states[c][cfg]['instance_pids']:
@@ -1319,7 +1324,7 @@ class sr_GlobalState:
             'sender', 'shovel', 'subscribe', 'watch', 'winnow'
         ]
         # active means >= 1 process exists on the node.
-        self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip' ]
+        self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip', 'oom_restarting']
         self.status_values = self.status_active + [ 'disabled', 'include', 'interactive', 'missing', 'new', 'stopped', 'unknown' ]
 
         self.bin_dir = os.path.dirname(os.path.realpath(__file__))

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -504,9 +504,9 @@ class sr_GlobalState:
                         elif os.path.exists('shutdown'):
                             self.states[c][cfg]['status'] = 'shutdown'
                             self.flux[ f"{c}/{cfg}" ] = 'shutdown'
-                        elif os.path.exists('oom_restarting'):
-                            self.states[c][cfg]['status'] = 'oom_restarting'
-                            self.flux[ f"{c}/{cfg}" ] = 'oom_restarting'
+                        elif os.path.exists('resources_restart'):
+                            self.states[c][cfg]['status'] = 'resources_restart'
+                            self.flux[ f"{c}/{cfg}" ] = 'resources_restart'
 
                         state_files = os.listdir() 
                         if len(state_files) == 0:
@@ -625,7 +625,7 @@ class sr_GlobalState:
                         if not 'status' in self.configs[c][cfg]:
                             continue
 
-                        if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'stopped', 'stopping', 'starting', 'oom_restarting']:
+                        if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'stopped', 'stopping', 'starting', 'resources_restart']:
                             continue
 
                         if hasattr(self.configs[c][cfg]['options'],'statehost') and (statehost != self.configs[c][cfg]['options'].statehost):
@@ -899,8 +899,8 @@ class sr_GlobalState:
                     self.configs[c][cfg]['status'] = 'interactive'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'starting'):
                     self.configs[c][cfg]['status'] = 'starting'
-                if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'oom_restarting'):
-                    self.configs[c][cfg]['status'] = 'oom_restarting'
+                if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'resources_restart'):
+                    self.configs[c][cfg]['status'] = 'resources_restart'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'shutdown'):
                     self.configs[c][cfg]['status'] = 'shutdown'
                 if os.path.exists(self.user_cache_dir + os.sep + c + os.sep + cfg + os.sep + 'running'):
@@ -1077,7 +1077,7 @@ class sr_GlobalState:
                                     hung_instances += 1
                                     self.states[c][cfg]['hung_instances'].append(i)
 
-                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'starting', 'shutdown', 'running', 'oom_restarting']:
+                    if self.configs[c][cfg]['status'] in [ 'disabled', 'interactive', 'new', 'starting', 'shutdown', 'running', 'resources_restart']:
                         flow_status = self.configs[c][cfg]['status']
                     else:
                         flow_status = 'unknown'
@@ -1100,7 +1100,7 @@ class sr_GlobalState:
                             if self.configs[c][cfg]['status'] not in [ 'disabled', 'new', 'interactive' ]:
                                 flow_status = 'stopped'
                         else:
-                            if observed_instances > 0 and flow_status not in ['starting','shutdown','oom_restarting']:
+                            if observed_instances > 0 and flow_status not in ['starting','shutdown','resources_restart']:
                                 flow_status = 'partial'
                                 for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                     if not i in self.states[c][cfg]['instance_pids']:
@@ -1110,7 +1110,7 @@ class sr_GlobalState:
                                     if flow_status not in [ 'interactive', 'new', 'running'] and len(self.states[c][cfg]['instance_pids']) == 0 :
                                         flow_status = 'stopped' 
                                     else:
-                                        if flow_status not in [ 'interactive', 'new', 'shutdown', 'starting' , 'oom_restarting']:
+                                        if flow_status not in [ 'interactive', 'new', 'shutdown', 'starting' , 'resources_restart']:
                                             flow_status = 'missing' 
                                         for i in range(1, int(self.configs[c][cfg]['instances'])+1 ):
                                             if not i in self.states[c][cfg]['instance_pids']:
@@ -1324,7 +1324,7 @@ class sr_GlobalState:
             'sender', 'shovel', 'subscribe', 'watch', 'winnow'
         ]
         # active means >= 1 process exists on the node.
-        self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip', 'oom_restarting']
+        self.status_active =  ['cpuSlow', 'disconnected', 'down', 'hung', 'idle', 'lagging', 'partial', 'reject', 'retry', 'running', 'slow', 'standby', 'starting', 'shutdown', 'waitVip', 'resources_restart']
         self.status_values = self.status_active + [ 'disabled', 'include', 'interactive', 'missing', 'new', 'stopped', 'unknown' ]
 
         self.bin_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
We previously discussed in issue #1439 that we could potentially use the already `starting` statefile to prevent sanity from interfering with the OOM restart. However, I decided to create a new statefile : `oom_restarting` because,

- `os.execl` will only re-execute the command executed from the command line (i.e. `/usr/bin/python3 /path/to/lib/python3.10/site-packages/sarracenia/instance.py --no 1 start component/config`). When we create a new statefile, we need to remove it after the process has started and the only way to do that with the command line executable is from `instance.py`. 
- My thought is that it will be easier for future analysts to understand why we are removing a statefile from `instance.py` when it's referencing directly to the OOM restart. Otherwise, it might cause confusion. 