### PR TITLE
Fix MQTT client thread leak on reconnect and close

### DIFF
--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -426,6 +426,12 @@ class MQTT(Moth):
 
             logger.info( f"is no around? {self.o['no']} " )
             if ('no' in self.o) and self.o['no'] > 0: # instances 'started'
+                if hasattr(self, 'client') and self.client is not None:
+                    try:
+                        self.client.loop_stop()
+                        self.client.disconnect()
+                    except Exception:
+                        pass
                 self.client = self.__clientSetup(cid)
                 self.client.connect( broker.url.hostname, port=self.__sslClientSetup(), \
                        clean_start=False, properties=props )
@@ -489,17 +495,24 @@ class MQTT(Moth):
             return
 
         try:
+            if hasattr(self, 'client') and self.client is not None:
+                try:
+                    self.client.loop_stop()
+                    self.client.disconnect()
+                except Exception:
+                    pass
+
             self.pending_publishes = collections.deque()
             self.unexpected_publishes = collections.deque()
- 
+
             props = Properties(PacketTypes.CONNECT)
             if self.o['messageAgeMax'] > 0:
                 props.MessageExpiryInterval = int(self.o['messageAgeMax'])
- 
+
             self.transport = 'websockets' if (self.o['broker'].url.scheme[-2:] == 'ws' ) or  \
                (self.o['broker'].url.scheme[-1] == 'w' ) else 'tcp'
