### PR TITLE
docs: add documentation for retryCountMax option

### DIFF
--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1899,6 +1899,24 @@ The AMQP protocol defines other queue options which are not exposed
 via sarracenia, because sarracenia itself picks appropriate values.
 
 
+retryCountMax <count> (default: 0)
+----------------------------------
+
+The **retryCountMax** option sets a limit on the number of times a message will be
+retried after a failure.  When a message fails to be transferred (in a subscriber)
+or published (in a post/sender), it is added to a retry queue. Each time it is
+retrieved from the queue for another attempt, its retry counter is incremented.
+
+If the number of attempts exceeds **retryCountMax**, the message is discarded
+and an ERROR is logged.
+
+The default value is 0, which means there is no limit on the number of retries
+(subject to **retry_ttl**).
+
+This option works alongside **retry_ttl**; the message will be discarded
+whichever limit is reached first.
+
+
 retryEmptyBeforeExit: <boolean> (default: False)
 ------------------------------------------------
 
@@ -1924,23 +1942,6 @@ retry_ttl <duration> (default: same as expire)
 The **retry_ttl** (retry time to live) option indicates how long to keep trying to send
 a file before it is aged out of a the queue.  Default is two days.  If a file has not
 been transferred after two days of attempts, it is discarded.
-
-retryCountMax <count> (default: 0)
-----------------------------------
-
-The **retryCountMax** option sets a limit on the number of times a message will be
-retried after a failure.  When a message fails to be transferred (in a subscriber)
-or published (in a post/sender), it is added to a retry queue. Each time it is
-retrieved from the queue for another attempt, its retry counter is incremented.
-
-If the number of attempts exceeds **retryCountMax**, the message is discarded
-and an ERROR is logged.
-
-The default value is 0, which means there is no limit on the number of retries
-(subject to **retry_ttl**).
-
-This option works alongside **retry_ttl**; the message will be discarded
-whichever limit is reached first.
 
 
 runStateThreshold_cpuSlow <count> (default: 0)

--- a/docs/source/Reference/sr3_options.7.rst
+++ b/docs/source/Reference/sr3_options.7.rst
@@ -1925,6 +1925,23 @@ The **retry_ttl** (retry time to live) option indicates how long to keep trying 
 a file before it is aged out of a the queue.  Default is two days.  If a file has not
 been transferred after two days of attempts, it is discarded.
 
+retryCountMax <count> (default: 0)
+----------------------------------
+
+The **retryCountMax** option sets a limit on the number of times a message will be
+retried after a failure.  When a message fails to be transferred (in a subscriber)
+or published (in a post/sender), it is added to a retry queue. Each time it is
+retrieved from the queue for another attempt, its retry counter is incremented.
+
+If the number of attempts exceeds **retryCountMax**, the message is discarded
+and an ERROR is logged.
+
+The default value is 0, which means there is no limit on the number of retries
+(subject to **retry_ttl**).
+
+This option works alongside **retry_ttl**; the message will be discarded
+whichever limit is reached first.
+
 
 runStateThreshold_cpuSlow <count> (default: 0)
 ----------------------------------------------

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1894,6 +1894,25 @@ L’option **retry_ttl** (nouvelle tentative de durée de vie) indique combien d
 un fichier avant qu’il ne soit  rejeté de la fil d’attente.  Le défaut est de deux jours.  Si un fichier n’a pas
 été transféré après deux jours de tentatives, il est jeté.
 
+retryCountMax <nombre> (défaut: 0)
+----------------------------------
+
+L’option **retryCountMax** définit une limite au nombre de fois qu’un message sera
+re-tenté après un échec. Lorsqu'un message ne parvient pas à être transféré (dans un abonné)
+ou publié (dans un post/expéditeur), il est ajouté à une file d'attente de re-tentative.
+Chaque fois qu'il est récupéré de la file d'attente pour une nouvelle tentative, son
+compteur de re-tentative est incrémenté.
+
+Si le nombre de tentatives dépasse **retryCountMax**, le message est rejeté
+et une ERREUR est enregistrée dans le journal.
+
+La valeur par défaut est 0, ce qui signifie qu'il n'y a pas de limite au nombre de re-tentatives
+(sous réserve de **retry_ttl**).
+
+Cette option fonctionne parallèlement à **retry_ttl**; le message sera rejeté
+selon la limite atteinte en premier.
+
+
 runStateThreshold_cpuSlow <count> (par défaut : 0)
 ---------------------------------------------------
 

--- a/docs/source/fr/Reference/sr3_options.7.rst
+++ b/docs/source/fr/Reference/sr3_options.7.rst
@@ -1862,6 +1862,25 @@ la cache de réception est également supprimé.
 Le protocole AMQP définit d’autres options de fil d’attente qui ne sont pas exposées
 via Sarracenia, parce que Sarracenia choisit soi-même des valeurs appropriées.
 
+retryCountMax <nombre> (défaut: 0)
+----------------------------------
+
+L'option **retryCountMax** définit une limite au nombre de fois qu'un message sera
+re-tenté après un échec. Lorsqu'un message ne parvient pas à être transféré (dans un abonné)
+ou publié (dans un post/expéditeur), il est ajouté à une file d'attente de re-tentative.
+Chaque fois qu'il est récupéré de la file d'attente pour une nouvelle tentative, son
+compteur de re-tentative est incrémenté.
+
+Si le nombre de tentatives dépasse **retryCountMax**, le message est rejeté
+et une ERREUR est enregistrée dans le journal.
+
+La valeur par défaut est 0, ce qui signifie qu'il n'y a pas de limite au nombre de re-tentatives
+(sous réserve de **retry_ttl**).
+
+Cette option fonctionne parallèlement à **retry_ttl**; le message sera rejeté
+selon la limite atteinte en premier.
+
+
 retryEmptyBeforeExit: <booléen> (défaut: False)
 -----------------------------------------------
 
@@ -1893,24 +1912,6 @@ retry_ttl <intervalle> (défaut: identique à expire)
 L’option **retry_ttl** (nouvelle tentative de durée de vie) indique combien de temps il faut continuer à essayer d’envoyer
 un fichier avant qu’il ne soit  rejeté de la fil d’attente.  Le défaut est de deux jours.  Si un fichier n’a pas
 été transféré après deux jours de tentatives, il est jeté.
-
-retryCountMax <nombre> (défaut: 0)
-----------------------------------
-
-L’option **retryCountMax** définit une limite au nombre de fois qu’un message sera
-re-tenté après un échec. Lorsqu'un message ne parvient pas à être transféré (dans un abonné)
-ou publié (dans un post/expéditeur), il est ajouté à une file d'attente de re-tentative.
-Chaque fois qu'il est récupéré de la file d'attente pour une nouvelle tentative, son
-compteur de re-tentative est incrémenté.
-
-Si le nombre de tentatives dépasse **retryCountMax**, le message est rejeté
-et une ERREUR est enregistrée dans le journal.
-
-La valeur par défaut est 0, ce qui signifie qu'il n'y a pas de limite au nombre de re-tentatives
-(sous réserve de **retry_ttl**).
-
-Cette option fonctionne parallèlement à **retry_ttl**; le message sera rejeté
-selon la limite atteinte en premier.
 
 
 runStateThreshold_cpuSlow <count> (par défaut : 0)


### PR DESCRIPTION
This PR adds documentation for the  retryCountMax  option in both English and French reference files, as requested by Peter Silva in PR #1597.

Includes:
- English:  docs/source/Reference/sr3_options.7.rst 
- French:  docs/source/fr/Reference/sr3_options.7.rst 