### PR TITLE
Fix pid/state file race condition during sr3 restart

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -653,8 +653,7 @@ class sr_GlobalState:
                                             with p.open() as f:
                                                 t = f.read().strip()
                                     except FileNotFoundError:
-                                        logger.error("pid file %s disappeared (race condition, see #1571), treating as missing", filename)
-                                        missing.append([c, cfg, i])
+                                        logger.error("pid file %s disappeared (race condition, see #1571), skipping.", filename)
                                         continue
                                     if t.isdigit():
                                         pid = int(t)

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -516,12 +516,16 @@ class sr_GlobalState:
                         for pathname in state_files:
                             p = pathlib.Path(pathname)
                             if p.suffix in ['.pid', '.qname', '.state', '.noVip']:
-                                if sys.version_info[0] > 3 or sys.version_info[
-                                        1] > 4:
-                                    t = p.read_text().strip()
-                                else:
-                                    with p.open() as f:
-                                        t = f.read().strip()
+                                try:
+                                    if sys.version_info[0] > 3 or sys.version_info[
+                                            1] > 4:
+                                        t = p.read_text().strip()
+                                    else:
+                                        with p.open() as f:
+                                            t = f.read().strip()
+                                except FileNotFoundError:
+                                    logger.error("state file %s disappeared (race condition, see #1571), skipping", pathname)
+                                    continue
                                 #print( 'read pathname:%s len: %d contents:%s' % ( pathname, len(t), t[0:10] ) )
                                 if len(t) == 0:
                                     continue
@@ -641,12 +645,17 @@ class sr_GlobalState:
                                 i_found.append(i)
                                 if i != 0:
                                     p = pathlib.Path(filename)
-                                    if sys.version_info[0] > 3 or sys.version_info[
-                                            1] > 4:
-                                        t = p.read_text().strip()
-                                    else:
-                                        with p.open() as f:
-                                            t = f.read().strip()
+                                    try:
+                                        if sys.version_info[0] > 3 or sys.version_info[
+                                                1] > 4:
+                                            t = p.read_text().strip()
+                                        else:
+                                            with p.open() as f:
+                                                t = f.read().strip()
+                                    except FileNotFoundError:
+                                        logger.error("pid file %s disappeared (race condition, see #1571), treating as missing", filename)
+                                        missing.append([c, cfg, i])
+                                        continue
                                     if t.isdigit():
                                         pid = int(t)
                                         if pid not in self.procs:
@@ -690,12 +699,16 @@ class sr_GlobalState:
                         for filename in os.listdir():
                             if filename[-4:] == '.pid':
                                 p = pathlib.Path(filename)
-                                if sys.version_info[0] > 3 or sys.version_info[
-                                        1] > 4:
-                                    t = p.read_text().strip()
-                                else:
-                                    with p.open() as f:
-                                        t = f.read().strip()
+                                try:
+                                    if sys.version_info[0] > 3 or sys.version_info[
+                                            1] > 4:
+                                        t = p.read_text().strip()
+                                    else:
+                                        with p.open() as f:
+                                            t = f.read().strip()
+                                except FileNotFoundError:
+                                    logger.error("pid file %s disappeared (race condition, see #1571), skipping cleanup", filename)
+                                    continue
                                 if t.isdigit():
                                     pid = int(t)
                                     if pid not in self.procs:


### PR DESCRIPTION
##### Summary
- Wraps all three `read_text()`/`open()` calls in `sr.py` with `try/except FileNotFoundError` to handle the race condition where a pid or state file disappears between `os.listdir()` and the subsequent read during concurrent process shutdown.
- Logs at `error` level with a reference to #1571 in each message.
- Covers all three vulnerable call sites (the original PR #1577 only addressed one).

@andreleblanc11 this cool?

Closes #1571

##### Test plan
- @andreleblanc11 to test on ECCC staging environment with `sr3 restart` under load 
- Confirm no crash on `FileNotFoundError` when pid files vanish mid-restart
- Verify error messages appear in logs with issue reference