### PR TITLE
Fix unit tests

### DIFF
--- a/sarracenia/flowcb/nodupe/redis.py
+++ b/sarracenia/flowcb/nodupe/redis.py
@@ -134,7 +134,7 @@ class Redis(NoDupe):
         new_count = len(self._redis.keys(self._rkey_base + ":*"))
         self.now = nowflt()
         
-        logger.info( f"cache size was {self.last_count:d} items " \
+        logger.info( f"cache size was {self._last_count:d} items " \
               f"{self.now - self._last_time:5.2f} sec ago, now saved {new_count:d} entries" )
 
         self._last_time = self.now

--- a/sarracenia/redisqueue.py
+++ b/sarracenia/redisqueue.py
@@ -297,7 +297,7 @@ class RedisQueue():
         logger.info(f"{self.name} on_housekeeping")
 
         if float(self.redis.get(self.key_name_lasthk)) + self.o.housekeeping > sarracenia.nowflt():
-            logger.info( f"Housekeeping ran less than {self.o.housekeeping:d}s ago; not running " )
+            logger.info( f"Housekeeping ran less than {self.o.housekeeping}s ago; not running " )
             return
 
         # A shared/distributed locking system is required when using Redis

--- a/tests/sarracenia/flowcb/accept/speedo_test.py
+++ b/tests/sarracenia/flowcb/accept/speedo_test.py
@@ -75,7 +75,9 @@ def test_after_accept(mocker, caplog):
     speedo.after_accept(worklist)
     assert len(worklist.incoming) == 1
     assert len(caplog.messages) == 1
-    assert 'speedo:   1 messages received: 0.0033 msg/s, 3.33 bytes/s, lag:   10 s' in caplog.messages
+    # format changed in #1628
+    #assert 'speedo:   1 messages received: 0.0033 msg/s, 3.33 bytes/s, lag:   10 s' in caplog.messages
+    assert 'speedo: 1 messages received: 0.00 msg/s, 3.33 bytes/s, lag:   10s' in caplog.messages
 
     caplog.clear()
     worklist.incoming = [make_message(nowtime_flt - 300)]
@@ -83,7 +85,9 @@ def test_after_accept(mocker, caplog):
     speedo.after_accept(worklist)
     assert len(worklist.incoming) == 1
     assert len(caplog.messages) == 2
-    assert 'speedo:   1 messages received: 0.0033 msg/s, 3.33 bytes/s, lag:  300 s' in caplog.messages
+    # format changed in #1628
+    #assert 'speedo:   1 messages received: 0.0033 msg/s, 3.33 bytes/s, lag:   10 s' in caplog.messages
+    assert 'speedo: 1 messages received: 0.00 msg/s, 3.33 bytes/s, lag:  300s' in caplog.messages
     assert 'speedo: Excessive lag! Messages posted  300 s ago' in caplog.messages
 
     caplog.clear()


### PR DESCRIPTION
After the string formatting changes, some unit tests were failing. 

❗ One of the issues that got discovered is a bit concerning - the `d` format code in f-strings only works with **integers**, but in % formatting it will also accept a float (it converts the float to int):

```
>>> x = 123.456
>>> "%d" % x
'123'
>>> f"{x:d}"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Unknown format code 'd' for object of type 'float'
```

I'm worried that there could be other cases of this that we haven't hit.