### PR TITLE
Add documentation improvements to release process post 3.02.00rc1

### DIFF
--- a/docs/source/Contribution/Release.rst
+++ b/docs/source/Contribution/Release.rst
@@ -34,7 +34,7 @@ To publish a pre-release one needs to:
 - validate that the correct version of C stack will be running when running flow tests.
   on each server::
 
-      sr3_cpost -h
+      sr3_cpost -h |& head -3
 
   Is that the version wanted?
   Consult C installation/release info to make sure you have the version you want

--- a/docs/source/Contribution/Release.rst
+++ b/docs/source/Contribution/Release.rst
@@ -34,15 +34,15 @@ To publish a pre-release one needs to:
 - validate that the correct version of C stack will be running when running flow tests.
   on each server::
 
-      sr3_cpost -h | head -3
+      sr3_cpost -h
 
   Is that the version wanted?
   Consult C installation/release info to make sure you have the version you want
   for the flow tests that follow.
 
-  * https://github.com/MetPX/sarrac/tree/_branch_/Build.rst
+  * https://github.com/MetPX/sarrac/blob/_branch_/Build.rst
 
-  * https://github.com/MetPX/sarrac/tree/_branch_/Release.rst
+  * https://github.com/MetPX/sarrac/blob/_branch_/Release.rst
 
 - run QA process on all operating systems looking for regressions on older 3.6-based ones.
 
@@ -50,7 +50,9 @@ To publish a pre-release one needs to:
   - github runs unit tests (only work on newer python versions.), review those results.
   - find ubuntu 18.04 server. build local package, run flow tests::
 
+         git pull
          git checkout development_py36
+         git pull
          python3 setup.py bdist_wheel
          pip3 install dist/metpx_sr3-${VERSION}-py3-none-any.whl
 
@@ -60,6 +62,11 @@ To publish a pre-release one needs to:
          # run flow tests:
 
           cd ~/sr_insects;
+          git pull
+          # Verify the branch you are working on is the correct one
+          git branch
+          # Make sure no other sr3 instances are running during the flow tests
+          sr3 status
           for flow_test in static_flow flakey_broker restart_server dynamic_flow; do
 
              cd $flow_test
@@ -70,12 +77,19 @@ To publish a pre-release one needs to:
 
   - find ubuntu 20.04 server. build local package, run flow tests::
 
+         git pull
          git checkout development
+         git pull
          pip3 install -e .
          
          # run flow tests:
 
           cd ~/sr_insects;
+          git pull
+          # Verify the branch you are working on is the correct one
+          git branch
+          # Make sure no other sr3 instances are running during the flow tests
+          sr3 status
           for flow_test in static_flow flakey_broker restart_server dynamic_flow; do
 
              cd $flow_test
@@ -86,6 +100,7 @@ To publish a pre-release one needs to:
 
   - find redhat 8 server.  build package::
    
+         git pull
          git checkout development_py36
          git pull
          python3 setup.py bdist_rpm
@@ -95,6 +110,19 @@ To publish a pre-release one needs to:
          sr3 --version
 
          # run flow tests
+         cd ~/sr_insects;
+         git pull
+         # Verify the branch you are working on is the correct one
+         git branch
+         # Make sure no other sr3 instances are running during the flow tests
+         sr3 status
+         for flow_test in static_flow flakey_broker restart_server dynamic_flow; do
+
+             cd $flow_test
+             ./flow_setup.sh && ./flow_limit.sh && ./flow_check.sh
+             # study results.
+             ./flow_cleanup.sh
+             cd ..
 
   - find redhat 9 server,  build package::
 
@@ -107,6 +135,19 @@ To publish a pre-release one needs to:
          sr3 --version
 
          # run flow tests
+         cd ~/sr_insects;
+         git pull
+         # Verify the branch you are working on is the correct one
+         git branch
+         # Make sure no other sr3 instances are running during the flow tests
+         sr3 status
+         for flow_test in static_flow flakey_broker restart_server dynamic_flow; do
+
+            cd $flow_test
+            ./flow_setup.sh && ./flow_limit.sh && ./flow_check.sh
+            # study results.
+            ./flow_cleanup.sh
+            cd ..
 
 - Set the pre-release tags::
 
@@ -140,6 +181,10 @@ To publish a pre-release one needs to:
     * git pull
     * python3 setup.py bdist_wheel
 
+  - verify the wheel file doesn't have any errors.
+
+    * twine check dist/the_wheel_produced_above.whl 
+
   - upload the pre-release so that installation with pip succeeds.
 
     * twine upload dist/the_wheel_produced_above.whl 
@@ -150,7 +195,7 @@ To publish a pre-release one needs to:
   * ensure the two branches are ready on github.
 
       * pre-release branch ready.
-      * pre-release_py36 branch ready.
+      * pre_release_py36 branch ready.
 
   * update git repository (Import now): https://code.launchpad.net/~ssc-hpc-chp-spc/metpx-sarracenia/+git/trunk
 
@@ -168,7 +213,7 @@ To publish a pre-release one needs to:
 
   - find redhat 8 server. build package:: 
 
-        git checkout pre-release_py36
+        git checkout pre_release_py36
         git pull
         python3 setup.py bdist_rpm 
 
@@ -176,7 +221,7 @@ To publish a pre-release one needs to:
     
   - find redhat 9 server, build package::
 
-        git checkout pre-release_py36
+        git checkout pre_release_py36
         git pull
         python3 setup.py bdist_rpm 
 
@@ -184,7 +229,7 @@ To publish a pre-release one needs to:
 
 - build Windows installer:
 
-  - from an Ubuntu system::
+  - from an Ubuntu system (needs to have > python 3.10 installed)::
     
       # if not already installed:
       sudo apt install nsis


### PR DESCRIPTION
I removed the `| head -3` from the sr3_cpost command because it doesn't change anything when I tried it out on Ubuntu systems.

More `git pulls` and `git branch` are always good

Some typo corrections