### PR TITLE
Revert "Fix AMQP connection and channel leak on reconnect"

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -249,14 +249,6 @@ class AMQP(Moth):
         else:
             sslarg=False
         
-        if self.connection:
-            try:
-                self.connection.collect()
-                self.connection.close()
-            except Exception:
-                logger.debug('failed to close old connection before reconnect', exc_info=True)
-            self.connection = None
-
         self.connection = amqp.Connection(host=host,
                                           userid=broker.url.username,
                                           password=unquote(
@@ -390,9 +382,9 @@ class AMQP(Moth):
             # from sr_consumer.build_connection...
             if not self.__connect(broker):
                 self.setEbo(start)
-                self.close()
+                self.connection = None
                 return
-
+            
             if self.o['prefetch'] != 0:
                 # using global False because RabbitMQ Quorum Queues don't support Global QoS, issue #1233
                 self.channel.basic_qos(0, queue['prefetch'], False)
@@ -445,7 +437,7 @@ class AMQP(Moth):
             logger.error( f"failed connection to {str(broker)}: {err}" )
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
-            self.close()
+            self.connection = None
 
 
     def putSetup(self) -> None:
@@ -470,7 +462,7 @@ class AMQP(Moth):
 
             if not self.__connect(self.o['broker']):
                 self.setEbo(start)
-                self.close()
+                self.connection = None
                 return
 
             # transaction mode... confirms would be better...
@@ -507,6 +499,7 @@ class AMQP(Moth):
                         self.o['broker'].url.hostname, err))
             logger.debug('Exception details: ', exc_info=True)
             self.setEbo(start)
+            self.connection=None
             self.close()
 
     def putCleanUp(self) -> None:


### PR DESCRIPTION
This reverts commit d4a52ba15f226e8f8fec72ebca2c51c0a4992daa. After this commit in the tree. all of the flow tests fail to remove queues during the "flow_cleanup.sh" phase. instead they delete and create new ones.

to reproduce:
* set up a host to run sr_insects' flow tests.
* put a window with the rabbitmq  manager web ui, "Queues and Streams" tab, so you can see all the queues defined.

```

cd static_flow
./flow_setup.sh declare
./flow_cleanup.sh

```

The window should show:

*  no queues extant before the flow_setup.sh runs.
* many defined queues after ./flow_setup.sh declare is run.
* no queues extant after the flow_cleanup.sh

but it doesn't instead all the same queues are there, but with different numbers.  so  delete does not work as it should (I think it deletes, and then re-creates.)  Identified this commit via bisection.

I don't know why this commit has that effect, but since it delivers no features, and will be extremely confusing in ops.
I recommend just backing out of it for now.