### PR TITLE
Fix MQTT ack() silently succeeding on broker mismatch

### DIFF
--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -713,12 +713,19 @@ class MQTT(Moth):
 
     def ack(self, m: sarracenia.Message ) -> bool:
 
-        if 'ack_id' in m:
-            logger.info( f"mid={m['ack_id']}")
-            if m['ack_id']['broker'] == self.broker:
-                self.client.ack( m['ack_id']['delivery_tag'], m['qos'] )
-                del m['ack_id']
-                m['_deleteOnPost'].remove('ack_id')
+        if 'ack_id' not in m:
+            return True
+
+        logger.info(f"mid={m['ack_id']}")
+        if m['ack_id']['broker'] != self.broker:
+            logger.warning(f"ack failed for {m['ack_id']}: broker mismatch (current: {self.broker})")
+            del m['ack_id']
+            m['_deleteOnPost'].remove('ack_id')
+            return False
+
+        self.client.ack(m['ack_id']['delivery_tag'], m['qos'])
+        del m['ack_id']
+        m['_deleteOnPost'].remove('ack_id')
         return True
 
     def putNewMessage(self,


### PR DESCRIPTION
##### What

MQTT `ack()` skipped the actual broker ack when `ack_id['broker']` didn't match the current broker (e.g. after failover), but still returned `True`. Message stays unacknowledged — silent message loss.

##### Change

Log a warning and return `False` on broker mismatch, matching how `amqp.py` handles the same case.