### PR TITLE
Fix SFTP file handle leaks in get/put

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -372,17 +372,18 @@ class Sftp(Transfer):
 
         # read from rfp and write to local_file
 
-        rw_length = self.read_writelocal(remote_file, rfp, local_file,
-                                         local_offset, length, exactLength=False)
-
-        
-        # close
-
-        alarm_set(self.o.timeout)
         try:
-            rfp.close()
+            rw_length = self.read_writelocal(remote_file, rfp, local_file,
+                                             local_offset, length,
+                                             exactLength)
         finally:
-            alarm_cancel()
+            # close
+
+            alarm_set(self.o.timeout)
+            try:
+                rfp.close()
+            finally:
+                alarm_cancel()
 
         return rw_length
 
@@ -509,22 +510,25 @@ class Sftp(Transfer):
 
         # read from local_file and write to rfp
 
-        rw_length = self.readlocal_write(local_file, local_offset, length, rfp)
-
-        # no sparse file... truncate where we are at
-
-        alarm_set(self.o.timeout)
-        self.fpos = remote_offset + rw_length
-        if not self.o.nofsetstat and length != 0: 
-            try:
-                rfp.truncate(self.fpos)
-            except Exception as ex:
-                logger.warning( f"truncate {remote_file} failed: {ex}")
-                logging.debug("Exception details:", exc_info=True)
         try:
-            rfp.close()
+            rw_length = self.readlocal_write(local_file, local_offset,
+                                             length, rfp)
+
+            # no sparse file... truncate where we are at
+
+            self.fpos = remote_offset + rw_length
+            if not self.o.nofsetstat and length != 0:
+                try:
+                    rfp.truncate(self.fpos)
+                except Exception as ex:
+                    logger.warning(f"truncate {remote_file} failed: {ex}")
+                    logging.debug("Exception details:", exc_info=True)
         finally:
-            alarm_cancel()
+            alarm_set(self.o.timeout)
+            try:
+                rfp.close()
+            finally:
+                alarm_cancel()
 
         return rw_length
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -375,7 +375,7 @@ class Sftp(Transfer):
         try:
             rw_length = self.read_writelocal(remote_file, rfp, local_file,
                                              local_offset, length,
-                                             exactLength)
+                                             exactLength=False)
         finally:
             # close
 


### PR DESCRIPTION
Second one from the sftp.py sweep -- same category as #1559 and PR #1578 but in different methods.

`get()` and `put()` both open a remote file pointer (`rfp`) but don't close it if the read/write operation throws an exception. If the transfer fails mid-stream (timeout, network drop, etc.), the fd leaks. Do that enough times and you hit "too many open files."

Fixed by wrapping the read/write calls in try/finally so `rfp.close()` always runs.

Also caught that `get()` was hardcoding `exactLength=False` instead of passing the caller's value through to `read_writelocal` -- now it passes the actual parameter.