### PR TITLE
Fix sleep duration in flow algorithm #1035

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -680,7 +680,7 @@ class Flow:
                             % (stime, elapsed, self.o.sleep))
                 else:
                     logger.debug('worked too long to sleep!')
-                    last_time = nowflt()
+                    last_time = now
                     continue
 
             if not self._stop_requested and (stime > 0):
@@ -702,7 +702,7 @@ class Flow:
                     if now_for_hk > next_housekeeping:
                         next_housekeeping = self._runHousekeeping(now_for_hk)
 
-                last_time = now
+                last_time = nowflt()
 
 
     def sundew_getDestInfos(self, msg, currentFileOption, filename):

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -680,7 +680,7 @@ class Flow:
                             % (stime, elapsed, self.o.sleep))
                 else:
                     logger.debug('worked too long to sleep!')
-                    last_time = now
+                    last_time = nowflt()
                     continue
 
             if not self._stop_requested and (stime > 0):


### PR DESCRIPTION
This small change makes the sleep in the flow algorithm behave like it's supposed to. It will now stop incrementing the sleep duration when the maximum value is reached (5 seconds). It used to toggle between to semi-arbitrary values.

See https://github.com/MetPX/sarracenia/issues/1035#issuecomment-4040096918 for more details on the explanation.

