### PR TITLE
Fix NameError and dead code in SFTP mkdir

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -457,19 +457,17 @@ class Sftp(Transfer):
         logger.debug("mkdir %s" % remote_dir)
         alarm_set(self.o.timeout)
         try:
-            s = self.sftp.lstat(path)
+            s = self.sftp.lstat(remote_dir)
             if S_ISDIR(s.st_mode):
                 return
-            logger.error( f"cannot mkdir {path}, file exists" )
+            logger.error(f"cannot mkdir {remote_dir}, file exists")
             return
         except FileNotFoundError:
-            pass
-        except:
-            return
-        else:
             self.sftp.mkdir(remote_dir, self.o.permDirDefault)
             # Apply permDirDefault value. mkdir is limited by SFTP server umask value
             self.sftp.chmod(remote_dir, self.o.permDirDefault)
+        except Exception:
+            return
         finally:
             alarm_cancel()
 


### PR DESCRIPTION
I found a couple of issues doing a sweep of sftp.py, here's the first.

The `mkdir` method has two bugs:

1. **NameError** -it references an undefined variable `path` instead of the parameter `remote_dir`. This would crash every time `mkdir` is called.

2. **Dead code** - the actual `mkdir`/`chmod` logic was in a `try/except/else` block's `else` clause, which only runs if the `try` succeeds with no exception. But every success path in the `try` does `return`, so the `else` never executes. The directory never actually gets created.

Moved the `mkdir`/`chmod` into the `FileNotFoundError` handler where it belongs, and narrowed the bare `except:` to `except Exception:`.