### PR TITLE
Change destfn_script into a set so duplicate entries dont get propogated

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -897,7 +897,7 @@ class Config:
         self.v2plugin_options = []
         self.imports = []
         self.logEvents = set(['after_accept', 'after_post', 'after_work', 'on_housekeeping' ])
-        self.destfn_scripts = []
+        self.destfn_scripts = set() # Define a set to avoid duplicate entries
         self.plugins_late = []
         self.plugins_early = []
         self.exchange = None
@@ -1107,7 +1107,7 @@ class Config:
             args = []
         if fn and re.compile('DESTFNSCRIPT=.*').match(fn):
             script=fn[13:]
-            self.destfn_scripts.append(script)
+            self.destfn_scripts.add(script)
 
         if self.directory:
            d = os.path.expanduser(self.directory)


### PR DESCRIPTION
Change `destfn_scripts` from a list to a set. This prevents duplicate entries from reaching the callback list of plugins.

I retested the same config as the one in #1690 with the patch applied and the callback only gets loaded once from the list.

```
2026-05-15 15:51:14,262 [DEBUG] sarracenia.flow loadCallbacks flowCallback plugins to load: ['sarracenia.flowcb.gather.message.Message', 'sarracenia.flowcb.retry.Retry', 'sarracenia.flowcb.housekeeping.resource
s.Resources', 'log', 'destfn.colour_image']
...
 'destfn_scripts': {'destfn.colour_image'},

 'accept '
           '.*something1.* '
           'into /net/local/home/leblanca/test/ with mirror:False '
           'filename:DESTFNSCRIPT=destfn.colour_image',
           'accept '
           '.*something2.* '
           'into /net/local/home/leblanca/test/ with mirror:False '
           'filename:DESTFNSCRIPT=destfn.colour_image',
           'accept '
           '.*something3.* '
           'into /net/local/home/leblanca/test/ with mirror:False '
           'filename:DESTFNSCRIPT=destfn.colour_image'],
```