### PR TITLE
change pypi classifier for sr3 from Beta to Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ authors = [
 ]
 
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         ]
     },
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
if you go to pypi.org, it lists metpx-sr3 as *Beta*.   That´s not longer accurate.
I think version 3 is a Production/Stable version now.   


On a related note, the v2_stable branch (aka metpx-sarracenia on pypi.org) is listed as "Production/Stable"... 
I think:

* there is no active development at this point.  It's just maintenance, and trying to keep a baseline, while v2 replacement is completed.

* We are not installing v2 anywhere.  sr3 is the recommendation for everyone, everywhere.


So the choices for new "Development Status" are:

```
6 - Mature: The project is well-established and actively maintained.
7 - Inactive: The project is no longer actively maintained.
     
```

I have an issue with *actively* maintained...   v2 is not abandonware... but it isn't going to get any features... I don't think anyone would recommend new installations of it.  So I feel like it is  6.5.... it's maintained, but not developed...

Which status do people think should be applied to v2 these days?  I'll do a separate PR for that. #1668 