### PR TITLE
Fix 5 bugs in flowcb/work/delete.py on_housekeeping

### DIFF
--- a/sarracenia/flowcb/work/delete.py
+++ b/sarracenia/flowcb/work/delete.py
@@ -63,7 +63,7 @@ class Delete(FlowCB):
                 files_to_delete.append(message['delete_source'])
 
             if self.o.delete_destination:
-                self.dirsOfDeletion |= set(message['new_dir'])
+                self.dirsOfDeletion |= set([message['new_dir']])
                 files_to_delete.append(
                     f"{message['new_dir']}/{message['new_file']}")
 
@@ -77,12 +77,12 @@ class Delete(FlowCB):
 
     def on_housekeeping(self):
 
-        dirlist=self.dirsOfDeletion
+        dirlist=list(self.dirsOfDeletion)
 
         logger.info('scan for directories to cleanup')
         for d in dirlist:
             if d in self.sacredDirs:
-                self.dirsOfDeletion.remove(d)
+                self.dirsOfDeletion.discard(d)
                 continue
             if os.path.isdir(d):
                 l = os.listdir(d)
@@ -93,11 +93,11 @@ class Delete(FlowCB):
                     if age > self.o.housekeeping:
                         try:
                             os.rmdir(d)
-                            self.dirsOfDeletion.remove(d)
-                            self.dirsofDeltion.add(dirname(d))
+                            self.dirsOfDeletion.discard(d)
+                            self.dirsOfDeletion.add(os.path.dirname(d))
                             logger.info( f"deleted {d}")
                         except Exception as err:
-                            logger.error(f"could not unlink {f}: {err}")
+                            logger.error(f"could not unlink {d}: {err}")
                             logger.debug("Exception details:", exc_info=True)
                     else:
                         logger.info( f"but not for long enough yet.")


### PR DESCRIPTION
##### What

Fixes 5 bugs in `flowcb/work/delete.py` that make `on_housekeeping` crash or silently misbehave when `delete_destination` is enabled.

##### Bugs fixed

1. **`set(message['new_dir'])` iterates characters** -- `set('/tmp/foo')` produces `{'/', 't', 'm', 'p', 'f', 'o'}` instead of `{'/tmp/foo'}`. Fixed with `set([message['new_dir']])`.

2. **RuntimeError: Set changed size during iteration** -- `on_housekeeping` iterates `self.dirsOfDeletion` while calling `.remove()` on it. Fixed by iterating over `list(self.dirsOfDeletion)`.

3. **KeyError from `.remove()`** -- if a dir was already discarded, `.remove()` raises. Changed to `.discard()`.

4. **`self.dirsofDeltion` typo + missing import** -- capital O missing, and `dirname()` called without import. Fixed to `self.dirsOfDeletion` and `os.path.dirname()`.

5. **Wrong variable in error message** -- `f"could not unlink {f}"` references the file loop variable from `after_work`, not the directory `d` being removed. Fixed to `{d}`.

##### How found

Copilot-generated test coverage on the fork surfaced these during unit test development.

##### Test

Existing flow tests cover the `after_work` path. The `on_housekeeping` path was previously untested -- these bugs would crash on the first non-empty housekeeping cycle with `delete_destination` enabled.