### PR TITLE
fix typo exitType -> ExitType

### DIFF
--- a/debian/metpx-sr3.service
+++ b/debian/metpx-sr3.service
@@ -12,7 +12,7 @@ Requires=network-online.target
 
 [Service]
 Type=forking
-exitType=cgroup
+ExitType=cgroup
 ExecStart=/usr/bin/sr3 start
 User=sarra
 Group=sarra

--- a/debian/metpx-sr3.user.service
+++ b/debian/metpx-sr3.user.service
@@ -21,7 +21,7 @@ After=network.target
 
 [Service]
 Type=forking
-exitType=cgroup
+ExitType=cgroup
 
 ExecStart=/usr/bin/sr3 start
 


### PR DESCRIPTION
Systemd complains "Unknown key name 'exitType' in section 'Service', ignoring"