### PR TITLE
skip geometry tests if missing pre-requisites.

### DIFF
--- a/tests/sarracenia/flowcb/filter/geometry_test.py
+++ b/tests/sarracenia/flowcb/filter/geometry_test.py
@@ -11,6 +11,13 @@ import sarracenia.flowcb.filter.geometry
 from sarracenia import Message as SR3Message
 import sarracenia.config
 
+from sarracenia.featuredetection import features
+
+
+print( f" {features['geometry']=} " )
+hoho = not features['geometry']['present']
+
+
 # poly2 intersects poly1 (poly2 is *inside* poly1)
 # poly3 doesn't intersect ploy1 or poly2
 # pointA is inside poly1 and poly2, but outside poly3
@@ -44,6 +51,7 @@ def make_message(feature):
 
     return m
 
+@pytest.mark.skipif( hoho, reason="missing python geometry prerequisites" )
 def test___init__():
     options = sarracenia.config.default_config()
     options.logLevel = 'DEBUG'
@@ -78,6 +86,7 @@ def test___init__():
         geojson = sarracenia.flowcb.filter.geometry.Geometry(options)
 
 
+@pytest.mark.skipif( hoho, reason="missing python geometry prerequisites" )
 def test_after_accept():
     options = sarracenia.config.default_config()
     options.logLevel = 'DEBUG'

--- a/tests/sarracenia/flowcb/filter/geometry_test.py
+++ b/tests/sarracenia/flowcb/filter/geometry_test.py
@@ -14,8 +14,7 @@ import sarracenia.config
 from sarracenia.featuredetection import features
 
 
-print( f" {features['geometry']=} " )
-hoho = not features['geometry']['present']
+missing_py_deps = not features['geometry']['present']
 
 
 # poly2 intersects poly1 (poly2 is *inside* poly1)
@@ -51,7 +50,7 @@ def make_message(feature):
 
     return m
 
-@pytest.mark.skipif( hoho, reason="missing python geometry prerequisites" )
+@pytest.mark.skipif( missing_py_deps, reason="missing python geometry prerequisites" )
 def test___init__():
     options = sarracenia.config.default_config()
     options.logLevel = 'DEBUG'
@@ -86,7 +85,7 @@ def test___init__():
         geojson = sarracenia.flowcb.filter.geometry.Geometry(options)
 
 
-@pytest.mark.skipif( hoho, reason="missing python geometry prerequisites" )
+@pytest.mark.skipif( missing_py_deps, reason="missing python geometry prerequisites" )
 def test_after_accept():
     options = sarracenia.config.default_config()
     options.logLevel = 'DEBUG'


### PR DESCRIPTION
the geometry modules are not working on my workstation. set up the relevant pytest to skip it if it cannot succeed.

Rather than failing, it marks the tests as skipped.  Ideally, one would have an environment to properly test this, but since it is broken, this lets you test other stuff without getting distracted:
```
idefix% pytest geometry_test.py
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/peter/Sarracenia/sr3/tests
configfile: pytest.ini
plugins: metadata-3.1.1, bug-1.6.0, cov-7.1.0, depends-1.0.1, html-4.2.0, mock-3.15.1, typeguard-4.4.4
collected 2 items                                                                                                                                                                            

geometry_test.py ss                                                                                                                                                                    [100%]

===================================================================================== 2 skipped in 0.61s =====================================================================================
idefix% 
```