### PR TITLE
Fix 2 small bugs in Publisher config class

### DIFF
--- a/sarracenia/config/publisher.py
+++ b/sarracenia/config/publisher.py
@@ -2,6 +2,7 @@
 import copy
 import json
 import os
+import sarracenia
 
 import logging
 
@@ -78,7 +79,7 @@ class Publisher(dict):
         if (not 'baseUrl' in self or not self['baseUrl']) and hasattr(options,'pollUrl') and options.pollUrl:
             self['baseUrl'] = options.pollUrl
 
-        if not 'baseDir' in self and not self['baseDir']:
+        if not 'baseDir' in self or not self['baseDir']:
             if self['baseUrl'] and ( self['baseUrl'][0:5] in [ 'file:' ] ):
                 self['baseDir'] = self['baseUrl'][5:]
             elif self['baseUrl'] and ( self['baseUrl'][0:5] in [ 'sftp:' ] ):


### PR DESCRIPTION
I was working on resolving merge conflicts on another branch and my old-fashioned (not AI 😄 ) linter noticed that `sarracenia.baseUrlParse` was called but undefined. Fixed by importing sarracenia.

I'm also pretty sure this logic was wrong:

```python
if not 'baseDir' in self and not self['baseDir']:
```

if baseDir is not in self, then accessing `self['baseDir']` will crash. I changed the and to or.