### PR TITLE
Fix messageRateMax throttle to converge accurately

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -662,11 +662,14 @@ class Flow:
 
             if (self.o.messageRateMax > 0) and (current_rate >=
                                                 self.o.messageRateMax):
-                stime = 1 + 2 * ((current_rate - self.o.messageRateMax) /
-                                 self.o.messageRateMax)
+                # sleep exactly long enough to bring the average rate to the target:
+                # we want total_messages / (run_time + sleep) == messageRateMax
+                stime = (total_messages / self.o.messageRateMax) - run_time
+                if stime < 0:
+                    stime = 0
                 logger.info(
-                    "current_rate/2 (%.2f) above messageRateMax(%.2f): throttling"
-                    % (current_rate, self.o.messageRateMax))
+                    "current_rate (%.2f) above messageRateMax(%.2f): sleeping %.2fs"
+                    % (current_rate, self.o.messageRateMax, stime))
             else:
                 logger.debug( f" not throttling: limit: {self.o.messageRateMax} " )
                 stime = 0


### PR DESCRIPTION
##### Summary
- The old throttle formula `1 + 2 * ((current_rate - max) / max)` didn't sleep long enough to bring the rate down to the target. It would stabilize around 2-3x the configured limit.
- Replaced with an exact calculation: `sleep = total_messages / messageRateMax - run_time`. This guarantees the cumulative average rate equals the target after sleeping.
- Example: 10 messages in 5 seconds (rate=2.0), limit 0.2 -> sleep 45s -> rate becomes 10/50 = 0.2

Closes #1555

##### Test plan
- Set `messageRateMax 0.2` with `batch 1` against a fast source
- Verify the rate converges to the target instead of stabilizing above it
- Verify the log message shows the actual sleep duration for easier debugging
- Verify that `messageRateMax 0` (default, unlimited) still works with no throttling