### PR TITLE
Add timeout protection to SFTP stat

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -573,10 +573,13 @@ class Sftp(Transfer):
 
     #when sftp is active, paramiko is present... STFPAttributes is then the same as FmdStat.
     def stat(self, path, msg=None) -> sarracenia.filemetadata.FmdStat:
+        alarm_set(self.o.timeout)
         try:
             return self.sftp.stat(path)
-        except:
+        except Exception:
             return None
+        finally:
+            alarm_cancel()
 
     # utime
     def utime(self, path, tup):


### PR DESCRIPTION
Third from the sftp.py sweep.

Every other SFTP operation in this class wraps paramiko calls in alarm_set/alarm_cancel to bail out if the connection stalls, but stat() was missing it. On a hung connection, stat() would block the process forever with no timeout.

Also narrowed the bare `except:` to `except Exception:` so we don't accidentally swallow SystemExit or KeyboardInterrupt.