### PR TITLE
Add retryCountMax option to limit retry attempts

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -84,6 +84,7 @@ default_options = {
     'amqp_consumer': False,
     'attempts': 3,
     'batch' : 100,
+    'retryCountMax': 0,
     'baseDir': None,
     'baseUrl_relPath': False,
     'delete': False,
@@ -137,8 +138,8 @@ default_options = {
 }
 
 count_options = [
-    'batch', 'count', 'exchangeSplit', 'instances', 'logRotateCount', 'no', 
-    'post_exchangeSplit', 'prefetch', 'messageCountMax', 'runStateThreshold_cpuSlow', 
+    'batch', 'count', 'exchangeSplit', 'instances', 'logRotateCount', 'no',
+    'post_exchangeSplit', 'prefetch', 'messageCountMax', 'retryCountMax', 'runStateThreshold_cpuSlow',
     'runStateThreshold_disconnected', 
     'runStateThreshold_reject', 'runStateThreshold_retry', 'runStateThreshold_slow', 
 ]

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -138,8 +138,11 @@ class Retry(FlowCB):
             return
 
         if len(worklist.failed) != 0:
-            logger.debug('putting %s messages into %s', len(worklist.failed), self.download_retry_name)
-            self.download_retry.put(worklist.failed)
+            for m in worklist.failed:
+                self.__set_isRetry(m)
+            to_retry = self.__filter_by_retry_count(worklist.failed)
+            logger.debug('putting %s messages into %s', len(to_retry), self.download_retry_name)
+            self.download_retry.put(to_retry)
             worklist.failed = []
 
         if len(self.post_retry) < 1:

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -92,6 +92,7 @@ class Retry(FlowCB):
                     del m[k]
             self.__set_isRetry(m)
 
+        message_list = self.__filter_by_retry_count(message_list)
 
         return (True, message_list)
 
@@ -121,6 +122,8 @@ class Retry(FlowCB):
 
         for m in mlist:
             self.__set_isRetry(m)
+
+        mlist = self.__filter_by_retry_count(mlist)
 
         #logger.debug("loading from %s: qty=%d ... got: %d " % (self.download_retry_name, qty, len(mlist)))
         if len(mlist) > 0:
@@ -170,7 +173,9 @@ class Retry(FlowCB):
         for m in worklist.failed:
             self.__set_isRetry(m)
 
-        self.post_retry.put(worklist.failed)
+        to_retry = self.__filter_by_retry_count(worklist.failed)
+
+        self.post_retry.put(to_retry)
         worklist.failed=[]
 
     def metricsReport(self) -> dict:
@@ -224,3 +229,17 @@ class Retry(FlowCB):
         if '_deleteOnPost' not in msg:
             msg['_deleteOnPost'] = set()
         msg['_deleteOnPost'].add('_isRetry')
+
+    def __filter_by_retry_count(self, message_list):
+        if self.o.retryCountMax <= 0:
+            return message_list
+
+        kept = []
+        for m in message_list:
+            count = m.get('_isRetry', 0)
+            if count > self.o.retryCountMax:
+                logger.error("gave up after %d retries: %s %s" %
+                             (count, m.get('baseUrl', ''), m.get('relPath', '')))
+            else:
+                kept.append(m)
+        return kept

--- a/tests/sarracenia/flowcb/retry_test.py
+++ b/tests/sarracenia/flowcb/retry_test.py
@@ -24,6 +24,7 @@ class Options:
         self.pid_filename = "/tmp/sarracenia/retyqueue_test/pid_filename"
         self.housekeeping = float(0)
         self.batch = 0
+        self.retryCountMax = 0
     def add_option(self, option, type, default = None):
         if not hasattr(self, option):
             setattr(self, option, default)


### PR DESCRIPTION
##### Summary
- New config option `retryCountMax` (default `0` = unlimited) that drops messages from the retry queue after they've been retried too many times.
- Works alongside `retry_ttl` — whichever condition is reached first applies.
- The existing `_isRetry` counter (already an integer) is checked at all three points where messages come out of or go into retry queues: `gather()`, `after_accept()`, and `after_post()`.
- Messages that exceed the limit are logged at ERROR and discarded.

Closes #1475

##### Usage
```
retryCountMax 5
```
With `attempts 3` and `retryCountMax 5`, a message gets up to 3 transfer attempts per retry cycle, for up to 5 cycles, before being permanently dropped.

##### Test plan
- Set `retryCountMax` to a small value (e.g. 2) with an unreachable destination
- Verify messages are retried the expected number of times then dropped with an ERROR log
- Verify default (`retryCountMax 0`) preserves current unlimited behavior
- Verify interaction with `retry_ttl` — whichever limit is hit first should apply