### PR TITLE
Replace eval() with getattr() for callback dispatch

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -285,19 +285,22 @@ class Flow:
 
     def _runCallbacksWorklist(self, entry_point):
 
-        if hasattr(self, entry_point):
-            if self.o.logLevel.lower() == 'debug' :
-                eval( f"self.{entry_point}(self.worklist)")
+        debug = self.o.logLevel.lower() == 'debug'
+
+        fn = getattr(self, entry_point, None)
+        if fn is not None:
+            if debug:
+                fn(self.worklist)
             else:
                 try:
-                    eval( f"self.{entry_point}(self.worklist)")
+                    fn(self.worklist)
                 except Exception as ex:
                     logger.error( f'flow {entry_point} crashed: {ex}' )
                     logger.debug( "details:", exc_info=True )
 
         if hasattr(self, 'plugins') and (entry_point in self.plugins):
             for p in self.plugins[entry_point]:
-                if self.o.logLevel.lower() == 'debug' :
+                if debug:
                     p(self.worklist)
                 else:
                     try:
@@ -308,25 +311,29 @@ class Flow:
 
     def runCallbacksTime(self, entry_point):
 
-        if hasattr(self, entry_point):
-            if self.o.logLevel.lower() == 'debug' :
-                eval( f"self.{entry_point}()")
+        debug = self.o.logLevel.lower() == 'debug'
+
+        fn = getattr(self, entry_point, None)
+        if fn is not None:
+            if debug:
+                fn()
             else:
                 try:
-                    eval( f"self.{entry_point}()")
+                    fn()
                 except Exception as ex:
                     logger.error( f'flow {entry_point} crashed: {ex}' )
                     logger.debug( "details:", exc_info=True )
 
-        for p in self.plugins[entry_point]:
-            if self.o.logLevel.lower() == 'debug' :
-                p()
-            else:
-                try:
+        if entry_point in self.plugins:
+            for p in self.plugins[entry_point]:
+                if debug:
                     p()
-                except Exception as ex:
-                    logger.error( f'flowCallback plugin {p}/{entry_point} crashed: {ex}' )
-                    logger.debug( "details:", exc_info=True )
+                else:
+                    try:
+                        p()
+                    except Exception as ex:
+                        logger.error( f'flowCallback plugin {p}/{entry_point} crashed: {ex}' )
+                        logger.debug( "details:", exc_info=True )
 
     def _runCallbackMetrics(self):
         """Collect metrics from plugins with a ``metricsReport`` entry point.

--- a/tests/sarracenia/flow/callback_dispatch_test.py
+++ b/tests/sarracenia/flow/callback_dispatch_test.py
@@ -1,0 +1,96 @@
+"""
+Test that flow callback dispatch uses getattr instead of eval.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+
+class TestCallbackDispatch(unittest.TestCase):
+
+    def _make_flow(self):
+        flow = MagicMock()
+        flow.o = MagicMock()
+        flow.o.logLevel.lower.return_value = 'info'
+        flow.worklist = MagicMock()
+        flow.plugins = {
+            'after_accept': [MagicMock()],
+            'on_housekeeping': [MagicMock()],
+        }
+        return flow
+
+    def test_worklist_callback_calls_flow_method(self):
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        flow.after_accept = MagicMock()
+
+        Flow._runCallbacksWorklist(flow, 'after_accept')
+
+        flow.after_accept.assert_called_once_with(flow.worklist)
+
+    def test_worklist_callback_calls_plugins(self):
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        plugin = flow.plugins['after_accept'][0]
+
+        Flow._runCallbacksWorklist(flow, 'after_accept')
+
+        plugin.assert_called_once_with(flow.worklist)
+
+    def test_time_callback_calls_flow_method(self):
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        flow.on_housekeeping = MagicMock()
+
+        Flow.runCallbacksTime(flow, 'on_housekeeping')
+
+        flow.on_housekeeping.assert_called_once_with()
+
+    def test_time_callback_calls_plugins(self):
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        plugin = flow.plugins['on_housekeeping'][0]
+
+        Flow.runCallbacksTime(flow, 'on_housekeeping')
+
+        plugin.assert_called_once_with()
+
+    def test_worklist_callback_exception_handled(self):
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        flow.after_accept = MagicMock(side_effect=RuntimeError("boom"))
+
+        # Should not raise
+        Flow._runCallbacksWorklist(flow, 'after_accept')
+
+    def test_missing_entry_point_no_plugins(self):
+        """If no flow method and no plugins for entry_point, nothing happens."""
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        flow.plugins['nonexistent'] = []
+
+        # MagicMock has every attr by default, so remove it
+        delattr(flow, 'nonexistent')
+
+        # Should not raise
+        Flow._runCallbacksWorklist(flow, 'nonexistent')
+
+    def test_time_callback_missing_entry_point(self):
+        """runCallbacksTime should not KeyError on missing entry_point."""
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        delattr(flow, 'nonexistent')
+
+        # Should not raise — entry_point not in self.plugins
+        Flow.runCallbacksTime(flow, 'nonexistent')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #1607

##### what

Flow callback dispatch was using eval(f"self.{entry_point}(...)") to call flow subclass methods — compiling Python source on every batch, every callback entry point. Replaced with getattr() for a direct attribute lookup.

##### changes

- eval() -> getattr(self, entry_point, None) — single lookup, no string compilation
- logLevel.lower() cached once per method call instead of per-plugin-iteration
- Added missing entry_point guard in runCallbacksTime to prevent KeyError when no plugins are registered for an entry point

##### not included

Noticed that _runHousekeeping calls on_housekeeping twice per cycle (once inline, once via runCallbacksTime). Filed separately as #1608 since it's a behavior change that needs team input.