### PR TITLE
Move alarm_cancel into finally blocks in FTP/SFTP close and delete

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -199,8 +199,8 @@ class Ftp(Transfer):
         except Exception as e:
             logger.error("FTP connection couldn't close properly.")
             logger.debug("Exception details:", exc_info=True)
-
-        alarm_cancel()
+        finally:
+            alarm_cancel()
 
     # connect...
     def connect(self):
@@ -309,7 +309,8 @@ class Ftp(Transfer):
             self.ftp.delete(path)
         except:
             d = self.ftp.pwd()
-        alarm_cancel()
+        finally:
+            alarm_cancel()
 
     # get
     def get(self,

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -189,16 +189,14 @@ class Sftp(Transfer):
 
         alarm_set(self.o.timeout)
         try:
-            try:
-                old_sftp.close()
-            except:
-                pass
-            try:
-                old_ssh.close()
-            except:
-                pass
-        finally:
-            alarm_cancel()
+            old_sftp.close()
+        except:
+            pass
+        try:
+            old_ssh.close()
+        except:
+            pass
+        alarm_cancel()
 
     # connect...
     def connect(self):

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -189,14 +189,16 @@ class Sftp(Transfer):
 
         alarm_set(self.o.timeout)
         try:
-            old_sftp.close()
-        except:
-            pass
-        try:
-            old_ssh.close()
-        except:
-            pass
-        alarm_cancel()
+            try:
+                old_sftp.close()
+            except:
+                pass
+            try:
+                old_ssh.close()
+            except:
+                pass
+        finally:
+            alarm_cancel()
 
     # connect...
     def connect(self):


### PR DESCRIPTION
close #1588

Last one from the sftp/ftp sweep.

A few spots in ftp.py and sftp.py had alarm_cancel() sitting after the try block instead of in a finally clause. If the except handler itself raises (e.g. ftp close() catches EOFError and calls old_ftp.close() which also fails), the alarm stays armed and could fire a spurious TimeoutException during whatever happens next.

Low probability but real — and the fix is just moving alarm_cancel() into finally where it should've been.