### PR TITLE
test: verify sr_insects test reliability fixes

### DIFF
--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -138,5 +138,5 @@ echo
 # Configure users
 sr3 --users declare
 echo "dir: +${PWD}+"
-git clone https://github.com/MetPX/sr_insects
+git clone -b fix/test-reliability https://github.com/MetPX/sr_insects
 


### PR DESCRIPTION
##### Purpose

Temporary PR to trigger CI against the sr_insects `fix/test-reliability` branch (MetPX/sr_insects#86) to verify test reliability improvements.

##### What changed

Only `travis/flow_autoconfig.sh` is modified to clone the sr_insects fix branch instead of main. This lets us test the sr_insects changes via sarracenia CI before merging them.

##### Expected result

flakey_broker, restart_server, and dynamic_flow should pass more reliably. See MetPX/sr_insects#86 for the full analysis and changes.

##### After verification

- If CI passes: merge sr_insects PR #86, then revert this change (or close this PR)
- If CI still fails: iterate on the sr_insects branch