### PR TITLE
Log post failures before retry clears worklist.failed

### DIFF
--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -170,6 +170,9 @@ class Retry(FlowCB):
         for m in worklist.failed:
             self.__set_isRetry(m)
 
+        for m in worklist.failed:
+            logger.warning("post failed, queued to retry: %s %s" %
+                           (m.get('baseUrl', ''), m.get('relPath', '')))
         self.post_retry.put(worklist.failed)
         worklist.failed=[]
 


### PR DESCRIPTION
##### Summary
- The `retry` plugin's `after_post` runs before the `log` plugin, so by the time `log.after_post` checks `worklist.failed` it's already empty — failed posts are never logged.
- Added a `logger.warning` in `retry.after_post` that logs each failed message before clearing the list.

Closes #1590

##### Approach
There were a few ways to handle this — reordering plugin load order, stashing failed messages for log.py to pick up later, or just logging directly in retry.py before clearing the list. Went with the simplest option. If you'd rather handle it differently let me know.

##### Test plan
- Configure a sender pointing to an unreachable destination
- Confirm failed post messages now appear in the log as warnings
- Verify retry queue still works as before