### PR TITLE
Fix #989: Detect '#' in credentials and auto-unquote passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pyproject-wheeldir/
 GEMINI.md
 CLAUDE.md
 GEMINI.md
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "url": "http://localhost:8931/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,0 @@
-{
-  "mcpServers": {
-    "playwright": {
-      "url": "http://localhost:8931/mcp"
-    }
-  }
-}

--- a/sarracenia/config/credentials.py
+++ b/sarracenia/config/credentials.py
@@ -42,6 +42,33 @@ import urllib, urllib.parse
 import sys
 
 
+class UrlParseResult(urllib.parse.ParseResult):
+    """ParseResult subclass that auto-unquotes username and password.
+
+    urllib.parse.urlparse percent-encodes reserved characters in netloc
+    (e.g. %40 for @, %23 for #).  Consumers that use url.username or
+    url.password directly receive the raw percent-encoded form.  This
+    subclass transparently unquotes those two fields so callers never
+    need to call urllib.parse.unquote() themselves.
+    """
+
+    @property
+    def username(self) -> str:
+        raw = super().username
+        return urllib.parse.unquote(raw) if raw else raw
+
+    @property
+    def password(self) -> str:
+        raw = super().password
+        return urllib.parse.unquote(raw) if raw else raw
+
+
+def _urlparse(urlstr: str) -> UrlParseResult:
+    """Parse a URL string and return a UrlParseResult with auto-unquoted credentials."""
+    pr = urllib.parse.urlparse(urlstr)  # keep internal _urlparse use of stdlib
+    return UrlParseResult(pr.scheme, pr.netloc, pr.path, pr.params, pr.query, pr.fragment)
+
+
 class Credential:
     r"""
 
@@ -88,7 +115,7 @@ class Credential:
         """
 
         if urlstr is not None:
-            self.url = urllib.parse.urlparse(urlstr)
+            self.url = _urlparse(urlstr)
         else:
             self.url = None
 
@@ -194,7 +221,7 @@ class CredentialDB:
         key=urlstr
         if details == None:
             details = Credential()
-            details.url = urllib.parse.urlparse(urlstr)
+            details.url = _urlparse(urlstr)
             if hasattr(details.url,'password'):
                 key = key.replace( f":{details.url.password}", "" )
 
@@ -225,14 +252,14 @@ class CredentialDB:
 
         # create url object if needed
 
-        url = urllib.parse.urlparse(urlstr)
+        url = _urlparse(urlstr)
 
         # add anonymous default, if necessary.
         if ( 'amqp' in url.scheme ) and \
            ( (url.username == None) or (url.username == '') ):
             urlstr = urllib.parse.urlunparse( ( url.scheme, \
                 f'anonymous:anonymous@{url.netloc}', url.path, None, None, url.port ) )
-            url = urllib.parse.urlparse(urlstr)
+            url = _urlparse(urlstr)
             if self.isValid(url):
                 self.add(urlstr)
                 return False, self.credentials[urlstr.replace(':anonymous@','@')]
@@ -347,7 +374,19 @@ class CredentialDB:
             # first field url string = protocol://user:password@host:port[/vost]
             parts = sline.split()
             urlstr = parts[0]
-            url = urllib.parse.urlparse(urlstr)
+            url = _urlparse(urlstr)
+
+            # Detect credentials broken by unencoded '#' in password/username.
+            # urlparse treats '#' as a fragment delimiter, so 'user:pass#word@host'
+            # is parsed as netloc='user:pass' and fragment='word@host', leaving
+            # url.hostname empty. Use %23 in credentials.conf to encode '#'.
+            if url.fragment and '@' in url.fragment:
+                logger.error(
+                    "credential URL appears malformed -- the password likely contains '#' "
+                    "which is a URL fragment delimiter. Replace '#' with '%%23' in credentials.conf. "
+                    "Other special characters: '@' -> '%%40', ':' -> '%%3a', '/' -> '%%2f'. "
+                    "Offending line: %s", urlstr)
+                return
 
             # credential details
             details = Credential()
@@ -460,7 +499,7 @@ class CredentialDB:
         # create url object if needed
 
         if not url:
-            url = urllib.parse.urlparse(urlstr)
+            url = _urlparse(urlstr)
 
         # resolving credentials
 
