### PR TITLE
Fix shell injection and password corruption in exec_rabbitmqadmin

### DIFF
--- a/sarracenia/rabbitmq_admin.py
+++ b/sarracenia/rabbitmq_admin.py
@@ -3,6 +3,7 @@
    rabbitmq administration bindings, to allow sr to invoke broker management functions.
 
 """
+import shlex
 import sys
 import urllib, urllib.parse
 import base64
@@ -28,51 +29,34 @@ def exec_rabbitmqadmin(url, options, simulate=False):
     """
        invoke rabbitmqadmin using a sub-process, with the given options.
     """
+    cmdlst = [
+        rabbitmqadmin,
+        '--host', url.hostname,
+        '--user', url.username,
+        '-p', url.password,
+        '--format', 'raw_json',
+    ]
+    if url.scheme == 'amqps':
+        cmdlst += ['--ssl', '--port=15671']
+    cmdlst += shlex.split(options)
+
+    logger.debug('exec_rabbitmqadmin host=%s options=%s', url.hostname, options)
+
+    if simulate:
+        print(f"dry_run: {' '.join(shlex.quote(a) for a in cmdlst)}")
+        return 0, None
 
     try:
-        command = rabbitmqadmin
-        command += ' --host \'' + url.hostname
-        command += '\' --user \'' + url.username
-        command += '\' -p \'' + url.password
-        command += '\' --format raw_json '
-        if url.scheme == 'amqps':
-            command += ' --ssl --port=15671 '
-        command += ' ' + options
-
-        logger.debug('command = %s', command)
-        if sys.version_info.major < 3 or (sys.version_info.major == 3
-                                          and sys.version_info.minor < 5):
-            if logger: logger.debug("using subprocess.getstatusoutput")
-
-            if simulate:
-                print(f"dry_run: {' '.join(command)}")
-                return 0, None
-
-            return subprocess.getstatusoutput(command)
-        else:
-            cmdlin = command.replace("'", '')
-            cmdlst = cmdlin.split()
-            if logger:
-                logger.debug('using subprocess.run cmdlst=%s', ' '.join(cmdlst))
-
-            if simulate:
-                print(f"dry_run: {cmdlin}")
-                return 0, None
-
-            rclass = subprocess.run(cmdlst, stdout=subprocess.PIPE)
-            if rclass.returncode == 0:
-                output = rclass.stdout
-                if type(output) == bytes: output = output.decode("utf-8")
-                return rclass.returncode, output
-            return rclass.returncode, None
-    except:
-        if sys.version_info.major < 3 or (sys.version_info.major == 3
-                                          and sys.version_info.minor < 5):
-            if logger: logger.error( f"trying run command {command}" )
-        else:
-            if logger:
-                logger.error( f"trying run command {' '.join(cmdlst)}" )
-        if logger: logger.debug('Exception details:', exc_info=True)
+        rclass = subprocess.run(cmdlst, stdout=subprocess.PIPE)
+        if rclass.returncode == 0:
+            output = rclass.stdout
+            if isinstance(output, bytes):
+                output = output.decode("utf-8")
+            return rclass.returncode, output
+        return rclass.returncode, None
+    except Exception:
+        logger.error('exec_rabbitmqadmin failed for host=%s options=%s', url.hostname, options)
+        logger.debug('Exception details:', exc_info=True)
 
     return 0, None
 

--- a/sarracenia/rabbitmq_admin.py
+++ b/sarracenia/rabbitmq_admin.py
@@ -291,7 +291,8 @@ def user_access(url, user):
 
 
 if __name__ == "__main__":
-    url = urllib.parse.urlparse(sys.argv[1])
+    from sarracenia.config.credentials import _urlparse
+    url = _urlparse(sys.argv[1])
     print(exec_rabbitmqadmin(url, "list queue names")[1])
 
     import json

--- a/tests/sarracenia/rabbitmq_admin_test.py
+++ b/tests/sarracenia/rabbitmq_admin_test.py
@@ -11,32 +11,68 @@ from sarracenia.config.credentials import _urlparse
 class Test_ExecRabbitmqadmin:
     """Regression tests for PR #989 / #1677 credential handling in rabbitmq_admin."""
 
