### PR TITLE
Fix trailing comma in admin role check in rabbitmq_admin

### DIFF
--- a/sarracenia/rabbitmq_admin.py
+++ b/sarracenia/rabbitmq_admin.py
@@ -92,7 +92,7 @@ def add_user(url, role, user, passwd, simulate):
 
     # admin and feeder gets the same permissions
 
-    if role in ['admin,', 'feeder', 'manager']:
+    if role in ['admin', 'feeder', 'manager']:
         c = "configure=.*"
         w = "write=.*"
         r = "read=.*"


### PR DESCRIPTION
##### What

One-character fix: `'admin,'` -> `'admin'` on line 95 of `rabbitmq_admin.py`.

##### Why

The trailing comma means `role in ['admin,', 'feeder', 'manager']` never matches when `role == 'admin'`, so admin users get created with the administrator tag but silently receive no permissions (configure/write/read are never declared).

##### How found

Copilot-generated test coverage on the fork flagged that the admin branch of `add_user` was unreachable.