### PR TITLE
Fix issue #1503 by removing trailing slash from relPath

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1954,9 +1954,8 @@ class Flow:
                 if len(msg['new_dir']) < 2 or ('fileOp' not in msg and 'directory' in msg['fileOp']): 
                     self.reject(msg, 422, f"new_file message field missing, do not know name of file to write. skipping." )
                     continue
-                np=os.path.dirname(msg['new_dir'])
-                msg['new_dir'] = os.path.dirname(np)
-                msg['new_file'] = os.path.basename(np)
+                msg['new_file'] = os.path.basename(msg['new_dir'])
+                msg['new_dir'] = os.path.dirname(msg['new_dir'])
 
             new_path = msg['new_dir'] + os.path.sep + msg['new_file']
             new_file = msg['new_file']

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1950,8 +1950,13 @@ class Flow:
                 continue
 
             if not 'new_file' in msg or not msg['new_file']:
-                self.reject(msg, 422, f"new_file message field missing, do not know name of file to write. skipping." )
-                continue
+                # issue #1503 move a little to the right to deal with when directory path ends in /
+                if len(msg['new_dir']) < 2 or ('fileOp' not in msg and 'directory' in msg['fileOp']): 
+                    self.reject(msg, 422, f"new_file message field missing, do not know name of file to write. skipping." )
+                    continue
+                np=os.path.dirname(msg['new_dir'])
+                msg['new_dir'] = os.path.dirname(np)
+                msg['new_file'] = os.path.basename(np)
 
             new_path = msg['new_dir'] + os.path.sep + msg['new_file']
             new_file = msg['new_file']


### PR DESCRIPTION
Problem: sr3c currently posts relPaths that end in `/` for directory events when the original command was executed with a trailing slash (e.g. `mkdir mydir/` or `rm -r mydir/`).

This works around that problem by removing the trailing slash from the relPath when the problem is detected.

It's @petersilva's original change and my tweak, so I guess @andreleblanc11 should be the one to approve it :) 