### PR TITLE
fix nodupe_ttl parsing

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -1973,13 +1973,14 @@ class Config:
         if self.action not in self.actions:
             logger.error( f"invalid action: {self.action} must be one of: {','.join(self.actions)}" )
 
-        if hasattr(self, 'nodupe_ttl'):
+        # nodupe_ttl is a combined duration and flag option for legacy reasons
+        # defaults to 0 (nodupe disabled)
+        if hasattr(self, 'nodupe_ttl') and self.nodupe_ttl is not None:
             if (type(self.nodupe_ttl) is str):
                 if isTrue(self.nodupe_ttl):
                     self.nodupe_ttl = 300
                 else:
-                    self.nodupe_ttl = durationToSeconds(
-                        self.nodupe_ttl, default=300)
+                    self.nodupe_ttl = durationToSeconds(self.nodupe_ttl, default=300)
         else:
             self.nodupe_ttl = 0
 

--- a/tests/sarracenia/config_test.py
+++ b/tests/sarracenia/config_test.py
@@ -562,3 +562,34 @@ def test_filename_option():
     assert(options.masks[8][2] == "SATNET=1")
     assert(options.masks[9][2] == "DESTFNSCRIPT=hi")
     assert(options.masks[10][2] is None)
+
+def test_nodupe_ttl_parsing():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.component = 'subscribe'
+    options.config = 'nodupettl'
+    options.action = 'start'
+
+    # default
+    assert(options.nodupe_ttl == 0)
+
+    # any true value should set it to 5 mins
+    options.parse_line("subscribe", "nodupettl", "subscribe/nodupettl", 1, "nodupe_ttl on")
+    options.finalize()
+    assert(options.nodupe_ttl == 300)
+
+    options.nodupe_ttl = None
+    options.parse_line("subscribe", "nodupettl", "subscribe/nodupettl", 1, "nodupe_ttl 10m")
+    options.finalize()
+    assert(options.nodupe_ttl == 600)
+    options.nodupe_ttl = None
+    options.parse_line("subscribe", "nodupettl", "subscribe/nodupettl", 1, "nodupe_ttl 50")
+    options.finalize()
+    assert(options.nodupe_ttl == 50)
+    options.nodupe_ttl = None
+    options.parse_line("subscribe", "nodupettl", "subscribe/nodupettl", 1, "nodupe_ttl off")
+    options.finalize()
+    assert(options.nodupe_ttl == 0)
+    options.nodupe_ttl = None
+    options.parse_line("subscribe", "nodupettl", "subscribe/nodupettl", 1, "nodupe_ttl 100")
+    options.finalize()
+    assert(options.nodupe_ttl == 100)


### PR DESCRIPTION
`nodupe_ttl False` would set nodupe_ttl to None but nodupe_ttl must be an int.


The key change is:

```diff
-        if hasattr(self, 'nodupe_ttl'):
+        if hasattr(self, 'nodupe_ttl') and self.nodupe_ttl is not None:
```