### PR TITLE
Fix diskqueue fd hygiene: fsync bug and bare except cleanup

### DIFF
--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -160,17 +160,18 @@ class DiskQueue():
         """
         try:
             self.housekeeping_fp.close()
-        except:
-            pass
+        except Exception as err:
+            logger.debug("housekeeping_fp close: %s" % err)
         try:
-            os.fsync(self.new_fp)
+            self.new_fp.flush()
+            os.fsync(self.new_fp.fileno())
             self.new_fp.close()
-        except:
-            pass
+        except Exception as err:
+            logger.debug("new_fp close: %s" % err)
         try:
             self.queue_fp.close()
-        except:
-            pass
+        except Exception as err:
+            logger.debug("queue_fp close: %s" % err)
         self.housekeeping_fp = None
         self.new_fp = None
         self.queue_fp = None
@@ -248,7 +249,7 @@ class DiskQueue():
             if not message:
                 try:
                     os.unlink(self.queue_file)
-                except:
+                except Exception:
                     pass
                 self.queue_fp = None
                 self.msg_count = 0
@@ -272,7 +273,7 @@ class DiskQueue():
         if self.msg_count == 0:
             try:
                 os.unlink(self.queue_file)
-            except:
+            except Exception:
                 pass
             self.queue_fp = None
 
@@ -354,7 +355,7 @@ class DiskQueue():
         if not line:
             try:
                 fp.close()
-            except:
+            except Exception:
                 pass
             return None, None
 
@@ -396,7 +397,7 @@ class DiskQueue():
             self.close()
             try:
                 os.unlink(self.housekeeping_path)
-            except:
+            except Exception:
                 pass
             fp = open(self.housekeeping_path, 'w')
             fp.close()
@@ -421,7 +422,7 @@ class DiskQueue():
 
             try:
                 fp.close()
-            except:
+            except Exception:
                 pass
 
             i = 0
@@ -441,7 +442,7 @@ class DiskQueue():
                 N = N + 1
             try:
                 fp.close()
-            except:
+            except Exception:
                 pass
 
             logger.debug("retrieved %d from the %d retry" %
@@ -460,7 +461,7 @@ class DiskQueue():
             logger.debug("%s No retry in list" % self.name)
             try:
                 os.unlink(self.housekeeping_path)
-            except:
+            except Exception:
                 pass
 
         # housekeeping file becomes new retry
@@ -469,14 +470,14 @@ class DiskQueue():
             logger.info("%s Number of messages in retry list %d" % (self.name, N))
             try:
                 os.rename(self.housekeeping_path, self.queue_file)
-            except:
+            except Exception:
                 logger.error("Something went wrong with rename")
 
         # cleanup
         self.msg_count_new = 0
         try:
             os.unlink(self.new_path)
-        except:
+        except Exception:
             pass
 
         elapse = sarracenia.nowflt() - self.now

--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -1,5 +1,6 @@
 import pytest
 from tests.conftest import *
+from unittest.mock import patch, MagicMock
 
 import jsonpickle, os
 
@@ -400,6 +401,92 @@ def test_diskqueue(tmp_path, caplog):
     assert dq.msg_count == 2
 
 
+def test_close__None_fps(tmp_path):
+    """close() should not crash when file pointers are None."""
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_close__None_fps')
+
+    assert dq.housekeeping_fp is None
+    assert dq.new_fp is None
+    assert dq.queue_fp is None
+
+    dq.close()
+
+    assert dq.housekeeping_fp is None
+    assert dq.new_fp is None
+    assert dq.queue_fp is None
 
 
+def test_close__already_closed_fps(tmp_path):
+    """close() should handle already-closed file pointers gracefully."""
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_close__already_closed')
+
+    message = make_message()
+    dq.put([message])
+
+    assert dq.new_fp is not None
+    dq.new_fp.close()
+
+    dq.close()
+
+    assert dq.new_fp is None
+    assert dq.msg_count == 0
+
+
+def test_close__fsync_uses_fileno(tmp_path):
+    """close() should call os.fsync with fileno(), not the file object.
+
+    The old code had os.fsync(self.new_fp) which passes a file object
+    instead of a file descriptor. This would raise TypeError, but the
+    bare except:pass hid the bug. Verify fsync is called correctly now.
+    """
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_close__fsync')
+
+    message = make_message()
+    dq.put([message])
+
+    assert dq.new_fp is not None
+    fd = dq.new_fp.fileno()
+
+    with patch('os.fsync') as mock_fsync:
+        dq.close()
+        mock_fsync.assert_called_once_with(fd)
+
+
+def test_close__keyboard_interrupt_propagates(tmp_path):
+    """KeyboardInterrupt must not be caught by close().
+
+    The old bare except: would swallow KeyboardInterrupt and SystemExit.
+    After narrowing to except Exception:, these should propagate.
+    """
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_close__kb_interrupt')
+
+    mock_fp = MagicMock()
+    mock_fp.close.side_effect = KeyboardInterrupt
+    dq.housekeeping_fp = mock_fp
+
+    with pytest.raises(KeyboardInterrupt):
+        dq.close()
+
+
+def test_get__keyboard_interrupt_propagates(tmp_path):
+    """KeyboardInterrupt in os.unlink during get() should propagate."""
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_get__kb_interrupt')
+
+    fp = open(dq.queue_file, 'w')
+    fp.close()
+    dq.msg_count = 1
+
+    with patch('os.unlink', side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            dq.get()
 


### PR DESCRIPTION
##### what

Three issues in `diskqueue.py` that affect reliability of the retry queue:

1. **`os.fsync` bug in `close()`** -- `os.fsync(self.new_fp)` passes a file object instead of a file descriptor. This always raised `TypeError`, but the bare `except: pass` swallowed it. The new_fp was never actually fsynced before close, so queued retry messages could be lost on crash.

2. **Bare `except:` blocks** -- 11 bare `except:` blocks throughout the file catch everything including `KeyboardInterrupt` and `SystemExit`. On `sr3 stop` or ctrl-c, these silently swallow the signal instead of letting the process shut down cleanly.

3. **Silent I/O errors in `close()`** -- if `close()` fails on any file pointer (disk full, stale NFS handle), there was zero indication in the logs.

##### fix

- Changed `os.fsync(self.new_fp)` to `self.new_fp.flush()` + `os.fsync(self.new_fp.fileno())`
- Narrowed all `except:` to `except Exception:` so `KeyboardInterrupt`/`SystemExit` propagate
- Added `logger.debug` in `close()` for I/O errors

##### regression tests

- `test_close__None_fps` -- close() with all None fps doesn't crash
- `test_close__already_closed_fps` -- close() with pre-closed fps is graceful
- `test_close__fsync_uses_fileno` -- verifies fsync gets the fd, not the file object
- `test_close__keyboard_interrupt_propagates` -- KeyboardInterrupt not swallowed in close()
- `test_get__keyboard_interrupt_propagates` -- KeyboardInterrupt not swallowed in get()

All 22 diskqueue tests pass (17 existing + 5 new).