### PR TITLE
Fix post_format not derived from post_topicPrefix

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -113,7 +113,7 @@ default_options = {
     'post_documentRoot': None,
     'post_baseDir': None,
     'post_baseUrl': None,
-    'post_format': 'v03',
+    'post_format': None,
     'realpathPost': False,
     'recursive' : True,
     'runStateThreshold_reject': 80,

--- a/sarracenia/config/publisher.py
+++ b/sarracenia/config/publisher.py
@@ -63,9 +63,10 @@ class Publisher(dict):
         if hasattr(options,'tlsRigour') :
             self['tlsRigour'] = options.tlsRigour
     
-        if hasattr(options,'post_format') :
+        if hasattr(options, 'post_format') and options.post_format is not None:
             self['format'] = options.post_format
-        elif hasattr(options,'post_topicPrefix') and options.post_topicPrefix[0] in [ 'v02', 'v03' ]:
+        elif hasattr(options, 'post_topicPrefix') and options.post_topicPrefix \
+                and options.post_topicPrefix[0] in ['v02', 'v03']:
             self['format'] = options.post_topicPrefix[0]
         else:
             self['format'] = 'v03'

--- a/sarracenia/config/publisher.py
+++ b/sarracenia/config/publisher.py
@@ -71,6 +71,9 @@ class Publisher(dict):
         else:
             self['format'] = 'v03'
 
+        # exportAny and exportMine expect 'post_format' in the options dict
+        self['post_format'] = self['format']
+
         if hasattr(options,'post_topicPrefix') and options.post_topicPrefix:
             self['topicPrefix'] = options.post_topicPrefix
         elif hasattr(options, 'topicPrefix') and options.topicPrefix:

--- a/sarracenia/moth/__init__.py
+++ b/sarracenia/moth/__init__.py
@@ -271,6 +271,8 @@ class Moth():
             props['broker'] = broker
             if 'exchange' in publisher:
                 props['exchange'] = publisher['exchange']
+            if 'format' in publisher:
+                props['format'] = publisher['format']
 
         elif not props['broker']:
             logger.error('no broker specified')
@@ -347,6 +349,8 @@ class Moth():
                     self.o['exchange'] = publisher['exchange']
                 if 'topicPrefix' in publisher:
                     self.o['topicPrefix'] = publisher['topicPrefix']
+                if 'format' in publisher:
+                    self.o['format'] = publisher['format']
 
         # apply settings from props.
         if 'settings' in self.o:

--- a/tests/sarracenia/config/publisher_test.py
+++ b/tests/sarracenia/config/publisher_test.py
@@ -74,3 +74,32 @@ def test_explicit_v02_post_format():
     pub = Publisher(opts)
     assert pub['format'] == 'v02'
     assert pub['post_format'] == 'v02'
+
+
+def test_topicprefix_fallback_is_empty_list():
+    """When neither post_topicPrefix nor topicPrefix is set, fallback must
+    be [] (empty list), not None. Peter fixed this in bab4b9424 -- None
+    causes TypeError when downstream code iterates or concatenates."""
+    opts = make_options()
+    del opts.post_topicPrefix
+    del opts.topicPrefix
+    pub = Publisher(opts)
+    assert pub['topicPrefix'] == [], \
+        "topicPrefix fallback must be [] not None (see commit bab4b9424)"
+
+
+def test_basedir_missing_no_keyerror():
+    """Publisher must not raise KeyError when baseDir is absent from the
+    dict. The guard must use 'or' (short-circuit) not 'and'."""
+    opts = make_options(post_baseUrl='file:/data/incoming')
+    del opts.post_baseDir
+    # This must not raise KeyError
+    pub = Publisher(opts)
+    assert pub['baseDir'] == '/data/incoming'
+
+
+def test_basedir_empty_string_derives_from_url():
+    """When baseDir is set but empty, it should still derive from baseUrl."""
+    opts = make_options(post_baseDir='', post_baseUrl='file:/data/output')
+    pub = Publisher(opts)
+    assert pub['baseDir'] == '/data/output'

--- a/tests/sarracenia/config/publisher_test.py
+++ b/tests/sarracenia/config/publisher_test.py
@@ -34,6 +34,7 @@ def test_format_defaults_to_v03():
     del opts.post_format
     pub = Publisher(opts)
     assert pub['format'] == 'v03'
+    assert pub['post_format'] == 'v03'
 
 
 def test_format_derived_from_v02_topicprefix():
@@ -45,6 +46,7 @@ def test_format_derived_from_v02_topicprefix():
     opts = make_options(post_topicPrefix=['v02', 'post'])
     pub = Publisher(opts)
     assert pub['format'] == 'v02'
+    assert pub['post_format'] == 'v02'
 
 
 def test_format_derived_from_v03_topicprefix():
@@ -52,6 +54,7 @@ def test_format_derived_from_v03_topicprefix():
     opts = make_options(post_topicPrefix=['v03', 'post'])
     pub = Publisher(opts)
     assert pub['format'] == 'v03'
+    assert pub['post_format'] == 'v03'
 
 
 def test_explicit_post_format_overrides_topicprefix():
@@ -62,6 +65,7 @@ def test_explicit_post_format_overrides_topicprefix():
     )
     pub = Publisher(opts)
     assert pub['format'] == 'v03'
