### PR TITLE
second pass at code base with flynt

### DIFF
--- a/sarracenia/examples/moth_http_retrieval.py
+++ b/sarracenia/examples/moth_http_retrieval.py
@@ -99,8 +99,7 @@ while count < 10:
                 elif name == 'air_temp':
                     air_temp = i.get('value')
 
-            print('station: %s, tc_id: %s, lat: %s, long: %s, air_temp: %s' %
-                  (stn_name, tc_id, lat, lon, air_temp))
+            print(f'station: {stn_name}, tc_id: {tc_id}, lat: {lat}, long: {lon}, air_temp: {air_temp}')
         h.ack(m)
         count += 1
         if count > 10:

--- a/sarracenia/flowcb/filter/pclean_f90.py
+++ b/sarracenia/flowcb/filter/pclean_f90.py
@@ -88,9 +88,7 @@ class PClean_F90(PClean):
                 self.ext_count += 1
                 # pick one test identified by file extension
                 src = '/' + msg['relPath']  # src file is in f30 dir
-                dest = "{}{}".format(
-                    src, test_extension
-                )  # format input file for extension test (next f90)
+                dest = f"{src}{test_extension}"  # format input file for extension test (next f90)
 
                 try:
                     if test_extension == '.slink':

--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -539,8 +539,7 @@ class File(FlowCB):
                   not sure if it should be an error message or not.
                   
                 """
-                logger.debug("skipping event that could not be processed: ({}): {}".format(
-                    event, err))
+                logger.debug(f"skipping event that could not be processed: ({event}): {err}")
                 logger.debug("Exception details:", exc_info=True)
                 event_done=True
             if event_done:
@@ -621,8 +620,7 @@ class File(FlowCB):
                 self.obs_watched.append(ow)
                 self.inl[dir_dev_id] = (ow, d)
                 logger.info(
-                    "sr_watch priming watch (instance=%d) scheduled for: %s " %
-                    (len(self.obs_watched), d))
+                    f"sr_watch priming watch (instance={len(self.obs_watched)}) scheduled for: {d} ")
             except:
                 logger.warning(f"sr_watch priming watch: {d} failed, deferred.")
                 logger.debug('Exception details:', exc_info=True)

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -251,8 +251,7 @@ class Disk(NoDupe):
             try:
                 os.unlink(self.cache_file)
             except Exception as err:
-                logger.warning("did not unlink: cache_file={}: err={}".format(
-                    self.cache_file, err))
+                logger.warning(f"did not unlink: cache_file={self.cache_file}: err={err}")
                 logger.debug('Exception details:', exc_info=True)
         self.cache_dict = {}
         self.count = 0

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -291,8 +291,7 @@ class V2Wrapper(FlowCB):
                             script, 'exec'))
         except:
             logger.error(
-                "sr_config/execfile 2 failed for option '%s' and plugin '%s'" %
-                (opname, path))
+                f"sr_config/execfile 2 failed for option '{opname}' and plugin '{path}'")
             logger.debug('Exception details: ', exc_info=True)
             return False
 

--- a/sarracenia/flowcb/work/send_egc_les.py
+++ b/sarracenia/flowcb/work/send_egc_les.py
@@ -107,8 +107,7 @@ class Send_egc_les(FlowCB):
 
         if egc == None:
             logger.error(
-                "file_send_egc_les EGC code not defined for %s %s, file not sent."
-                % (HDR, CCCC))
+                f"file_send_egc_les EGC code not defined for {HDR} {CCCC}, file not sent.")
         return egc
 
     def after_work(self, worklist):
@@ -196,8 +195,7 @@ class Send_egc_les(FlowCB):
                     new_ok.append(msg)
                 else:
                     logger.error(
-                        "file_send_egc_les: error with return info from file: %s" %
-                        filepath)
+                        f"file_send_egc_les: error with return info from file: {filepath}")
                     worklist.rejected.append(msg)
             except:
                 logger.error(

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -709,8 +709,7 @@ class AMQP(Moth):
                         exchange = self.o['exchange'][self.splitPick(message)]
                     else:
                         logger.error(
-                            'do not know which exchange to publish to: %s' %
-                            self.o['exchange'])
+                            f"do not know which exchange to publish to: {self.o['exchange']}")
                         return False
                 else:
                     exchange = self.o['exchange'][0]
@@ -785,8 +784,7 @@ class AMQP(Moth):
             self.channel.basic_publish(AMQP_Message, exchange, topic, timeout=pub_timeout)
             # Issue #732: tx_commit can get stuck forever
             self.channel.tx_commit()
-            logger.debug("published body: {} headers: {} to {} under: {} ".format(
-                          body, headers, exchange, topic))
+            logger.debug(f"published body: {body} headers: {headers} to {exchange} under: {topic} ")
             self.metrics['txGoodCount'] += 1
             return True  # no failure == success :-)
 

--- a/sarracenia/rabbitmq_admin.py
+++ b/sarracenia/rabbitmq_admin.py
@@ -303,8 +303,7 @@ if __name__ == "__main__":
 
     u = 'tsource'
     up = rabbitmq_user_access(url, u)
-    print("permissions for %s: \nqueues: %s\nexchanges: %s\nbindings %s" %
-          (u, up['queues'], up['exchanges'], up['bindings']))
+    print(f"permissions for {u}: \nqueues: {up['queues']}\nexchanges: {up['exchanges']}\nbindings {up['bindings']}")
     #print( "\n\nbindings: %s" % json.loads(exec_rabbitmqadmin(url,"list bindings")[1]) )
 
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -2045,8 +2045,7 @@ class sr_GlobalState:
 
         if hasattr(self, 'leftovers') and (len(self.leftovers) > 0):
             if self.leftovers[0] in ['examples', 'eg', 'ie']:
-                print('Sample Configurations: (from: %s )' %
-                      (self.package_lib_dir + os.sep + 'examples'))
+                print(f"Sample Configurations: (from: {self.package_lib_dir + os.sep + 'examples'} )")
                 for c in sarracenia.config.Config.components:
                     self.print_configdir2(
                         f" of {c} ",
@@ -2574,8 +2573,7 @@ class sr_GlobalState:
 
             if self.configs[c][cfg]['status'] in self.status_active:
                 for i in self.states[c][cfg]['instance_pids']:
-                    print("failed to kill: %s/%s instance: %s, pid: %s )" %
-                          (c, cfg, i, self.states[c][cfg]['instance_pids'][i]))
+                    print(f"failed to kill: {c}/{cfg} instance: {i}, pid: {self.states[c][cfg]['instance_pids'][i]} )")
 
             self._tag_progress( c, cfg, 'shutdown', ending=True )
 
@@ -2670,8 +2668,7 @@ class sr_GlobalState:
         for indexSelfBroker,h in enumerate(self.brokers):
             if 'admin' in self.brokers[h]:
                 admin_url = self.brokers[h]['admin'].url
-                admin_urlstr = "%s://%s@%s" % ( admin_url.scheme, \
-                   admin_url.username, admin_url.hostname)
+                admin_urlstr = f"{admin_url.scheme}://{admin_url.username}@{admin_url.hostname}"
                 if admin_url.port:
                     admin_urlstr += ":" + str(admin_url.port)
                 a = f'admin: {admin_urlstr}'
@@ -3163,13 +3160,9 @@ class sr_GlobalState:
                 status[self.configs[c][cfg]['status']].append(cfg + sfx)
 
             if (len(status['partial']) + len(status['running'])) < 1:
-                print('%-10s %-10s %-6s %3d %s' %
-                      (c, 'stopped', 'OK', len(status['stopped']), ', '.join(
-                          status['stopped'])))
+                print(f"{c:10} {'stopped':10} {'OK':6} {len(status['stopped']):3} {', '.join(status['stopped'])}")
             elif len(status['running']) == len(self.configs[c]):
-                print('%-10s %-10s %-6s %3d %s' %
-                      (c, 'running', 'OK', len(self.configs[c]), ', '.join(
-                          status['running'])))
+                print(f"{c:10} {'running':10} {'OK':6} {len(self.configs[c]):3} {', '.join(status['running'])}")
             elif len(status['running']) == (len(self.configs[c]) -
                                             len(status['disabled'])):
                 print('%-10s %-10s %-6s %-3d %s' % (c, 'most', 'OKd', \

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -400,8 +400,7 @@ class Https(Transfer):
         except urllib.error.HTTPError as e:
             logger.error(f'failed 4 {self.__url_redir_str()}')
             logger.error(
-                'Server couldn\'t fulfill the request. Error code: %s, %s' %
-                (e.code, e.reason))
+                f'Server couldn\'t fulfill the request. Error code: {e.code}, {e.reason}')
             self.connected = False
             raise
         except urllib.error.URLError as e:


### PR DESCRIPTION

flynt is an f-string formatting linter... that converts old-style python strings to f-strings.
This is preferred for strings when they are not in logger.debug() invocations (and flynt is aware of that.)
A previous PR took care of many (large majority) of such changes.

After many parallel changes it seems more old stle strings present. doing a second pass. for #1623

I think the main difference is this time, I told it about the line length convention:
```

idefix% find . -name '*.py' | xargs flynt -ll 119 -v 
...

```
It skips lines that will be too long (default > 88) if reformatted... Once I gave it the longer
line length, it decided to do more transformations.