@@ -509,7 +548,7 @@ class CredentialDB:
             logging.critical(f"bad credential {urlstr}")
             # Callers expect that a Credential object will be returned
             cred_details = Credential()
-            cred_details.url = urllib.parse.urlparse(urlstr)
+            cred_details.url = _urlparse(urlstr)
             return False, cred_details
         return True, cred_details
 

--- a/sarracenia/config/credentials.py
+++ b/sarracenia/config/credentials.py
@@ -42,14 +42,21 @@ import urllib, urllib.parse
 import sys
 
 
+_REDACT_RE = re.compile(r'(://[^:@/]+:)[^@]+(@)')
+
+
 class UrlParseResult(urllib.parse.ParseResult):
     """ParseResult subclass that auto-unquotes username and password.
 
-    urllib.parse.urlparse percent-encodes reserved characters in netloc
-    (e.g. %40 for @, %23 for #).  Consumers that use url.username or
-    url.password directly receive the raw percent-encoded form.  This
-    subclass transparently unquotes those two fields so callers never
-    need to call urllib.parse.unquote() themselves.
+    urllib.parse preserves percent-encoding in .username and .password
+    (e.g. 'pass%23word' stays 'pass%23word', not 'pass#word').  Consumers
+    that need the decoded value had to call urllib.parse.unquote() themselves.
+    This subclass does that transparently via the .username and .password
+    properties, so callers always receive the human-readable decoded form.
+
+    When reconstructing a URL string (e.g. for passing to an external library),
+    use .raw_username and .raw_password to get the percent-encoded forms, or
+    use .netloc / .geturl() directly so encoding is preserved correctly.
     """
 
     @property
@@ -62,10 +69,20 @@ class UrlParseResult(urllib.parse.ParseResult):
         raw = super().password
         return urllib.parse.unquote(raw) if raw else raw
 
+    @property
+    def raw_username(self) -> str:
+        """Username in percent-encoded form, suitable for URL reconstruction."""
+        return super().username
+
+    @property
+    def raw_password(self) -> str:
+        """Password in percent-encoded form, suitable for URL reconstruction."""
+        return super().password
+
 
 def _urlparse(urlstr: str) -> UrlParseResult:
     """Parse a URL string and return a UrlParseResult with auto-unquoted credentials."""
-    pr = urllib.parse.urlparse(urlstr)  # keep internal _urlparse use of stdlib
+    pr = urllib.parse.urlparse(urlstr)
     return UrlParseResult(pr.scheme, pr.netloc, pr.path, pr.params, pr.query, pr.fragment)
 
 
@@ -222,8 +239,8 @@ class CredentialDB:
         if details == None:
             details = Credential()
             details.url = _urlparse(urlstr)
-            if hasattr(details.url,'password'):
-                key = key.replace( f":{details.url.password}", "" )
+            if hasattr(details.url,'raw_password') and details.url.raw_password:
+                key = key.replace( f":{details.url.raw_password}", "" )
 
         self.credentials[key] = details
 
@@ -378,14 +395,16 @@ class CredentialDB:
 
             # Detect credentials broken by unencoded '#' in password/username.
             # urlparse treats '#' as a fragment delimiter, so 'user:pass#word@host'
-            # is parsed as netloc='user:pass' and fragment='word@host', leaving
-            # url.hostname empty. Use %23 in credentials.conf to encode '#'.
-            if url.fragment and '@' in url.fragment:
+            # is parsed as netloc='user:pass' and fragment='word@host/'.
+            # The '@' that separates userinfo from host ends up in the fragment
+            # instead of netloc -- that is the reliable symptom.
+            # Use %23 in credentials.conf to encode '#'.
+            if url.fragment and '@' in url.fragment and '@' not in url.netloc:
                 logger.error(
                     "credential URL appears malformed -- the password likely contains '#' "
                     "which is a URL fragment delimiter. Replace '#' with '%%23' in credentials.conf. "
                     "Other special characters: '@' -> '%%40', ':' -> '%%3a', '/' -> '%%2f'. "
-                    "Offending line: %s", urlstr)
+                    "Offending line: %s", _REDACT_RE.sub(r'\1<secret>\2', urlstr))
                 return
 
             # credential details

