### PR TITLE
log when a putNewMessage *crashes*

### DIFF
--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -53,6 +53,8 @@ class Message(FlowCB):
                         if not p.putNewMessage(m):
                             failures.append(i)
                     except Exception as e:
+                        logger.warning(f"putNewMessage crashed {e}")
+                        logger.debug("Exception details:", exc_info=True)
                         failures.append(i)
             else:
                 for p in self.posters:


### PR DESCRIPTION
currently the putNewMessage can silently crash, with no opportunity to see where an exception occurred. The retry handling works properly, but I think it's important for the user to know the code actually crashed, rather than just behaving the same as when putNewMessage returned False.