### PR TITLE
v2: Fix issue #1449 where v2 gets stuck in an infinite loop

### DIFF
--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -160,6 +160,10 @@ class HostConnect:
             except Exception as err:
                 self.logger.error("AMQP cannot connect to {} with {}".format(self.host, err))
                 self.logger.debug('Exception details: ', exc_info=True)
+                try:
+                    self.close()
+                except:
+                    pass
 
                 if not self.loop:
                     self.logger.error("giving up. Failed to connect to broker")
@@ -584,6 +588,11 @@ class Queue:
                 time.sleep(backoff)
                 if backoff < 60:
                     backoff *= 2
+                # https://github.com/MetPX/sarracenia/issues/1449
+                # don't get stuck in an infinite loop, give up if not bound successfully after multiple attempts
+                else:
+                    self.logger.error("failed to bind queue multiple times, giving up")
+                    raise Exception("failed to bind queue")
 
         self.logger.debug("queue build done")
 

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -582,6 +582,8 @@ class Queue:
                 except (BrokenPipeError, ConnectionResetError):
                     self.logger.error("lost connection to broker, attempting to reconnect")
                     self.hc.reconnect()
+                    bound = 0 # restart binding from the beginning
+                    break # out of for loop
                 except Exception as err:
                     self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
                                   % (self.name, exchange_name, exchange_key, err))

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -578,8 +578,9 @@ class Queue:
                     bound += 1
                     continue
                 # https://github.com/MetPX/sarracenia/issues/1449
-                # can't recover from these exceptions in this loop, need to reconnect to the broker
+                # need to reconnect to the broker when one of these exceptions occurs
                 except (BrokenPipeError, ConnectionResetError):
+                    self.logger.error("lost connection to broker, attempting to reconnect")
                     self.hc.reconnect()
                 except Exception as err:
                     self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
@@ -592,10 +593,6 @@ class Queue:
                 time.sleep(backoff)
                 if backoff < 60:
                     backoff *= 2
-                # https://github.com/MetPX/sarracenia/issues/1449
-                # don't get stuck in an infinite loop, try reconnecting if binding continues to fail
-                else:
-                    self.hc.reconnect()
 
         self.logger.debug("queue build done")
 

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -582,8 +582,6 @@ class Queue:
                 except (BrokenPipeError, ConnectionResetError):
                     self.logger.error("lost connection to broker, attempting to reconnect")
                     self.hc.reconnect()
-                    bound = 0 # restart binding from the beginning
-                    break # out of for loop
                 except Exception as err:
                     self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
                                   % (self.name, exchange_name, exchange_key, err))
@@ -595,6 +593,8 @@ class Queue:
                 time.sleep(backoff)
                 if backoff < 60:
                     backoff *= 2
+                bound = 0 # restart binding from the beginning
+                break # out of for loop
 
         self.logger.debug("queue build done")
 

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -582,6 +582,26 @@ class Queue:
                 except (BrokenPipeError, ConnectionResetError):
                     self.logger.error("lost connection to broker, attempting to reconnect")
                     self.hc.reconnect()
+                except amqp.exceptions.NotFound as err:
+                    # this is ugly, but if the queue doesn't exist, it needs to be created otherwise binding will fail
+                    # restart from the beginning by calling itself again
+                    if "Queue.bind: (404) NOT_FOUND - no queue" in str(err):
+                        self.logger.error("bind queue: %s failed because queue does not exist %s"
+                                  % (self.name, err))
+                        self.logger.debug('Exception details:', exc_info=True)
+                        self.build()
+                        return
+                    elif "Queue.bind: (404) NOT_FOUND - no exchange" in str(err):
+                        self.logger.error("bind queue: %s to exchange: %s failed because exchange does not exist %s"
+                                  % (self.name, exchange_name, err))
+                        self.logger.debug('Exception details:', exc_info=True)
+                    else:
+                        self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
+                                  % (self.name, exchange_name, exchange_key, err))
+                        # FIXME unsuitable error msg: The exception is too broad to conclude this is a permission issue
+                        self.logger.error("Permission issue with %s@%s or exchange %s not found."
+                                      % (self.hc.user, self.hc.host, exchange_name))
+                        self.logger.debug('Exception details:', exc_info=True)
                 except Exception as err:
                     self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
                                   % (self.name, exchange_name, exchange_key, err))

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -577,6 +577,10 @@ class Queue:
                     last_exchange_name = exchange_name
                     bound += 1
                     continue
+                # https://github.com/MetPX/sarracenia/issues/1449
+                # can't recover from these exceptions in this loop, caller needs to reconnect to the broker
+                except (BrokenPipeError, ConnectionResetError):
+                    raise
                 except Exception as err:
                     self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
                                   % (self.name, exchange_name, exchange_key, err))

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -578,9 +578,9 @@ class Queue:
                     bound += 1
                     continue
                 # https://github.com/MetPX/sarracenia/issues/1449
-                # can't recover from these exceptions in this loop, caller needs to reconnect to the broker
+                # can't recover from these exceptions in this loop, need to reconnect to the broker
                 except (BrokenPipeError, ConnectionResetError):
-                    raise
+                    self.hc.reconnect()
                 except Exception as err:
                     self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
                                   % (self.name, exchange_name, exchange_key, err))
@@ -593,10 +593,9 @@ class Queue:
                 if backoff < 60:
                     backoff *= 2
                 # https://github.com/MetPX/sarracenia/issues/1449
-                # don't get stuck in an infinite loop, give up if not bound successfully after multiple attempts
+                # don't get stuck in an infinite loop, try reconnecting if binding continues to fail
                 else:
-                    self.logger.error("failed to bind queue multiple times, giving up")
-                    raise Exception("failed to bind queue")
+                    self.hc.reconnect()
 
         self.logger.debug("queue build done")
 

--- a/sarra/sr_amqp.py
+++ b/sarra/sr_amqp.py
@@ -595,6 +595,8 @@ class Queue:
                         self.logger.error("bind queue: %s to exchange: %s failed because exchange does not exist %s"
                                   % (self.name, exchange_name, err))
                         self.logger.debug('Exception details:', exc_info=True)
+                        # we don't declare exchanges in a subscriber, that's the publisher's responsibility
+                        # need to sit here and retry until the exchange gets created or permissions get fixed
                     else:
                         self.logger.error("bind queue: %s to exchange: %s with key: %s failed with %s"
                                   % (self.name, exchange_name, exchange_key, err))


### PR DESCRIPTION
I marked issue #1449 as wontfix a while ago, but we keep having this bug cause issues, so I tried fixing it. It's annoying because when it happens, we have to login to a bunch of regional servers and restart sarra processes there. (Those will hopefully be upgraded to sr3 in May, but this will still help reduce the chance of problems in other places where v2 will stay a bit longer).

There are instructions to reproduce the issue inside #1449.

I made a lot of commits with small changes before I got it right, it's best to only look at the "Files Changed" tab.

I also realized that another way to get stuck in an infinite loop was by trying to create bindings on a queue that had been deleted. It's unlikely to happen, but I think it's possible so I added a fix for that too.

Using the latest sr_insects, the flow tests are inconsistent and broken:

**Static:**
```
v2_dev:       31/34, 33/34, 33/34
v2_issue1449: 31/34, 31/34, 33/34
```

**Flakey:**
```
v2_dev:       31/33, 18/33, 31/33, 31/33
v2_issue1449: 31/33, 30/33, 32/33, 31/33, 31/33
```


Using sr_insects commit 97f828e (most recent one that mentions v2):

**Flakey:**
```
v2_dev:       33/33, 33/33
v2_issue1449: 33/33, 33/33
```