--- a/sarracenia/flowcb/download/mail_ingest.py
+++ b/sarracenia/flowcb/download/mail_ingest.py
@@ -47,7 +47,7 @@ class Mail_ingest(FlowCB):
                         user            = setting.username
                         user = urllib.parse.unquote(user)
                         password        = setting.password
-                        password = urllib.parse.unquote(password)
+                        password = urllib.parse.password
                         server          = setting.hostname
                         protocol        = setting.scheme.lower() 
                         port            = setting.port

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -486,7 +486,6 @@ class AMQP(Moth):
             # transaction mode... confirms would be better...
             self.channel.tx_select()
             broker_str = str(self.o['broker'])
-                ':' + self.o['broker'].url.password + '@', '@')
 
             logger.debug('putSetup ... 1. connected to %s', broker_str)
 

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -303,7 +303,7 @@ class AMQP(Moth):
                     return -2
 
             #FIXME: test self.first_setup and props['reset']... delete queue...
-            broker_str = broker.url.geturl().replace( ':' + broker.url.password + '@', '@')
+            broker_str = str(broker)
 
             if queue['declare'] and queue['name']:
 
@@ -401,7 +401,7 @@ class AMQP(Moth):
             #logger.info('getSetup connected to {}'.format(self.o['broker'].url.hostname) )
 
             #FIXME: test self.first_setup and props['reset']... delete queue...
-            broker_str = broker.url.geturl().replace( ':' + broker.url.password + '@', '@')
+            broker_str = str(broker)
 
             # from Queue declare
             msg_count = self._queueDeclare()
@@ -485,7 +485,7 @@ class AMQP(Moth):
 
             # transaction mode... confirms would be better...
             self.channel.tx_select()
-            broker_str = self.o['broker'].url.geturl().replace(
+            broker_str = str(self.o['broker'])
                 ':' + self.o['broker'].url.password + '@', '@')
 
             logger.debug('putSetup ... 1. connected to %s', broker_str)

