### PR TITLE
Fix RecursionError crash in diskqueue on corrupted files

### DIFF
--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -348,19 +348,19 @@ class DiskQueue():
             logger.debug('DEBUG %s open read', path)
             fp = open(path, 'r')
 
-        line = fp.readline()
-        if not line:
-            try:
-                fp.close()
-            except Exception:
-                pass
-            return None, None
+        while True:
+            line = fp.readline()
+            if not line:
+                try:
+                    fp.close()
+                except Exception:
+                    pass
+                return None, None
 
-        msg = self.msgFromJSON(line)
-        # a corrupted line : go to the next
-        if msg is None: return self.msg_get_from_file(fp, path)
-
-        return fp, msg
+            msg = self.msgFromJSON(line)
+            if msg is not None:
+                return fp, msg
+            # corrupted line, skip to next
 
     def on_housekeeping(self):
         """

--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -490,3 +490,47 @@ def test_get__keyboard_interrupt_propagates(tmp_path):
         with pytest.raises(KeyboardInterrupt):
             dq.get()
 
+
+def test_msg_get_from_file__corrupted_lines(tmp_path):
+    """Regression: msg_get_from_file used recursion to skip corrupted lines.
+    With >1000 consecutive bad lines, this hit Python's recursion limit
+    and crashed with RecursionError.  The fix uses a while loop instead.
+    """
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_corrupted_lines')
+
+    message = make_message()
+    valid_line = jsonpickle.encode(message) + '\n'
+
+    # write 2000 corrupted lines followed by one valid message
+    with open(dq.queue_file, 'w') as fp:
+        for i in range(2000):
+            fp.write('THIS IS NOT VALID JSON line %d\n' % i)
+        fp.write(valid_line)
+
+    fp_out, msg = dq.msg_get_from_file(None, dq.queue_file)
+
+    assert msg is not None, "valid message after 2000 corrupted lines was not found"
+    assert msg == message
+    assert fp_out is not None
+    fp_out.close()
+
+
+def test_msg_get_from_file__all_corrupted(tmp_path):
+    """If the entire file is corrupted, msg_get_from_file should return
+    None without crashing.
+    """
+    BaseOptions = Options()
+    BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(BaseOptions, 'test_all_corrupted')
+
+    with open(dq.queue_file, 'w') as fp:
+        for i in range(500):
+            fp.write('GARBAGE LINE %d\n' % i)
+
+    fp_out, msg = dq.msg_get_from_file(None, dq.queue_file)
+
+    assert fp_out is None
+    assert msg is None
+


### PR DESCRIPTION
##### What

`msg_get_from_file()` used recursion to skip corrupted (non-JSON) lines in the retry queue file. A queue file with >1000 consecutive bad lines crashes the process with `RecursionError`. This happens after kill -9, disk full during write, or any partial write corruption.

##### The fix

Replace the recursive call with a `while True` loop that skips corrupted lines iteratively. Can now handle arbitrarily large corrupted files without crashing.