### PR TITLE
remove duplicate on_housekeeping call in _runHousekeeping

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -419,16 +419,6 @@ class Flow:
             Return the time when housekeeping should be run next
         """
         logger.info(f'on_housekeeping pid: {os.getpid()} {self.o.component}/{self.o.config} instance: {self.o.no}')
-        if hasattr(self, "on_housekeeping"):
-            if self._logLevel_debug :
-                self.on_housekeeping()
-            else:
-                try:
-                    self.on_housekeeping()
-                except Exception as ex:
-                    logger.error( f'flow on_housekeeping crashed: {ex}' )
-                    logger.debug( "details:", exc_info=True )
-
         self.runCallbacksTime('on_housekeeping')
         self.metricsFlowReset()
         self.metrics['flow']['last_housekeeping'] = now

--- a/tests/sarracenia/flow/callback_dispatch_test.py
+++ b/tests/sarracenia/flow/callback_dispatch_test.py
@@ -2,6 +2,7 @@
 Test that flow callback dispatch uses getattr instead of eval.
 """
 
+import time
 import unittest
 from unittest.mock import MagicMock
 
@@ -91,6 +92,24 @@ class TestCallbackDispatch(unittest.TestCase):
 
         # Should not raise — entry_point not in self.plugins
         Flow.runCallbacksTime(flow, 'nonexistent')
+
+    def test_runHousekeeping_calls_on_housekeeping_once(self):
+        """_runHousekeeping should dispatch on_housekeeping only through runCallbacksTime."""
+        from sarracenia.flow import Flow
+
+        flow = self._make_flow()
+        flow.o.component = 'flow'
+        flow.o.config = 'test'
+        flow.o.no = 0
+        flow.o.housekeeping = 300
+        flow.on_housekeeping = MagicMock()
+        flow.metricsFlowReset = MagicMock()
+        flow.metrics = {'flow': {}}
+        flow.runCallbacksTime = lambda entry_point: Flow.runCallbacksTime(flow, entry_point)
+
+        Flow._runHousekeeping(flow, time.time())
+
+        flow.on_housekeeping.assert_called_once_with()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### Summary

Fixes #1608 - `_runHousekeeping` was calling `on_housekeeping()` twice per cycle: once inline (lines 409–417) and again via `runCallbacksTime('on_housekeeping')`. The inline block is redundant since `runCallbacksTime` already dispatches to both the flow method and plugins with identical error handling.

Removed the inline block, keeping only the `runCallbacksTime` call.

##### Test

Added a unit test that asserts `on_housekeeping` is called exactly once per housekeeping cycle.