- 
-            self.client = paho.mqtt.client.Client( 
+
+            self.client = paho.mqtt.client.Client(
                     callback_api_version = paho.mqtt.client.CallbackAPIVersion.VERSION2, \
                     userdata=self, transport=self.transport, protocol=self.proto_version )
  
@@ -843,4 +856,5 @@ class MQTT(Moth):
                         ebo *= 2
                 logger.info('no more pending messages')
             self.client.disconnect()
+            self.client.loop_stop()
         self.connected=False

--- a/tests/sarracenia/moth/mqtt_thread_leak_test.py
+++ b/tests/sarracenia/moth/mqtt_thread_leak_test.py
@@ -1,0 +1,150 @@
+import pytest
+from tests.conftest import *
+from unittest.mock import patch, MagicMock, PropertyMock
+
+from sarracenia.moth.mqtt import MQTT
+
+
+def make_mqtt_instance(is_subscriber=True):
+    """Create a minimal MQTT instance without connecting."""
+    m = MQTT.__new__(MQTT)
+    m.is_subscriber = is_subscriber
+    m.connected = False
+    m.connect_in_progress = False
+    m.subscribe_in_progress = 0
+    m._stop_requested = False
+    m.o = {}
+    m.metrics = {
+        'rxBadCount': 0,
+        'txBadCount': 0,
+        'rxByteCount': 0,
+        'txByteCount': 0,
+        'rxGoodCount': 0,
+        'txGoodCount': 0,
+        'rxLast': '',
+        'txLast': '',
+        'connected': False,
+    }
+    return m
+
+
+def test_close__calls_loop_stop():
+    """close() should call loop_stop() after disconnect()."""
+    m = make_mqtt_instance()
+    mock_client = MagicMock()
+    mock_client.is_connected.return_value = True
+    m.client = mock_client
+
+    m.close()
+
+    mock_client.disconnect.assert_called_once()
+    mock_client.loop_stop.assert_called_once()
+
+
+def test_close__loop_stop_after_disconnect():
+    """loop_stop() must be called after disconnect()."""
+    m = make_mqtt_instance()
+    call_order = []
+    mock_client = MagicMock()
+    mock_client.is_connected.return_value = True
+    mock_client.disconnect.side_effect = lambda: call_order.append('disconnect')
+    mock_client.loop_stop.side_effect = lambda: call_order.append('loop_stop')
+    m.client = mock_client
+
+    m.close()
+
+    assert call_order == ['disconnect', 'loop_stop']
+
+
+def test_close__not_connected_skips_loop_stop():
+    """If client is not connected, should not call disconnect or loop_stop."""
+    m = make_mqtt_instance()
+    mock_client = MagicMock()
+    mock_client.is_connected.return_value = False
+    m.client = mock_client
+
+    m.close()
+
+    mock_client.disconnect.assert_not_called()
+    mock_client.loop_stop.assert_not_called()
+
+
+def test_getSetup__stops_old_client():
+    """getSetup() should stop the old client before creating a new one."""
+    m = make_mqtt_instance()
+    old_client = MagicMock()
+    m.client = old_client
+
+    m.o = {
+        'no': 1,
+        'subscription_index': 0,
+        'clean_session': False,
+        'subscriptions': [{
+            'queue': {'name': 'q_test'},
+            'broker': MagicMock(
+                url=MagicMock(
+                    hostname='localhost',
+                    username='user',
+                    password='pass',
+                    scheme='mqtt',
+                ),
+            ),
+        }],
+    }
+    m.next_connect_time = 0
+    m.next_message = 0
+
+    new_client = MagicMock()
+
+    def setup_then_stop(cid):
+        m._stop_requested = True
+        return new_client
+
+    with patch.object(MQTT, '_MQTT__clientSetup', side_effect=setup_then_stop):
+        with patch.object(MQTT, '_MQTT__sslClientSetup', return_value=1883):
+            try:
+                m.getSetup()
+            except Exception:
+                pass
+
+    old_client.loop_stop.assert_called_once()
+    old_client.disconnect.assert_called_once()
+
+
+def test_putSetup__stops_old_client():
+    """putSetup() should stop the old client before creating a new one."""
+    m = make_mqtt_instance(is_subscriber=False)
+    old_client = MagicMock()
+    m.client = old_client
+
+    m.o = {
+        'broker': MagicMock(
+            url=MagicMock(
+                hostname='localhost',
+                username='user',
+                password='pass',
+                scheme='mqtt',
+            ),
+        ),
+        'messageAgeMax': 0,
+        'no': 1,
+    }
+    m.proto_version = 5
+    m.next_connect_time = 0
+    m.next_message = 0
+
+    new_client = MagicMock()
+
+    def client_then_stop(*args, **kwargs):
+        m._stop_requested = True
+        return new_client
+
+    with patch('paho.mqtt.client.Client', side_effect=client_then_stop):
+        with patch.object(MQTT, '_MQTT__sslClientSetup', return_value=1883):
+            try:
+                m.putSetup()
+            except Exception:
+                pass
+
+    old_client.loop_stop.assert_called_once()
+    old_client.disconnect.assert_called_once()


### PR DESCRIPTION
##### what

Two related thread leak issues in the MQTT transport layer:

1. `close()` calls `client.disconnect()` but never `client.loop_stop()`. The paho background thread keeps running after the connection is closed. Compare with `putCleanUp()` (line 558-561) which correctly calls both.

2. `getSetup()` and `putSetup()` create a new client with `loop_start()` without stopping the old client's thread first. Each reconnection leaks one orphaned paho thread that continues running in the background.

Over time with flaky MQTT brokers that trigger reconnections, this accumulates threads indefinitely.

##### the fix

- Add `loop_stop()` to `close()` after `disconnect()`
- In `getSetup()` and `putSetup()`, call `loop_stop()` + `disconnect()` on the old client before creating the new one
- Old client cleanup is wrapped in try/except since the old client may already be in a bad state

##### regression tests

New `tests/sarracenia/moth/mqtt_thread_leak_test.py` with 5 tests:

- `test_close__calls_loop_stop` -- close() calls both disconnect and loop_stop
- `test_close__loop_stop_after_disconnect` -- correct call order verified
- `test_close__not_connected_skips_loop_stop` -- no-op when not connected
- `test_getSetup__stops_old_client` -- old client stopped before new one created
- `test_putSetup__stops_old_client` -- same for publish path