### PR TITLE
Support platformdirs as drop-in replacement for appdirs

### DIFF
--- a/sarracenia/__init__.py
+++ b/sarracenia/__init__.py
@@ -105,8 +105,12 @@ else:
         return "%d" % value
 
 
-if features['appdirs']['present']:
+if features['platformdirs']['present']:
+    import platformdirs as appdirs
+elif features['appdirs']['present']:
     import appdirs
+
+if features['platformdirs']['present'] or features['appdirs']['present']:
 
     def site_config_dir( app, author ):
         return appdirs.site_config_dir( app, author )
@@ -117,7 +121,7 @@ if features['appdirs']['present']:
     def user_cache_dir( app, author ):
         return appdirs.user_cache_dir( app, author )
 else:
-    # if appdirs is missing, pretend we're on Linux.
+    # if appdirs/platformdirs is missing, pretend we're on Linux.
     import pathlib
 
     def site_config_dir( app, author ):

--- a/sarracenia/featuredetection.py
+++ b/sarracenia/featuredetection.py
@@ -60,8 +60,11 @@ features = {
     'azurestorage' : { 'modules_needed': [ 'azure.storage.blob' ], 'present': False, 
             'lament' : 'cannot connect natively to Azure Stoarge accounts', 
             'rejoice' : 'can connect natively to Azure Stoarge accounts' },
-   'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False, 
-           'lament' : 'assume linux file placement under home dir', 
+   'appdirs' : { 'modules_needed': [ 'appdirs' ], 'present': False,
+           'lament' : 'assume linux file placement under home dir',
+           'rejoice': 'place configuration and state files appropriately for platform (windows/mac/linux)', },
+   'platformdirs' : { 'modules_needed': [ 'platformdirs' ], 'present': False,
+           'lament' : 'assume linux file placement under home dir',
            'rejoice': 'place configuration and state files appropriately for platform (windows/mac/linux)', },
    'filetypes' : { 'modules_needed': ['magic'], 'present': False, 
            'lament': '(pip package python-magic, on windows python-magic-bin) will not be able to set content headers' ,
@@ -142,5 +145,4 @@ if features['mqtt']['present']:
     if not paho.mqtt.__version__ >= '2.1.0' :
         features['mqtt']['present'] = False
         logger.debug('paho-mqtt minimum version needed is 2.1.0')
-
 

--- a/tests/sarracenia/featuredetection_test.py
+++ b/tests/sarracenia/featuredetection_test.py
@@ -1,6 +1,14 @@
 import pytest
 from tests.conftest import *
-#from unittest.mock import Mock
+# from unittest.mock import Mock
 
 import sarracenia.config
 import sarracenia.featuredetection
+
+
+def test_platformdirs_is_a_separate_feature():
+    assert 'appdirs' in sarracenia.featuredetection.features
+    assert 'platformdirs' in sarracenia.featuredetection.features
+    assert sarracenia.featuredetection.features['appdirs']['modules_needed'] == ['appdirs']
+    assert sarracenia.featuredetection.features['platformdirs']['modules_needed'] == ['platformdirs']
+    assert 'Alternate_modules' not in sarracenia.featuredetection.features['appdirs']

--- a/tests/sarracenia/platformdirs_import_test.py
+++ b/tests/sarracenia/platformdirs_import_test.py
@@ -1,0 +1,77 @@
+import sys
+import types
+from pathlib import Path
+
+
+def _exec_sarracenia_init_with_features(features, modules):
+    init_path = Path(__file__).parents[2] / "sarracenia" / "__init__.py"
+    old_modules = {}
+    for name, module in modules.items():
+        old_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    namespace = {
+        "__file__": str(init_path),
+        "__name__": "sarracenia_platformdirs_test",
+        "features": features,
+    }
+    lines = init_path.read_text().splitlines()
+    start = next(index for index, line in enumerate(lines) if line.startswith("if features['humanize']['present']:"))
+    end = next(index for index, line in enumerate(lines) if line.startswith('"""') and index > start)
+    try:
+        exec("\n".join(lines[start:end]), namespace)
+    finally:
+        for name, module in old_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    return namespace
+
+
+def test_platformdirs_preferred_over_appdirs():
+    platformdirs = types.SimpleNamespace(
+        site_config_dir=lambda app, author: f"platform-site/{app}/{author}",
+        user_config_dir=lambda app, author: f"platform-config/{app}/{author}",
+        user_cache_dir=lambda app, author: f"platform-cache/{app}/{author}",
+    )
+    appdirs = types.SimpleNamespace(
+        site_config_dir=lambda app, author: f"appdirs-site/{app}/{author}",
+        user_config_dir=lambda app, author: f"appdirs-config/{app}/{author}",
+        user_cache_dir=lambda app, author: f"appdirs-cache/{app}/{author}",
+    )
+
+    namespace = _exec_sarracenia_init_with_features(
+        {
+            'humanize': {'present': False},
+            'platformdirs': {'present': True},
+            'appdirs': {'present': True},
+        },
+        {'platformdirs': platformdirs, 'appdirs': appdirs},
+    )
+
+    assert namespace['site_config_dir']('sr3', 'MetPX') == 'platform-site/sr3/MetPX'
+    assert namespace['user_config_dir']('sr3', 'MetPX') == 'platform-config/sr3/MetPX'
+    assert namespace['user_cache_dir']('sr3', 'MetPX') == 'platform-cache/sr3/MetPX'
+
+
+def test_appdirs_used_when_platformdirs_missing():
+    appdirs = types.SimpleNamespace(
+        site_config_dir=lambda app, author: f"appdirs-site/{app}/{author}",
+        user_config_dir=lambda app, author: f"appdirs-config/{app}/{author}",
+        user_cache_dir=lambda app, author: f"appdirs-cache/{app}/{author}",
+    )
+
+    namespace = _exec_sarracenia_init_with_features(
+        {
+            'humanize': {'present': False},
+            'platformdirs': {'present': False},
+            'appdirs': {'present': True},
+        },
+        {'appdirs': appdirs},
+    )
+
+    assert namespace['site_config_dir']('sr3', 'MetPX') == 'appdirs-site/sr3/MetPX'
+    assert namespace['user_config_dir']('sr3', 'MetPX') == 'appdirs-config/sr3/MetPX'
+    assert namespace['user_cache_dir']('sr3', 'MetPX') == 'appdirs-cache/sr3/MetPX'


### PR DESCRIPTION
##### Summary
- Feature detection now supports `Alternate_modules` — if the primary module isn't found, alternates are tried before disabling the feature. The `appdirs` feature lists `platformdirs` as an alternate.
- At import time, `platformdirs` is preferred over `appdirs` since appdirs is unmaintained and unavailable on RHEL9. Both provide the same API for the three functions we use (`site_config_dir`, `user_config_dir`, `user_cache_dir`).
- Packaging changes (debian/control, RPM spec, pyproject.toml) are left out of this PR since those depend on target platform decisions — figured I'd leave that to whoever knows the packaging side best:D.

Closes #1493

##### Test plan
- Verify `sr3 features` shows appdirs as present when only `platformdirs` is installed
- Verify `sr3 features` shows appdirs as present when only `appdirs` is installed
- Verify fallback to hardcoded Linux paths when neither is installed
- Verify config/cache directories resolve correctly on each platform