### PR TITLE
Fix v02 post format crash after shallow copy in putNewMessage

### DIFF
--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -153,7 +153,7 @@ class Message:
        
         self.headers = h
         self.hdrstr = str(h)
-        self.isRetry = bool(h.isRetry())
+        self.isRetry = bool(h.get('_isRetry', False))
 
         # from sr_message/sr_new ...
         self.local_offset = 0

--- a/tests/sarracenia/flowcb/v2wrapper_message_test.py
+++ b/tests/sarracenia/flowcb/v2wrapper_message_test.py
@@ -1,0 +1,81 @@
+import pytest
+from tests.conftest import *
+
+import sarracenia
+from sarracenia.flowcb.v2wrapper import Message
+
+
+def make_plain_dict_message():
+    """Create a plain dict (not sarracenia.Message) with minimum v02 fields.
+
+    This simulates what happens after dict(message) shallow copy in
+    putNewMessage -- the sarracenia.Message class is lost.
+    """
+    return {
+        'pubTime': '20180118T151049.356378078',
+        'baseUrl': 'https://example.com',
+        'relPath': '/data/observations/test.txt',
+        'identity': {
+            'method': 'md5',
+            'value': 'CY9rzUYh03PK3k6DJie09g==',
+        },
+        '_format': 'v02',
+        '_deleteOnPost': set(),
+    }
+
+
+def make_sr3_message():
+    """Create a sarracenia.Message (dict subclass with isRetry method)."""
+    m = sarracenia.Message()
+    m['pubTime'] = '20180118T151049.356378078'
+    m['baseUrl'] = 'https://example.com'
+    m['relPath'] = '/data/observations/test.txt'
+    m['identity'] = {
+        'method': 'md5',
+        'value': 'CY9rzUYh03PK3k6DJie09g==',
+    }
+    m['_format'] = 'v02'
+    m['_deleteOnPost'] = set()
+    return m
+
+
+def test_v2wrapper_message_from_plain_dict():
+    """v2wrapper.Message must work with a plain dict, not just sarracenia.Message.
+
+    Regression test for PR #1604: dict(message) shallow copy strips the
+    Message class, so v2wrapper.Message.__init__ must not call h.isRetry().
+    """
+    d = make_plain_dict_message()
+    msg = Message(d)
+    assert msg.isRetry is False
+
+
+def test_v2wrapper_message_from_plain_dict_with_retry():
+    """Plain dict with _isRetry flag should set isRetry=True."""
+    d = make_plain_dict_message()
+    d['_isRetry'] = True
+    msg = Message(d)
+    assert msg.isRetry is True
+
+
+def test_v2wrapper_message_from_plain_dict_with_retry_count():
+    """Plain dict with _isRetry as int (retry count) should be truthy."""
+    d = make_plain_dict_message()
+    d['_isRetry'] = 3
+    msg = Message(d)
+    assert msg.isRetry is True
+
+
+def test_v2wrapper_message_from_sr3_message():
+    """sarracenia.Message (dict subclass) should still work."""
+    m = make_sr3_message()
+    msg = Message(m)
+    assert msg.isRetry is False
+
+
+def test_v2wrapper_message_from_sr3_message_with_retry():
+    """sarracenia.Message with _isRetry should set isRetry=True."""
+    m = make_sr3_message()
+    m['_isRetry'] = True
+    msg = Message(m)
+    assert msg.isRetry is True


### PR DESCRIPTION
##### what

PR #1604 changed `putNewMessage()` from `copy.deepcopy(message)` to `dict(message)` for performance. This broke the v02 post format path.

`dict(message)` strips the `sarracenia.Message` class, producing a plain dict. When posting in v02 format, the call chain hits `v2wrapper.Message.__init__()` which calls `h.isRetry()` on the message -- but a plain dict has no `isRetry()` method.

```
AttributeError: 'dict' object has no attribute 'isRetry'
```

Traced by Reid -- the v02 path goes: `putNewMessage` -> `PostFormat.exportAny` -> `v02.exportMine` -> `v2wrapper.Message(body)` -> `h.isRetry()` crash.

##### why tests didn't catch it

The sr_insects flow tests don't exercise v02 post format. All flow tests use v03.

##### the fix

Replace `h.isRetry()` with `h.get('_isRetry', False)` in `v2wrapper.py:156`. The `isRetry()` method literally just checks `'_isRetry' in msg`, so inlining it removes the class dependency. Works with both plain dicts and Message objects.

##### regression tests

New `tests/sarracenia/flowcb/v2wrapper_message_test.py` with 5 tests:

- `test_v2wrapper_message_from_plain_dict` -- plain dict (post-shallow-copy) doesn't crash
- `test_v2wrapper_message_from_plain_dict_with_retry` -- plain dict with _isRetry=True
- `test_v2wrapper_message_from_plain_dict_with_retry_count` -- plain dict with _isRetry as int
- `test_v2wrapper_message_from_sr3_message` -- sarracenia.Message still works
- `test_v2wrapper_message_from_sr3_message_with_retry` -- sarracenia.Message with retry flag