### PR TITLE
Fix FTP connection leak on failed connect

### DIFF
--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -214,10 +214,11 @@ class Ftp(Transfer):
         # timeout alarm 100 secs to connect
         alarm_set(self.o.timeout)
 
+        ftp = None
         try:
             expire = -999
             if self.o.timeout: expire = self.o.timeout
-            if self.port == '' or self.port == None: 
+            if self.port == '' or self.port == None:
                 if self.implicit_ftps:
                     self.port = 990
                 else:
@@ -255,7 +256,7 @@ class Ftp(Transfer):
 
             try:
                 self.originalDir = ftp.pwd()
-            except:
+            except Exception:
                 logger.warning("Unable to ftp.pwd")
                 logger.debug('Exception details: ', exc_info=True)
 
@@ -263,9 +264,14 @@ class Ftp(Transfer):
             self.connected = True
             self.ftp = ftp
 
-        except:
-            logger.error(f"Unable to connect to {self.host} (user:{self.user})")
+        except Exception:
+            logger.error("Unable to connect to %s (user:%s)", self.host, self.user)
             logger.debug('Exception details: ', exc_info=True)
+            if ftp is not None:
+                try:
+                    ftp.close()
+                except Exception:
+                    pass
 
         alarm_cancel()
         return self.connected

--- a/tests/sarracenia/transfer/ftp_test.py
+++ b/tests/sarracenia/transfer/ftp_test.py
@@ -1,0 +1,146 @@
+import ftplib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sarracenia.transfer.ftp import Ftp
+
+
+class MockOptions:
+
+    def __init__(self):
+        self.sendTo = "ftp://user:pass@localhost/"
+        self.timeout = 30
+        self.logLevel = "DEBUG"
+        self.logFormat = ""
+        self.batch = 100
+        self.byteRateMax = 0
+        self.bufSize = 8192
+        self.ftpFilenameEncoding = "utf-8"
+        self.tlsRigour = "normal"
+        self.credentials = MagicMock()
+
+    def add_option(self, option, kind, default=None):
+        if not hasattr(self, option):
+            setattr(self, option, default)
+
+
+def make_ftp_transfer():
+    options = MockOptions()
+    options.credentials.get.return_value = (
+        True,
+        MagicMock(
+            url=MagicMock(
+                hostname="localhost",
+                port=21,
+                username="user",
+                password="pass",
+            ),
+            tls=False,
+            prot_p=False,
+            passive=True,
+            binary=True,
+            implicit_ftps=False,
+        ),
+    )
+    transfer = Ftp.__new__(Ftp)
+    transfer.o = options
+    transfer.connected = False
+    transfer.ftp = None
+    transfer.sendTo = options.sendTo
+    transfer.host = "localhost"
+    transfer.port = 21
+    transfer.user = "user"
+    transfer.password = "pass"
+    transfer.tls = False
+    transfer.implicit_ftps = False
+    transfer.prot_p = False
+    transfer.passive = True
+    transfer.binary = True
+    transfer.originalDir = "."
+    transfer.pwd = "."
+    return transfer
+
+
+def test_connect_closes_ftp_on_login_failure():
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.return_value = None
+    mock_ftp.login.side_effect = ftplib.error_perm("530 Login incorrect")
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                result = transfer.connect()
+
+    assert result is False
+    assert transfer.connected is False
+    mock_ftp.close.assert_called_once()
+
+
+def test_connect_closes_ftp_on_connect_failure():
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.side_effect = OSError("Connection refused")
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                result = transfer.connect()
+
+    assert result is False
+    assert transfer.connected is False
+    mock_ftp.close.assert_called_once()
+
+
+def test_connect_closes_ftp_on_set_pasv_failure():
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.return_value = None
+    mock_ftp.login.return_value = None
+    mock_ftp.set_pasv.side_effect = OSError("set_pasv failed")
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                result = transfer.connect()
+
+    assert result is False
+    assert transfer.connected is False
+    mock_ftp.close.assert_called_once()
+
+
+def test_connect_keyboard_interrupt_propagates():
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.side_effect = KeyboardInterrupt
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                with pytest.raises(KeyboardInterrupt):
+                    transfer.connect()
+
+
+def test_connect_success_does_not_close():
+    transfer = make_ftp_transfer()
+
+    mock_ftp = MagicMock(spec=ftplib.FTP)
+    mock_ftp.connect.return_value = None
+    mock_ftp.login.return_value = None
+    mock_ftp.set_pasv.return_value = None
+    mock_ftp.pwd.return_value = "/home/user"
+
+    with patch("ftplib.FTP", return_value=mock_ftp):
+        with patch("sarracenia.transfer.ftp.alarm_set"):
+            with patch("sarracenia.transfer.ftp.alarm_cancel"):
+                result = transfer.connect()
+
+    assert result is True
+    assert transfer.connected is True
+    assert transfer.ftp is mock_ftp
+    mock_ftp.close.assert_not_called()


### PR DESCRIPTION
##### what

If `connect()`, `login()`, or `set_pasv()` raises an exception after the local `ftp` object is created but before `self.ftp = ftp` assignment, the FTP socket is never closed. The bare `except:` swallows the error and the local variable goes out of scope, leaking the socket into TIME_WAIT state.

With retry logic, each failed connect attempt leaks one socket. A box connecting to multiple FTP sources with one flaky remote accumulates hundreds of leaked sockets per day.

##### the fix

- Initialize `ftp = None` before the try block
- Close it in the except block if it was created
- Narrow bare `except:` to `except Exception:` so `KeyboardInterrupt`/`SystemExit` propagate
- Same pattern as the SFTP fixes in PRs #1578, #1581, #1583

##### regression tests

New `tests/sarracenia/transfer/ftp_test.py` with 5 tests:

- `test_connect__closes_ftp_on_login_failure` -- login fails, socket is closed
- `test_connect__closes_ftp_on_connect_failure` -- connect fails, socket is closed
- `test_connect__no_leak_on_set_pasv_failure` -- set_pasv fails after login, socket is closed
- `test_connect__keyboard_interrupt_propagates` -- KeyboardInterrupt not swallowed
- `test_connect__success_does_not_close` -- successful connect assigns ftp, does not close