### PR TITLE
Close transfer protocol connections on flow shutdown

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -479,6 +479,15 @@ class Flow:
     def close(self) -> None:
 
         self.runCallbacksTime('on_stop')
+
+        for scheme in list(self.proto):
+            if self.proto[scheme] is not None:
+                try:
+                    self.proto[scheme].close()
+                except Exception as err:
+                    logger.debug("proto %s close: %s", scheme, err)
+                self.proto[scheme] = None
+
         if os.path.exists( self.o.novipFilename ):
             os.unlink( self.o.novipFilename )
         logger.info(

--- a/tests/sarracenia/flow_close_test.py
+++ b/tests/sarracenia/flow_close_test.py
@@ -1,0 +1,107 @@
+import pytest
+from tests.conftest import *
+from unittest.mock import patch, MagicMock
+
+import types
+
+import sarracenia
+import sarracenia.flowcb
+from sarracenia.flow import Flow
+
+
+def make_flow():
+    """Create a minimal Flow instance with patched-out plugin loading."""
+    cfg = MagicMock()
+    cfg.logLevel = 'INFO'
+    cfg.logFormat = '%(asctime)s [%(levelname)s] %(message)s'
+    cfg.settings = {}
+    cfg.topicPrefix = ['v03']
+    cfg.post_topicPrefix = ['v03']
+    cfg.nodupe_ttl = 0
+    cfg.nodupe_driver = 'disk'
+    cfg.plugins_early = []
+    cfg.plugins_late = []
+    cfg.component = 'flow'
+    cfg.config = 'test'
+    cfg.no = 1
+    cfg.novipFilename = '/tmp/test_flow_close_novip'
+
+    flow = Flow.__new__(Flow)
+    flow._stop_requested = False
+    flow.o = cfg
+
+    flow.plugins = {}
+    for ep in sarracenia.flowcb.entry_points:
+        flow.plugins[ep] = []
+
+    flow.worklist = types.SimpleNamespace()
+    flow.worklist.ok = []
+    flow.worklist.incoming = []
+    flow.worklist.rejected = []
+    flow.worklist.failed = []
+    flow.worklist.directories_ok = []
+
+    flow._logLevel_debug = False
+    flow.proto = {}
+    return flow
+
+
+def test_close__closes_proto_connections():
+    """close() should close all active proto connections."""
+    flow = make_flow()
+
+    mock_sftp = MagicMock()
+    mock_ftp = MagicMock()
+    flow.proto = {'sftp': mock_sftp, 'ftp': mock_ftp}
+
+    with patch('os.path.exists', return_value=False):
+        flow.close()
+
+    mock_sftp.close.assert_called_once()
+    mock_ftp.close.assert_called_once()
+    assert flow.proto['sftp'] is None
+    assert flow.proto['ftp'] is None
+
+
+def test_close__skips_none_proto():
+    """close() should skip proto entries that are already None."""
+    flow = make_flow()
+
+    mock_sftp = MagicMock()
+    flow.proto = {'sftp': mock_sftp, 'ftp': None}
+
+    with patch('os.path.exists', return_value=False):
+        flow.close()
+
+    mock_sftp.close.assert_called_once()
+    assert flow.proto['sftp'] is None
+    assert flow.proto['ftp'] is None
+
+
+def test_close__proto_close_exception_doesnt_crash():
+    """If a proto.close() raises, close() should continue with others."""
+    flow = make_flow()
+
+    mock_sftp = MagicMock()
+    mock_sftp.close.side_effect = OSError("connection reset")
+    mock_ftp = MagicMock()
+    flow.proto = {'sftp': mock_sftp, 'ftp': mock_ftp}
+
+    with patch('os.path.exists', return_value=False):
+        flow.close()
+
+    mock_sftp.close.assert_called_once()
+    mock_ftp.close.assert_called_once()
+    assert flow.proto['sftp'] is None
+    assert flow.proto['ftp'] is None
+
+
+def test_close__empty_proto():
+    """close() should work fine with no proto connections."""
+    flow = make_flow()
+    flow.proto = {}
+
+    with patch('os.path.exists', return_value=False):
+        flow.close()
+
+    assert flow.proto == {}


### PR DESCRIPTION
##### what

`Flow.close()` runs on_stop callbacks but never closes active transfer connections in `self.proto`. On clean daemon shutdown, all SFTP/FTP/HTTP sockets are left for GC and OS cleanup instead of being explicitly closed.

The error paths in `do_download()` (line 2530) and `send()` (line 2983) already close proto on failure and set to None. But the clean shutdown path never does.

##### the fix

Iterate `self.proto` in `close()` and close each active connection before the shutdown log message. Exceptions during close are logged at debug level and do not prevent other connections from being closed.

##### regression tests

New `tests/sarracenia/flow_close_test.py` with 4 tests:

- `test_close__closes_proto_connections` -- both sftp and ftp protos get closed
- `test_close__skips_none_proto` -- already-None entries are skipped
- `test_close__proto_close_exception_doesnt_crash` -- one proto failing to close doesn't block the others
- `test_close__empty_proto` -- no proto connections is fine