-    def test_plain_password_reaches_command(self):
-        """Plain password is passed to exec_rabbitmqadmin without modification."""
-        url = _urlparse('amqp://admin:secret@localhost/')
+    def _run_and_get_cmdlst(self, url, options='list exchanges name'):
         with patch('sarracenia.rabbitmq_admin.subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout=b'[]')
-            exec_rabbitmqadmin(url, 'list exchanges name')
-        call_args = mock_run.call_args[0][0]
-        assert 'secret' in call_args
+            exec_rabbitmqadmin(url, options)
+        return mock_run.call_args[0][0]
+
+    def test_password_passed_as_separate_argument(self):
+        """Password must be a standalone element in the argument list, not shell-interpolated.
+
+        The old implementation built a shell command string and used getstatusoutput
+        (shell=True) or replace()+split(), both of which allowed injection or corruption.
+        The fix uses subprocess.run with a list — password is never shell-parsed.
+        """
+        url = _urlparse('amqp://admin:secret@localhost/')
+        cmdlst = self._run_and_get_cmdlst(url)
+        assert isinstance(cmdlst, list), "subprocess.run must receive a list, not a string"
+        # '-p' followed immediately by the password as its own element
+        assert '-p' in cmdlst
+        password_index = cmdlst.index('-p') + 1
+        assert cmdlst[password_index] == 'secret'
 
     def test_encoded_hash_password_decoded_for_command(self):
-        """Password with '%23' must be decoded to '#' before being passed to rabbitmqadmin.
-
-        Regression: exec_rabbitmqadmin used urllib.parse.urlparse() in __main__
-        (plain ParseResult) and then dropped the unquote() call, so percent-encoded
-        passwords were passed verbatim ('pass%23word') instead of decoded ('pass#word').
-        """
+        """Password '%23' must be decoded to '#' as a separate argument."""
         url = _urlparse('amqp://admin:pass%23word@localhost/')
-        assert url.password == 'pass#word', "UrlParseResult must decode %23 to #"
+        cmdlst = self._run_and_get_cmdlst(url)
+        password_index = cmdlst.index('-p') + 1
+        assert cmdlst[password_index] == 'pass#word'
+        assert 'pass%23word' not in cmdlst
 
-        with patch('sarracenia.rabbitmq_admin.subprocess.run') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout=b'[]')
-            exec_rabbitmqadmin(url, 'list exchanges name')
-        call_args = mock_run.call_args[0][0]
-        # Decoded password must appear; encoded form must not
-        assert 'pass#word' in ' '.join(call_args) or 'pass#word' in call_args
-        assert 'pass%23word' not in ' '.join(call_args)
+    def test_password_with_single_quote_not_corrupted(self):
+        """Password containing a single quote must not be stripped or split.
+
+        The old replace("'","").split() approach silently dropped the quote,
+        causing authentication to fail for any password containing "'".
+        """
+        url = _urlparse("amqp://admin:it's@localhost/")
+        cmdlst = self._run_and_get_cmdlst(url)
+        password_index = cmdlst.index('-p') + 1
+        assert cmdlst[password_index] == "it's"
+
+    def test_no_shell_injection_via_password(self):
+        """A password containing shell metacharacters is passed as a single safe argument."""
+        url = _urlparse('amqp://admin:secret;id@localhost/')
+        cmdlst = self._run_and_get_cmdlst(url)
+        assert isinstance(cmdlst, list)
+        password_index = cmdlst.index('-p') + 1
+        assert cmdlst[password_index] == 'secret;id'
+
+    def test_options_tokenised_correctly(self):
+        """Options string is split into tokens, not concatenated into a shell string."""
+        url = _urlparse('amqp://admin:secret@localhost/')
+        cmdlst = self._run_and_get_cmdlst(url, 'list exchanges name')
+        assert 'list' in cmdlst
+        assert 'exchanges' in cmdlst
+        assert 'name' in cmdlst
+
+    def test_amqps_adds_ssl_flag(self):
+        """AMQPS scheme adds --ssl and --port=15671 to the argument list."""
+        url = _urlparse('amqps://admin:secret@broker.example.com/')
+        cmdlst = self._run_and_get_cmdlst(url)
+        assert '--ssl' in cmdlst
+        assert '--port=15671' in cmdlst
 
     def test_plain_urlparse_would_pass_encoded_password(self):
         """Demonstrates the bug: stdlib urlparse returns encoded password from url.password.
@@ -47,4 +83,4 @@ class Test_ExecRabbitmqadmin:
         import urllib.parse
         url_broken = urllib.parse.urlparse('amqp://admin:pass%23word@localhost/')
         assert url_broken.password == 'pass%23word', \
-            "stdlib urlparse must NOT decode — confirms why _urlparse is needed in __main__"
+            "stdlib urlparse must NOT decode -- confirms why _urlparse is needed in __main__"

--- a/tests/sarracenia/rabbitmq_admin_test.py
+++ b/tests/sarracenia/rabbitmq_admin_test.py
@@ -1,6 +1,50 @@
 import pytest
 from tests.conftest import *
-#from unittest.mock import Mock
+from unittest.mock import patch, MagicMock
 
 import sarracenia.config
 import sarracenia.rabbitmq_admin
+from sarracenia.rabbitmq_admin import exec_rabbitmqadmin
+from sarracenia.config.credentials import _urlparse
+
+
+class Test_ExecRabbitmqadmin:
+    """Regression tests for PR #989 / #1677 credential handling in rabbitmq_admin."""
+
+    def test_plain_password_reaches_command(self):
+        """Plain password is passed to exec_rabbitmqadmin without modification."""
+        url = _urlparse('amqp://admin:secret@localhost/')
+        with patch('sarracenia.rabbitmq_admin.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=b'[]')
+            exec_rabbitmqadmin(url, 'list exchanges name')
+        call_args = mock_run.call_args[0][0]
+        assert 'secret' in call_args
+
+    def test_encoded_hash_password_decoded_for_command(self):
+        """Password with '%23' must be decoded to '#' before being passed to rabbitmqadmin.
+
+        Regression: exec_rabbitmqadmin used urllib.parse.urlparse() in __main__
+        (plain ParseResult) and then dropped the unquote() call, so percent-encoded
+        passwords were passed verbatim ('pass%23word') instead of decoded ('pass#word').
+        """
+        url = _urlparse('amqp://admin:pass%23word@localhost/')
+        assert url.password == 'pass#word', "UrlParseResult must decode %23 to #"
+
+        with patch('sarracenia.rabbitmq_admin.subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=b'[]')
+            exec_rabbitmqadmin(url, 'list exchanges name')
+        call_args = mock_run.call_args[0][0]
+        # Decoded password must appear; encoded form must not
+        assert 'pass#word' in ' '.join(call_args) or 'pass#word' in call_args
+        assert 'pass%23word' not in ' '.join(call_args)
+
+    def test_plain_urlparse_would_pass_encoded_password(self):
+        """Demonstrates the bug: stdlib urlparse returns encoded password from url.password.
+
+        This test documents why the __main__ block must use _urlparse, not urlparse.
+        Plain ParseResult.password does NOT decode percent-encoding.
+        """
+        import urllib.parse
+        url_broken = urllib.parse.urlparse('amqp://admin:pass%23word@localhost/')
+        assert url_broken.password == 'pass%23word', \
+            "stdlib urlparse must NOT decode — confirms why _urlparse is needed in __main__"


### PR DESCRIPTION
Two bugs in `exec_rabbitmqadmin`:

1. The legacy path used `subprocess.getstatusoutput()` with `shell=True`, with `url.hostname`, `url.username`, `url.password`, and `options` all string-concatenated into the command. A password containing `;`, `$(`, or backticks could execute arbitrary commands.

2. The modern path did `command.replace("'", "").split()` — this stripped every single quote from the entire command string and then split on whitespace. A password with a single quote was silently corrupted; a value containing a space was split into multiple arguments.

##### What changed

Build a list from the start and pass it directly to `subprocess.run()`. The password is always a standalone list element, never touched by the shell. `shlex.split()` is used only for the `options` string, which is operator-controlled input like `"list exchanges name"`.

Also drops the Python < 3.5 code path — Sarracenia requires Python 3.6+.

##### Tests

Added in `tests/sarracenia/rabbitmq_admin_test.py`:

- `test_password_passed_as_separate_argument` — subprocess receives a list, password is its own element
- `test_password_with_single_quote_not_corrupted` — single quote in password survives intact
- `test_no_shell_injection_via_password` — shell metacharacters in password are inert
- `test_options_tokenised_correctly` — options string is split into tokens correctly
- `test_amqps_adds_ssl_flag` — `--ssl` and `--port=15671` added for amqps scheme

All pass. Full credential suite (31 tests): 31 passed, 0 failed.

Fork CI unit tests: passing — https://github.com/robjarawan/sarracenia/actions/runs/24844944675

(edited main comment to trigger full re-run of actions jobs)