+    assert pub['post_format'] == 'v03'
 
 
 def test_explicit_v02_post_format():
@@ -69,3 +73,4 @@ def test_explicit_v02_post_format():
     opts = make_options(post_format='v02')
     pub = Publisher(opts)
     assert pub['format'] == 'v02'
+    assert pub['post_format'] == 'v02'

--- a/tests/sarracenia/config/publisher_test.py
+++ b/tests/sarracenia/config/publisher_test.py
@@ -1,0 +1,71 @@
+import pytest
+from tests.conftest import *
+from unittest.mock import MagicMock
+
+from sarracenia.config.publisher import Publisher
+
+
+def make_options(**overrides):
+    """Minimal options object for Publisher."""
+    opts = MagicMock()
+    opts.post_broker = MagicMock()
+    opts.post_broker.url = MagicMock()
+    opts.post_broker.url.username = 'tsource'
+    opts.post_broker.url.scheme = 'amqp'
+    opts.post_exchange = ['xs_tsource']
+    opts.post_baseDir = '/tmp'
+    opts.post_baseUrl = 'http://localhost'
+    opts.post_exchangeSplit = 0
+
+    # defaults matching config/__init__.py
+    opts.post_format = None
+    opts.post_topicPrefix = ['v03', 'post']
+
+    for k, v in overrides.items():
+        setattr(opts, k, v)
+
+    return opts
+
+
+def test_format_defaults_to_v03():
+    """When neither post_format nor post_topicPrefix is set, default to v03."""
+    opts = make_options()
+    del opts.post_topicPrefix
+    del opts.post_format
+    pub = Publisher(opts)
+    assert pub['format'] == 'v03'
+
+
+def test_format_derived_from_v02_topicprefix():
+    """post_topicPrefix v02.post should derive format v02.
+
+    This is the bug that Peter found -- post_format defaulted to 'v03'
+    which always took priority, so post_topicPrefix was never used.
+    """
+    opts = make_options(post_topicPrefix=['v02', 'post'])
+    pub = Publisher(opts)
+    assert pub['format'] == 'v02'
+
+
+def test_format_derived_from_v03_topicprefix():
+    """post_topicPrefix v03.post should derive format v03."""
+    opts = make_options(post_topicPrefix=['v03', 'post'])
+    pub = Publisher(opts)
+    assert pub['format'] == 'v03'
+
+
+def test_explicit_post_format_overrides_topicprefix():
+    """If user explicitly sets post_format, it wins over topicPrefix."""
+    opts = make_options(
+        post_format='v03',
+        post_topicPrefix=['v02', 'post'],
+    )
+    pub = Publisher(opts)
+    assert pub['format'] == 'v03'
+
+
+def test_explicit_v02_post_format():
+    """If user explicitly sets post_format v02, use it."""
+    opts = make_options(post_format='v02')
+    pub = Publisher(opts)
+    assert pub['format'] == 'v02'


### PR DESCRIPTION
##### what

Setting `post_topicPrefix v02.post` in a config should derive `post_format v02`, but it doesn't. Peter found this while investigating the v02 regression (sr_insects#85) -- the format derivation has been broken since at least 3.00.56.

##### root cause

In `config/__init__.py`, `post_format` defaults to `'v03'`. In `publisher.py`, the logic is:

```python
if hasattr(options, 'post_format'):      # always True -- default is 'v03'
    self['format'] = options.post_format
elif hasattr(options, 'post_topicPrefix') ...   # never reached
```

Since `post_format` always has a value, the `elif` branch that derives format from `post_topicPrefix` is dead code.

##### the fix

- Change `post_format` default from `'v03'` to `None`
- Check for `None` in `publisher.py` so the topicPrefix derivation kicks in when the user hasn't explicitly set `post_format`
- Explicit `post_format` still takes priority when set by the user

##### regression tests

New `tests/sarracenia/config/publisher_test.py` with 5 tests:

- `test_format_defaults_to_v03` -- neither post_format nor topicPrefix set
- `test_format_derived_from_v02_topicprefix` -- the bug case
- `test_format_derived_from_v03_topicprefix` -- v03 topicPrefix still works
- `test_explicit_post_format_overrides_topicprefix` -- user sets post_format, wins over topicPrefix
- `test_explicit_v02_post_format` -- user sets post_format v02 directly

##### context

Peter's investigation in sr_insects#85 and sarracenia#1623. The sr_insects sender config `tsource2send_f50.conf` has `post_topic_prefix v02.post` but was silently posting v03 because format was never derived.