### PR TITLE
Fix: create destination directory before writing config file in sr3 add

### DIFF
--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -1471,6 +1471,7 @@ class sr_GlobalState:
                 logger.info(f"did not find anything to copy for: {l}. creating an empty one.")
                 if cfg[-5:] not in [ '.inc', '.conf' ]:
                     cfg = cfg + '.conf'
+                os.makedirs(destdir, exist_ok=True)
                 with open( destdir + os.sep + cfg, 'w' ) as f:
                     f.write('')
 


### PR DESCRIPTION
## Fix: Prevent crash when adding config file

### Problem
Running:
sr3 add subscriber/dual_amis.conf

caused FileNotFoundError because the destination directory did not exist.

### Solution
Ensure directory is created before writing file using:
os.makedirs(destdir, exist_ok=True)

### Testing
Tested by running:
sr3 add subscriber/dual_amis.conf

File is now created successfully without errors.