### PR TITLE
Use `copy.copy` for shallow copying

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -688,7 +688,8 @@ class AMQP(Moth):
                 return False
 
         # Shallow copy: only top-level keys are deleted (_deleteOnPost), nested dicts are read-only
-        body = dict(message)
+        # copy.copy(message) produces a sarracenia.Message object
+        body = copy.copy(message)
 
         if 'format' in self.o:
             version=self.o['format']

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -747,7 +747,8 @@ class MQTT(Moth):
                 return False
 
         # Shallow copy: only top-level keys are deleted (_deleteOnPost), nested dicts are read-only
-        body = dict(message)
+        # copy.copy(message) produces a sarracenia.Message object
+        body = copy.copy(message)
 
         if 'format' in self.o:
             postFormat=self.o['format']


### PR DESCRIPTION
copy.copy will produce a sarracenia.Message object.

The `dict()` code gives a dict. Message is a subclass of dict, so a Message can be used where a dict is expected, but a dict can't necessarily be used where a Message is expected.

I think this is the safest fix.