--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -251,10 +251,8 @@ class AMQP(Moth):
         
         self.connection = amqp.Connection(host=host,
                                           userid=broker.url.username,
-                                          password=unquote(
-                                              broker.url.password),
-                                          login_method=broker.login_method,
-                                          virtual_host=vhost,
+                                          password=broker.url.password,
+                                          login_method=broker.login_method,                                          virtual_host=vhost,
                                           ssl=sslarg,
                                           client_properties={'product':'MetPX Sarracenia (sr3)',
                                                              'product_version':sarracenia.__version__,

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -396,7 +396,7 @@ class MQTT(Moth):
         if 'max_inflight_messages' in queue:
             client.max_inflight_messages_set(queue['max_inflight_messages'])
 
-        client.username_pw_set(broker.url.username, unquote(broker.url.password))
+        client.username_pw_set(broker.url.username, broker.url.password)
         return client
 
     def getSetup(self):
@@ -542,7 +542,7 @@ class MQTT(Moth):
                 self.client.max_queued_messages_set(self.o['max_queued_messages'])
  
             self.client.username_pw_set(self.o['broker'].url.username,
-                                        unquote(self.o['broker'].url.password))
+                                        self.o['broker'].url.password)
             self.connect_in_progress = True
             res = self.client.connect_async(self.o['broker'].url.hostname,
                                       port=self.__sslClientSetup(),

--- a/sarracenia/rabbitmq_admin.py
+++ b/sarracenia/rabbitmq_admin.py
@@ -33,7 +33,7 @@ def exec_rabbitmqadmin(url, options, simulate=False):
         command = rabbitmqadmin
         command += ' --host \'' + url.hostname
         command += '\' --user \'' + url.username
-        command += '\' -p \'' + urllib.parse.unquote(url.password)
+        command += '\' -p \'' + url.password
         command += '\' --format raw_json '
         if url.scheme == 'amqps':
             command += ' --ssl --port=15671 '
@@ -84,7 +84,7 @@ def add_user(url, role, user, passwd, simulate):
 
     declare = f"declare user name='{user}' password="
 
-    if passwd != None: declare += f"'{urllib.parse.unquote(passwd)}'"
+    if passwd != None: declare += f"'{passwd}'"
     if role == 'admin': declare += " tags=administrator "
     else: declare += ' tags="" '
 
@@ -180,7 +180,7 @@ def broker_get_exchanges(url, ssl_key_file=None, ssl_cert_file=None):
         conn = http.client.HTTPConnection(url.hostname, "15672")
 
     bcredentials = bytes(
-        url.username + ':' + urllib.parse.unquote(url.password), "utf-8")
+        url.username + ':' + url.password, "utf-8")
     b64credentials = base64.b64encode(bcredentials).decode("ascii")
     headers = {"Authorization": "Basic " + b64credentials}
 

--- a/sarracenia/transfer/azure.py
+++ b/sarracenia/transfer/azure.py
@@ -114,7 +114,7 @@ class Azure(Transfer):
                 self.account = url.username if url.username != '' else None
 
                 if url.password is not None and url.password != '':
-                    self.key = urllib.parse.unquote_plus(url.password)
+                    self.key = url.password
                 else:
                     self.key = None
 

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -228,13 +228,13 @@ class Ftp(Transfer):
                 ftp = ftplib.FTP()
                 ftp.encoding = 'utf-8'
                 ftp.connect(self.host, self.port, timeout=expire)
-                ftp.login(self.user, unquote(self.password))
+                ftp.login(self.user, self.password)
             # implicit FTPS (usually port 990)
             elif self.tls and self.implicit_ftps:
                 ftp = IMPLICIT_FTP_TLS()
                 ftp.encoding = self.o.ftpFilenameEncoding
                 ftp.connect(host=self.host, port=self.port, timeout=expire)
-                ftp.login(user=self.user, passwd=unquote(self.password))
+                ftp.login(user=self.user, passwd=self.password)
                 if self.prot_p:
                     ftp.prot_p()
             # explicit FTPS (port 21)
@@ -242,7 +242,7 @@ class Ftp(Transfer):
                 # ftplib supports FTPS with TLS
                 ftp = ftplib.FTP_TLS(self.host,
                                      self.user,
-                                     unquote(self.password),
+                                     self.password,
                                      timeout=expire)
                 ftp.encoding = self.o.ftpFilenameEncoding
                 if self.prot_p: ftp.prot_p()

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -180,7 +180,7 @@ class Https(Transfer):
              # username and password credentials
             if self.user != None:
                 # continue with authentication
-                self.password_mgr.add_password(None, self.sendTo, self.user, unquote(self.password))
+                self.password_mgr.add_password(None, self.sendTo, self.user, self.password)
 
             return True
 

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -217,7 +217,7 @@ class Sftp(Transfer):
             # FIXME this should be an option... for security reasons... not forced
             self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             if self.password:
-                self.ssh.connect(self.host,self.port,self.user,unquote(self.password), \
+                self.ssh.connect(self.host,self.port,self.user,self.password, \
                                  pkey=None,key_filename=self.ssh_keyfile,\
                                  timeout=self.o.timeout,allow_agent=False,look_for_keys=False)
             else:

--- a/tests/sarracenia/credentials_test.py
+++ b/tests/sarracenia/credentials_test.py
@@ -4,3 +4,98 @@ from tests.conftest import *
 
 import sarracenia.config
 import sarracenia.config.credentials
+from sarracenia.config.credentials import Credential, CredentialDB, _urlparse
+
+
+class Test_UrlParseResult:
+
+    def test_normal_password_unquoted(self):
+        """Plain password is returned unchanged."""
+        url = _urlparse('amqps://user:plainpass@broker.example.com/')
+        assert url.password == 'plainpass'
+        assert url.username == 'user'
+
+    def test_percent_encoded_hash_in_password(self):
+        """'%23' in password is decoded to '#'."""
+        url = _urlparse('amqps://user:pass%23word@broker.example.com/')
+        assert url.password == 'pass#word'
+        assert url.raw_password == 'pass%23word'
+
+    def test_percent_encoded_at_in_password(self):
+        """'%40' in password is decoded to '@'."""
+        url = _urlparse('amqps://user:pass%40word@broker.example.com/')
+        assert url.password == 'pass@word'
+        assert url.raw_password == 'pass%40word'
+
+    def test_percent_encoded_colon_in_password(self):
+        """'%3a' in password is decoded to ':'."""
+        url = _urlparse('amqps://user:pass%3aword@broker.example.com/')
+        assert url.password == 'pass:word'
+        assert url.raw_password == 'pass%3aword'
+
+    def test_none_password_stays_none(self):
+        """URL with no password returns None for both password and raw_password."""
+        url = _urlparse('amqps://broker.example.com/')
+        assert url.password is None
+        assert url.raw_password is None
+
+    def test_raw_password_used_for_key_stripping(self):
+        """raw_password returns the percent-encoded form for URL key reconstruction."""
+        url = _urlparse('amqps://user:pass%23word@broker.example.com/')
+        assert url.raw_password == 'pass%23word'
+        assert url.password == 'pass#word'
+
+
+class Test_HashDetection:
+    """Verify that unencoded '#' in a credential URL is detected and reported."""
+
+    def test_hash_in_password_detected(self, caplog):
+        """CredentialDB._parse() reports an error when '#' breaks the URL."""
+        import logging
+        db = CredentialDB()
+        with caplog.at_level(logging.ERROR, logger='sarracenia.config.credentials'):
+            db._parse('amqps://user:pass#word@broker.example.com/')
+        assert any('<secret>' in r.message for r in caplog.records), \
+            f"expected <secret> in error log, got: {[r.message for r in caplog.records]}"
+
+    def test_hash_detection_does_not_add_credential(self):
+        """Broken credential with '#' is not added to the DB."""
+        db = CredentialDB()
+        db._parse('amqps://user:pass#word@broker.example.com/')
+        assert len(db.credentials) == 0
+
+    def test_valid_credential_not_falsely_flagged(self, caplog):
+        """Valid credential with no '#' produces no fragment-detection error."""
+        import logging
+        db = CredentialDB()
+        with caplog.at_level(logging.ERROR, logger='sarracenia.config.credentials'):
+            db._parse('amqps://user:plainpass@broker.example.com/')
+        assert not any('password likely contains' in r.message for r in caplog.records)
+
+    def test_encoded_hash_not_flagged(self, caplog):
+        """Percent-encoded '#' (%23) is valid and must not trigger the detection."""
+        import logging
+        db = CredentialDB()
+        with caplog.at_level(logging.ERROR, logger='sarracenia.config.credentials'):
+            db._parse('amqps://user:pass%23word@broker.example.com/')
+        assert not any('password likely contains' in r.message for r in caplog.records)
+
+    def test_anonymous_url_not_flagged(self, caplog):
+        """Anonymous URL (no credentials) does not trigger fragment detection."""
+        import logging
+        db = CredentialDB()
+        with caplog.at_level(logging.ERROR, logger='sarracenia.config.credentials'):
+            db._parse('amqps://broker.example.com/')
+        assert not any('password likely contains' in r.message for r in caplog.records)
+
+
+class Test_CredentialDbAdd:
+
+    def test_add_encoded_password_key_strips_correctly(self):
+        """add() key must strip the encoded password so lookup by bare URL works."""
+        db = CredentialDB()
+        db.add('amqps://user:pass%23word@broker.example.com/')
+        # Lookup key is URL without password (encoded form stripped)
+        keys = list(db.credentials.keys())
+        assert any('pass%23word' not in k and 'broker.example.com' in k for k in keys), \
+            f"password not stripped from key, keys: {keys}"


### PR DESCRIPTION
### Description:
When `credentials.conf` contains a password with an unencoded `#`, `urlparse` treats it as a URL fragment delimiter. This results in a broken parse where the `@` (user/host separator) ends up in the fragment instead of the netloc, causing a silent "credential not found" error with no useful explanation.

I ran into this issue and wanted to hurt myself last week.

This PR adds:
1.  **Transparent Unquoting**: A `UrlParseResult` subclass that auto-unquotes `.username` and `.password`. This ensures that percent-encoded characters (like `%23` for `#`) are decoded before they are used by plugins or internal code.
2.  **Heuristic Detection**: Checks if `#` has broken the URL (by looking for `@` in the fragment) and logs a clear `logger.error` suggesting `%23` as the fix.
3.  **Redaction**: Adds a `_REDACT_RE` to ensure the password is shown as `<secret>` in error logs.
4.  **Key Stripping Fix**: Uses the raw (encoded) password when stripping credentials from the URL key in `add()`, ensuring lookups by bare URL continue to work correctly for complex passwords.

**Testing:**
- 12 new unit tests in `tests/sarracenia/credentials_test.py` covering encoding/decoding round-trips, false-positive safety, and key-stripping behavior.
- Verified all tests pass in the local WSL environment.