### PR TITLE
Fix SFTP ssh socket leak on failed connect

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -244,6 +244,12 @@ class Sftp(Transfer):
         except:
             logger.error( f"sr_sftp/connect: unable to connect to {self.host} (user:{self.user})" )
             logger.debug('Exception details: ', exc_info=True)
+            try:
+                if self.ssh is not None:
+                    self.ssh.close()
+                    self.ssh = None
+            except Exception:
+                pass
 
         finally:
             alarm_cancel()

--- a/tests/sarracenia/transfer/sftp_test.py
+++ b/tests/sarracenia/transfer/sftp_test.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+import logging
+
+import sarracenia
+import sarracenia.config
+from sarracenia.transfer.sftp import Sftp
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def sftp_options():
+    options = sarracenia.config.default_config()
+    options.sendTo = 'sftp://testuser@testhost/path'
+    options.timeout = 5
+    options.credentials = MagicMock()
+    url = MagicMock()
+    url.hostname = 'testhost'
+    url.port = 22
+    url.username = 'testuser'
+    url.password = 'testpass'
+    details = MagicMock()
+    details.url = url
+    details.ssh_keyfile = None
+    options.credentials.get.return_value = (True, details)
+    return options
+
+
+class Test_SftpConnectCleanup:
+    """Test that failed SFTP connections close sockets to prevent fd leaks."""
+
+    @patch('sarracenia.transfer.sftp.paramiko.SSHClient')
+    def test_connect_failure_closes_ssh(self, mock_ssh_class, sftp_options):
+        """When ssh.connect() raises, the SSHClient should be closed."""
+        mock_ssh = MagicMock()
+        mock_ssh.connect.side_effect = Exception("Connection refused")
+        mock_ssh_class.return_value = mock_ssh
+
+        sftp = Sftp('sftp', sftp_options)
+        result = sftp.connect()
+
+        assert result is False
+        mock_ssh.close.assert_called_once()
+        assert sftp.ssh is None
+
+    @patch('sarracenia.transfer.sftp.paramiko.SSHClient')
+    def test_connect_auth_failure_closes_ssh(self, mock_ssh_class, sftp_options):
+        """When ssh.connect() raises auth error, the SSHClient should be closed."""
+        mock_ssh = MagicMock()
+        mock_ssh.connect.side_effect = Exception("Authentication failed")
+        mock_ssh_class.return_value = mock_ssh
+
+        sftp = Sftp('sftp', sftp_options)
+        result = sftp.connect()
+
+        assert result is False
+        mock_ssh.close.assert_called_once()
+
+    @patch('sarracenia.transfer.sftp.paramiko.SSHClient')
+    def test_connect_success_does_not_close(self, mock_ssh_class, sftp_options):
+        """Successful connect should not close the connection."""
+        mock_ssh = MagicMock()
+        mock_sftp_channel = MagicMock()
+        mock_sftp_channel.getcwd.return_value = '/home/testuser'
+        mock_ssh.open_sftp.return_value = mock_sftp_channel
+        mock_ssh_class.return_value = mock_ssh
+
+        sftp = Sftp('sftp', sftp_options)
+        result = sftp.connect()
+
+        assert result is True
+        mock_ssh.close.assert_not_called()
+        assert sftp.connected is True
+
+    @patch('sarracenia.transfer.sftp.paramiko.SSHClient')
+    def test_repeated_connect_failures_no_fd_leak(self, mock_ssh_class, sftp_options):
+        """Multiple failed connect attempts should each close their ssh client."""
+        mock_ssh_instances = [MagicMock() for _ in range(5)]
+        for m in mock_ssh_instances:
+            m.connect.side_effect = Exception("Connection refused")
+
+        sftp = Sftp('sftp', sftp_options)
+
+        for i in range(5):
+            mock_ssh_class.side_effect = [mock_ssh_instances[i]]
+            result = sftp.connect()
+            assert result is False
+
+        for m in mock_ssh_instances:
+            m.close.assert_called_once()


### PR DESCRIPTION
##### what

When `ssh.connect()` or `open_sftp()` raises in `Sftp.connect()`, `self.ssh` was left open. On retry, each attempt leaked another `SSHClient` socket until hitting `ulimit` and crashing with `OSError: [Errno 24] Too many open files`.

##### fix

Close and null `self.ssh` in the except block so each failed attempt cleans up after itself. Pattern is consistent with how ftp.py handles the same case in #1620.

##### tests

4 new tests in `tests/sarracenia/transfer/sftp_test.py`:
- failed connect closes ssh
- auth failure closes ssh
- successful connect does not close
- repeated failures each close their own client (no accumulation)

##### notes

Extracted from #1581, which bundled this with ftp.py and flow/__init__.py changes for separate concerns. Closing #1581 in favour of this and #1620.