### PR TITLE
make diskqueue work properly with jsonpickle >= v4

### DIFF
--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -219,6 +219,10 @@ class DiskQueue():
             logger.debug("Error information: ", exc_info=True)
             return None
 
+        if type(msg) is not sarracenia.Message:
+            logger.error(f"invalid line in retry file (not decoded as sarracenia.Message): {line}")
+            return None
+
         return msg
 
     def msgToJSON(self, message):


### PR DESCRIPTION
With older versions of jsonpickle, when the string being decoded was not valid JSON, it would raise an exception:

```
>>> import jsonpickle
>>> jsonpickle.decode('THIS IS NOT VALID JSON line %d\n' % 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/jsonpickle/unpickler.py", line 87, in decode
    data = backend.decode(string)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jsonpickle/backend.py", line 72, in decode
    raise e
  File "/usr/lib/python3/dist-packages/jsonpickle/backend.py", line 69, in decode
    return self.backend_decode(name, string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/jsonpickle/backend.py", line 221, in backend_decode
    return self._decoders[name](string, *optargs, **decoder_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

But newer versions just return the string back:

```
Type "help", "copyright", "credits" or "license" for more information.
>>> import jsonpickle
>>> jsonpickle.decode('THIS IS NOT VALID JSON line %d\n' % 1)
'THIS IS NOT VALID JSON line 1'
>>>
```

@robjarawan's unit test update actually caught this failure.

I modified diskqueue to check if the object returned by decode is actually a sarracenia message object.