### PR TITLE
Add httpUserAgent config option

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -916,7 +916,7 @@ class Config:
         self.log_flowcb_needed = False
         self.sleep = 0.1
         self.housekeeping = 300
-        self.httpUserAgent = None
+        self.httpUserAgent = 'Sarracenia ' + sarracenia.__version__
         self.inline = False
         self.inlineByteMax = 4096
         self.inlineEncoding = 'guess'

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -191,7 +191,7 @@ str_options = [
     'accelCpCommand', 'accelWgetCommand', 'accelScpCommand',
     'action', 'admin', 'baseDir', 'broker', 'cluster', 'directory', 'exchange',
     'exchangeSuffix', 'feeder', 'filename', 'flatten', 'flowMain', 'header', 
-    'hostname', 'httpsSafeQuote', 'identity', 'inlineEncoding', 'logFormat', 'logLevel',
+    'hostname', 'httpsSafeQuote', 'httpUserAgent', 'identity', 'inlineEncoding', 'logFormat', 'logLevel',
     'pollUrl', 'post_baseUrl', 'post_baseDir', 'post_broker', 'post_exchange',
     'post_exchangeSuffix', 'post_format', 'post_topic', 'queueName', 'queueShare', 'queueType', 'sendTo', 'rename',
     'report_exchange', 'source', 'strip', 'timezone', 'nodupe_ttl', 'nodupe_driver', 
@@ -916,6 +916,7 @@ class Config:
         self.log_flowcb_needed = False
         self.sleep = 0.1
         self.housekeeping = 300
+        self.httpUserAgent = None
         self.inline = False
         self.inlineByteMax = 4096
         self.inlineEncoding = 'guess'

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -162,12 +162,6 @@ class Https(Transfer):
         if not self.credentials(): 
             self.connected = False
 
-        ua = 'Sarracenia ' + sarracenia.__version__
-        if self.o.httpUserAgent:
-            safe_ua = self.o.httpUserAgent.replace('\r', '').replace('\n', '')
-            ua += ' ' + safe_ua
-        self.user_agent = ua
-
         self.connected = True
         return self.connected
 
@@ -266,7 +260,6 @@ class Https(Transfer):
         self.head_opener = None
         self.password_mgr = None
 
-        self.user_agent = 'Sarracenia ' + sarracenia.__version__
         self.urlstr = ''
         self.path = ''
         self.cwd = ''
@@ -356,7 +349,7 @@ class Https(Transfer):
         alarm_set(self.o.timeout)
 
         try:
-            headers = {'user-agent': self.user_agent}
+            headers = {'user-agent': self.o.httpUserAgent}
 
             # Bearer token credential is passed as a header
             if self.bearer_token:

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -162,6 +162,12 @@ class Https(Transfer):
         if not self.credentials(): 
             self.connected = False
 
+        ua = 'Sarracenia ' + sarracenia.__version__
+        if self.o.httpUserAgent:
+            safe_ua = self.o.httpUserAgent.replace('\r', '').replace('\n', '')
+            ua += ' ' + safe_ua
+        self.user_agent = ua
+
         self.connected = True
         return self.connected
 
@@ -260,6 +266,7 @@ class Https(Transfer):
         self.head_opener = None
         self.password_mgr = None
 
+        self.user_agent = 'Sarracenia ' + sarracenia.__version__
         self.urlstr = ''
         self.path = ''
         self.cwd = ''
@@ -349,8 +356,8 @@ class Https(Transfer):
         alarm_set(self.o.timeout)
 
         try:
-            headers = {'user-agent': 'Sarracenia ' + sarracenia.__version__}
-            
+            headers = {'user-agent': self.user_agent}
+
             # Bearer token credential is passed as a header
             if self.bearer_token:
                 logger.debug('bearer_token: %s' % self.bearer_token)


### PR DESCRIPTION
##### Summary
- Adds `httpUserAgent` string option to append a custom suffix to the default `Sarracenia <version>` user-agent header in HTTP(S) requests
- User-agent string is built once in `connect()` rather than reconstructed on every request
- CRLF characters are stripped from user input to prevent HTTP header injection (defense-in-depth)

Closes #1477

##### Test plan
- [ ] Set `httpUserAgent MyApp/1.0` in config, verify header sent
- [ ] Verify default behavior unchanged when option is not set