### PR TITLE
Octal number tweaks

### DIFF
--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -66,6 +66,7 @@ class octal_number(int):
 
     def __new__(cls, value):
         if type(value) is str:
+            value = value[2:] if value.startswith("0o") else value
             return super().__new__(cls, int(value, base=8))
         elif type(value) is int:
             return super().__new__(cls, value)

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -66,16 +66,15 @@ class octal_number(int):
 
     def __new__(cls, value):
         if type(value) is str:
-            self = int(value,base=8)
+            return super().__new__(cls, int(value, base=8))
         elif type(value) is int:
-            self = value
-        return self
+            return super().__new__(cls, value)
 
     def __str__(self) -> str:
-        return f"0o{self:o}"
+        return f"0o{self:03o}"
 
     def __repr__(self) -> str:
-        return f"0o{self:o}"
+        return f"0o{self:03o}"
 
 
 default_options = {

--- a/tests/sarracenia/config_octal_number_test.py
+++ b/tests/sarracenia/config_octal_number_test.py
@@ -1,6 +1,8 @@
 import pytest
+import unittest
 
-import logging, copy
+import logging
+import copy
 
 import sarracenia
 import sarracenia.config
@@ -15,128 +17,138 @@ logger.setLevel('DEBUG')
 
  
 
-# --- construction from int ---
+class TestOctalNumberType(unittest.TestCase):
+    """Tests that octal_number instances are genuine subclass instances with
+    correct string representations — covering the __new__ bug where a plain
+    int was returned instead of an octal_number instance."""
 
-def test_from_int_returns_octal_number_instance():
-    v = octal_number(0o755)
-    assert isinstance(v, octal_number), (
-        "octal_number(int) must return an octal_number instance, not a plain int"
-    )
+    # --- construction from int ---
 
-def test_from_int_preserves_value():
-    assert octal_number(0o644) == 0o644
-    assert octal_number(0o644) == 420
+    def test_from_int_returns_octal_number_instance(self):
+        v = octal_number(0o755)
+        assert isinstance(v, octal_number), (
+            "octal_number(int) must return an octal_number instance, not a plain int"
+        )
 
-def test_from_int_zero():
-    v = octal_number(0)
-    assert isinstance(v, octal_number)
-    assert v == 0
+    def test_from_int_preserves_value(self):
+        assert octal_number(0o644) == 0o644
+        assert octal_number(0o644) == 420
 
-def test_from_base10_int():
-    v = octal_number(123)
-    assert isinstance(v, octal_number)
-    assert v == 123
+    def test_from_int_zero(self):
+        v = octal_number(0)
+        assert isinstance(v, octal_number)
+        assert v == 0
 
-# --- construction from octal string ---
+    def test_from_base10_int(self):
+        v = octal_number(123)
+        assert isinstance(v, octal_number)
+        assert v == 123
 
-def test_from_str_returns_octal_number_instance():
-    v = octal_number("755")
-    assert isinstance(v, octal_number), (
-        "octal_number(str) must return an octal_number instance, not a plain int"
-    )
+    # --- construction from octal string ---
 
-def test_from_str_parses_as_octal():
-    # "644" in octal == 420 in decimal
-    assert octal_number("644") == 0o644
+    def test_from_str_returns_octal_number_instance(self):
+        v = octal_number("755")
+        assert isinstance(v, octal_number), (
+            "octal_number(str) must return an octal_number instance, not a plain int"
+        )
 
-def test_from_str_755():
-    assert octal_number("755") == 0o755
+    def test_from_str_parses_as_octal(self):
+        # "644" in octal == 420 in decimal
+        assert octal_number("644") == 0o644
 
-def test_from_str_with_0o_prefix():
-    # '0o' prefix is stripped before parsing, so this should work
-    v = octal_number("0o755")
-    assert isinstance(v, octal_number)
-    assert v == 0o755
-    assert str(v) == "0o755"
+    def test_from_str_755(self):
+        assert octal_number("755") == 0o755
 
-# --- __str__ and __repr__ ---
+    def test_from_str_with_0o_prefix(self):
+        # '0o' prefix is stripped before parsing, so this should work
+        v = octal_number("0o755")
+        assert isinstance(v, octal_number)
+        assert v == 0o755
+        assert str(v) == "0o755"
 
-def test_str_shows_octal_prefix():
-    v = octal_number(0o755)
-    assert str(v) == "0o755", (
-        "__str__ must return '0o<octal>' — failed because __new__ returned a plain int"
-    )
+    # --- __str__ and __repr__ ---
 
-def test_repr_shows_octal_prefix():
-    v = octal_number(0o755)
-    assert repr(v) == "0o755"
+    def test_str_shows_octal_prefix(self):
+        v = octal_number(0o755)
+        assert str(v) == "0o755", (
+            "__str__ must return '0o<octal>' — failed because __new__ returned a plain int"
+        )
 
-def test_str_from_int_input():
-    assert str(octal_number(0o644)) == "0o644"
+    def test_repr_shows_octal_prefix(self):
+        v = octal_number(0o755)
+        assert repr(v) == "0o755"
 
-def test_str_from_str_input():
-    assert str(octal_number("644")) == "0o644"
+    def test_str_from_int_input(self):
+        assert str(octal_number(0o644)) == "0o644"
 
-def test_str_zero():
-    assert str(octal_number(0)) == "0o000"
+    def test_str_from_str_input(self):
+        assert str(octal_number("644")) == "0o644"
 
-def test_repr_zero():
-    assert repr(octal_number(0)) == "0o000"
+    def test_str_zero(self):
+        assert str(octal_number(0)) == "0o000"
 
-# --- arithmetic preserves int semantics ---
+    def test_repr_zero(self):
+        assert repr(octal_number(0)) == "0o000"
 
-def test_arithmetic_value_correct():
-    # 0o755 == 493 decimal
-    assert int(octal_number("755")) == 493
+    # --- arithmetic preserves int semantics ---
 
-def test_octal_number_is_int_subclass():
-    assert issubclass(octal_number, int)
+    def test_arithmetic_value_correct(self):
+        # 0o755 == 493 decimal
+        assert int(octal_number("755")) == 493
 
-def test_usable_as_int_in_comparisons():
-    v = octal_number("644")
-    assert v == 0o644
-    assert v != 0o755
-    assert v < 0o755
-    assert v > 0o400
+    def test_octal_number_is_int_subclass(self):
+        assert issubclass(octal_number, int)
 
-def test_permDefault_is_octal_number_instance():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
-    assert isinstance(options.permDefault, octal_number), (
-        "permDefault must be stored as an octal_number, not a plain int"
-    )
+    def test_usable_as_int_in_comparisons(self):
+        v = octal_number("644")
+        assert v == 0o644
+        assert v != 0o755
+        assert v < 0o755
+        assert v > 0o400
 
-def test_permDefault_str_representation():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
-    assert str(options.permDefault) == "0o755"
+ 
+class TestOctalNumberInConfig(unittest.TestCase):
+    """Integration tests: octal values parsed through the config layer must
+    come back as octal_number instances with correct repr."""
 
-def test_permDefault_value_755():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
-    assert options.permDefault == 0o755
+    def test_permDefault_is_octal_number_instance(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+        assert isinstance(options.permDefault, octal_number), (
+            "permDefault must be stored as an octal_number, not a plain int"
+        )
 
-def test_permDefault_value_644():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 644")
-    assert options.permDefault == 0o644
+    def test_permDefault_str_representation(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+        assert str(options.permDefault) == "0o755"
 
-def test_add_option_octal_is_octal_number_instance():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.add_option('myPerm', kind='octal', default_value='644')
-    assert isinstance(options.myPerm, octal_number), (
-        "add_option with kind='octal' must store an octal_number instance"
-    )
+    def test_permDefault_value_755(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+        assert options.permDefault == 0o755
 
-def test_add_option_octal_str_representation():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.add_option('myPerm', kind='octal', default_value='644')
-    assert str(options.myPerm) == "0o644"
+    def test_permDefault_value_644(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 644")
+        assert options.permDefault == 0o644
 
-def test_add_option_octal_parse_line():
-    options = copy.deepcopy(sarracenia.config.default_config())
-    options.add_option('myPerm', kind='octal', default_value='644')
-    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "myPerm 755")
-    assert isinstance(options.myPerm, octal_number)
-    assert options.myPerm == 0o755
-    assert str(options.myPerm) == "0o755"
+    def test_add_option_octal_is_octal_number_instance(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.add_option('myPerm', kind='octal', default_value='644')
+        assert isinstance(options.myPerm, octal_number), (
+            "add_option with kind='octal' must store an octal_number instance"
+        )
+
+    def test_add_option_octal_str_representation(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.add_option('myPerm', kind='octal', default_value='644')
+        assert str(options.myPerm) == "0o644"
+
+    def test_add_option_octal_parse_line(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.add_option('myPerm', kind='octal', default_value='644')
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "myPerm 755")
+        assert isinstance(options.myPerm, octal_number)
+        assert options.myPerm == 0o755
+        assert str(options.myPerm) == "0o755"

--- a/tests/sarracenia/config_octal_number_test.py
+++ b/tests/sarracenia/config_octal_number_test.py
@@ -1,0 +1,152 @@
+import pytest
+
+import logging
+
+import sarracenia
+import sarracenia.config
+from sarracenia.config import octal_number
+
+logger = logging.getLogger('sarracenia.config')
+logger.setLevel('DEBUG')
+
+# ---------------------------------------------------------------------------
+# Tests for the octal_number type used by 'octal' config options
+# ---------------------------------------------------------------------------
+
+ 
+
+class TestOctalNumberType:
+    """Tests that octal_number instances are genuine subclass instances with
+    correct string representations — covering the __new__ bug where a plain
+    int was returned instead of an octal_number instance."""
+
+    # --- construction from int ---
+
+    def test_from_int_returns_octal_number_instance(self):
+        v = octal_number(0o755)
+        assert isinstance(v, octal_number), (
+            "octal_number(int) must return an octal_number instance, not a plain int"
+        )
+
+    def test_from_int_preserves_value(self):
+        assert octal_number(0o644) == 0o644
+        assert octal_number(0o644) == 420
+
+    def test_from_int_zero(self):
+        v = octal_number(0)
+        assert isinstance(v, octal_number)
+        assert v == 0
+
+    def test_from_base10_int(self):
+        v = octal_number(123)
+        assert isinstance(v, octal_number)
+        assert v == 123
+
+    # --- construction from octal string ---
+
+    def test_from_str_returns_octal_number_instance(self):
+        v = octal_number("755")
+        assert isinstance(v, octal_number), (
+            "octal_number(str) must return an octal_number instance, not a plain int"
+        )
+
+    def test_from_str_parses_as_octal(self):
+        # "644" in octal == 420 in decimal
+        assert octal_number("644") == 0o644
+
+    def test_from_str_755(self):
+        assert octal_number("755") == 0o755
+
+    def test_from_str_with_0o_prefix(self):
+        # '0o' prefix is stripped before parsing, so this should work
+        v = octal_number("0o755")
+        assert isinstance(v, octal_number)
+        assert v == 0o755
+        assert str(v) == "0o755"
+
+    # --- __str__ and __repr__ ---
+
+    def test_str_shows_octal_prefix(self):
+        v = octal_number(0o755)
+        assert str(v) == "0o755", (
+            "__str__ must return '0o<octal>' — failed because __new__ returned a plain int"
+        )
+
+    def test_repr_shows_octal_prefix(self):
+        v = octal_number(0o755)
+        assert repr(v) == "0o755"
+
+    def test_str_from_int_input(self):
+        assert str(octal_number(0o644)) == "0o644"
+
+    def test_str_from_str_input(self):
+        assert str(octal_number("644")) == "0o644"
+
+    def test_str_zero(self):
+        assert str(octal_number(0)) == "0o0"
+
+    def test_repr_zero(self):
+        assert repr(octal_number(0)) == "0o0"
+
+    # --- arithmetic preserves int semantics ---
+
+    def test_arithmetic_value_correct(self):
+        # 0o755 == 493 decimal
+        assert int(octal_number("755")) == 493
+
+    def test_octal_number_is_int_subclass(self):
+        assert issubclass(octal_number, int)
+
+    def test_usable_as_int_in_comparisons(self):
+        v = octal_number("644")
+        assert v == 0o644
+        assert v != 0o755
+        assert v < 0o755
+        assert v > 0o400
+
+ 
+class TestOctalNumberInConfig:
+    """Integration tests: octal values parsed through the config layer must
+    come back as octal_number instances with correct repr."""
+
+    def test_permDefault_is_octal_number_instance(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+        assert isinstance(options.permDefault, octal_number), (
+            "permDefault must be stored as an octal_number, not a plain int"
+        )
+
+    def test_permDefault_str_representation(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+        assert str(options.permDefault) == "0o755"
+
+    def test_permDefault_value_755(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+        assert options.permDefault == 0o755
+
+    def test_permDefault_value_644(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 644")
+        assert options.permDefault == 0o644
+
+    def test_add_option_octal_is_octal_number_instance(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.add_option('myPerm', kind='octal', default_value='644')
+        assert isinstance(options.myPerm, octal_number), (
+            "add_option with kind='octal' must store an octal_number instance"
+        )
+
+    def test_add_option_octal_str_representation(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.add_option('myPerm', kind='octal', default_value='644')
+        assert str(options.myPerm) == "0o644"
+
+    def test_add_option_octal_parse_line(self):
+        options = copy.deepcopy(sarracenia.config.default_config())
+        options.add_option('myPerm', kind='octal', default_value='644')
+        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "myPerm 755")
+        assert isinstance(options.myPerm, octal_number)
+        assert options.myPerm == 0o755
+        assert str(options.myPerm) == "0o755"

--- a/tests/sarracenia/config_octal_number_test.py
+++ b/tests/sarracenia/config_octal_number_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-import logging
+import logging, copy
 
 import sarracenia
 import sarracenia.config
@@ -15,138 +15,128 @@ logger.setLevel('DEBUG')
 
  
 
-class TestOctalNumberType:
-    """Tests that octal_number instances are genuine subclass instances with
-    correct string representations — covering the __new__ bug where a plain
-    int was returned instead of an octal_number instance."""
+# --- construction from int ---
 
-    # --- construction from int ---
+def test_from_int_returns_octal_number_instance():
+    v = octal_number(0o755)
+    assert isinstance(v, octal_number), (
+        "octal_number(int) must return an octal_number instance, not a plain int"
+    )
 
-    def test_from_int_returns_octal_number_instance(self):
-        v = octal_number(0o755)
-        assert isinstance(v, octal_number), (
-            "octal_number(int) must return an octal_number instance, not a plain int"
-        )
+def test_from_int_preserves_value():
+    assert octal_number(0o644) == 0o644
+    assert octal_number(0o644) == 420
 
-    def test_from_int_preserves_value(self):
-        assert octal_number(0o644) == 0o644
-        assert octal_number(0o644) == 420
+def test_from_int_zero():
+    v = octal_number(0)
+    assert isinstance(v, octal_number)
+    assert v == 0
 
-    def test_from_int_zero(self):
-        v = octal_number(0)
-        assert isinstance(v, octal_number)
-        assert v == 0
+def test_from_base10_int():
+    v = octal_number(123)
+    assert isinstance(v, octal_number)
+    assert v == 123
 
-    def test_from_base10_int(self):
-        v = octal_number(123)
-        assert isinstance(v, octal_number)
-        assert v == 123
+# --- construction from octal string ---
 
-    # --- construction from octal string ---
+def test_from_str_returns_octal_number_instance():
+    v = octal_number("755")
+    assert isinstance(v, octal_number), (
+        "octal_number(str) must return an octal_number instance, not a plain int"
+    )
 
-    def test_from_str_returns_octal_number_instance(self):
-        v = octal_number("755")
-        assert isinstance(v, octal_number), (
-            "octal_number(str) must return an octal_number instance, not a plain int"
-        )
+def test_from_str_parses_as_octal():
+    # "644" in octal == 420 in decimal
+    assert octal_number("644") == 0o644
 
-    def test_from_str_parses_as_octal(self):
-        # "644" in octal == 420 in decimal
-        assert octal_number("644") == 0o644
+def test_from_str_755():
+    assert octal_number("755") == 0o755
 
-    def test_from_str_755(self):
-        assert octal_number("755") == 0o755
+def test_from_str_with_0o_prefix():
+    # '0o' prefix is stripped before parsing, so this should work
+    v = octal_number("0o755")
+    assert isinstance(v, octal_number)
+    assert v == 0o755
+    assert str(v) == "0o755"
 
-    def test_from_str_with_0o_prefix(self):
-        # '0o' prefix is stripped before parsing, so this should work
-        v = octal_number("0o755")
-        assert isinstance(v, octal_number)
-        assert v == 0o755
-        assert str(v) == "0o755"
+# --- __str__ and __repr__ ---
 
-    # --- __str__ and __repr__ ---
+def test_str_shows_octal_prefix():
+    v = octal_number(0o755)
+    assert str(v) == "0o755", (
+        "__str__ must return '0o<octal>' — failed because __new__ returned a plain int"
+    )
 
-    def test_str_shows_octal_prefix(self):
-        v = octal_number(0o755)
-        assert str(v) == "0o755", (
-            "__str__ must return '0o<octal>' — failed because __new__ returned a plain int"
-        )
+def test_repr_shows_octal_prefix():
+    v = octal_number(0o755)
+    assert repr(v) == "0o755"
 
-    def test_repr_shows_octal_prefix(self):
-        v = octal_number(0o755)
-        assert repr(v) == "0o755"
+def test_str_from_int_input():
+    assert str(octal_number(0o644)) == "0o644"
 
-    def test_str_from_int_input(self):
-        assert str(octal_number(0o644)) == "0o644"
+def test_str_from_str_input():
+    assert str(octal_number("644")) == "0o644"
 
-    def test_str_from_str_input(self):
-        assert str(octal_number("644")) == "0o644"
+def test_str_zero():
+    assert str(octal_number(0)) == "0o000"
 
-    def test_str_zero(self):
-        assert str(octal_number(0)) == "0o0"
+def test_repr_zero():
+    assert repr(octal_number(0)) == "0o000"
 
-    def test_repr_zero(self):
-        assert repr(octal_number(0)) == "0o0"
+# --- arithmetic preserves int semantics ---
 
-    # --- arithmetic preserves int semantics ---
+def test_arithmetic_value_correct():
+    # 0o755 == 493 decimal
+    assert int(octal_number("755")) == 493
 
-    def test_arithmetic_value_correct(self):
-        # 0o755 == 493 decimal
-        assert int(octal_number("755")) == 493
+def test_octal_number_is_int_subclass():
+    assert issubclass(octal_number, int)
 
-    def test_octal_number_is_int_subclass(self):
-        assert issubclass(octal_number, int)
+def test_usable_as_int_in_comparisons():
+    v = octal_number("644")
+    assert v == 0o644
+    assert v != 0o755
+    assert v < 0o755
+    assert v > 0o400
 
-    def test_usable_as_int_in_comparisons(self):
-        v = octal_number("644")
-        assert v == 0o644
-        assert v != 0o755
-        assert v < 0o755
-        assert v > 0o400
+def test_permDefault_is_octal_number_instance():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+    assert isinstance(options.permDefault, octal_number), (
+        "permDefault must be stored as an octal_number, not a plain int"
+    )
 
- 
-class TestOctalNumberInConfig:
-    """Integration tests: octal values parsed through the config layer must
-    come back as octal_number instances with correct repr."""
+def test_permDefault_str_representation():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+    assert str(options.permDefault) == "0o755"
 
-    def test_permDefault_is_octal_number_instance(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
-        assert isinstance(options.permDefault, octal_number), (
-            "permDefault must be stored as an octal_number, not a plain int"
-        )
+def test_permDefault_value_755():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
+    assert options.permDefault == 0o755
 
-    def test_permDefault_str_representation(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
-        assert str(options.permDefault) == "0o755"
+def test_permDefault_value_644():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 644")
+    assert options.permDefault == 0o644
 
-    def test_permDefault_value_755(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 755")
-        assert options.permDefault == 0o755
+def test_add_option_octal_is_octal_number_instance():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.add_option('myPerm', kind='octal', default_value='644')
+    assert isinstance(options.myPerm, octal_number), (
+        "add_option with kind='octal' must store an octal_number instance"
+    )
 
-    def test_permDefault_value_644(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "permDefault 644")
-        assert options.permDefault == 0o644
+def test_add_option_octal_str_representation():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.add_option('myPerm', kind='octal', default_value='644')
+    assert str(options.myPerm) == "0o644"
 
-    def test_add_option_octal_is_octal_number_instance(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.add_option('myPerm', kind='octal', default_value='644')
-        assert isinstance(options.myPerm, octal_number), (
-            "add_option with kind='octal' must store an octal_number instance"
-        )
-
-    def test_add_option_octal_str_representation(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.add_option('myPerm', kind='octal', default_value='644')
-        assert str(options.myPerm) == "0o644"
-
-    def test_add_option_octal_parse_line(self):
-        options = copy.deepcopy(sarracenia.config.default_config())
-        options.add_option('myPerm', kind='octal', default_value='644')
-        options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "myPerm 755")
-        assert isinstance(options.myPerm, octal_number)
-        assert options.myPerm == 0o755
-        assert str(options.myPerm) == "0o755"
+def test_add_option_octal_parse_line():
+    options = copy.deepcopy(sarracenia.config.default_config())
+    options.add_option('myPerm', kind='octal', default_value='644')
+    options.parse_line("subscribe", "ex1", "subscribe/ex1", 1, "myPerm 755")
+    assert isinstance(options.myPerm, octal_number)
+    assert options.myPerm == 0o755
+    assert str(options.myPerm) == "0o755"


### PR DESCRIPTION
The octal_number class wasn't quite working right, the `__str__` and `__repr__` methods were never actually being used because `self = value` was just changing self to be an actual real `int`, not an instance of `octal_number`.

This fixes that, so octal numbers are actually stored as instances of the `octal_number` class, which means the `__str__` and `__repr__` methods will work as expected.

I also made a few improvements:
- added 0 padding to the string output
- made it work when given a string like `"0o644"` (before it would only work with `"644"`, now both work).
- added a unit test (generated by claude)

Now when octal numbers are printed, they are actually octal:

```
# from sr3 show
 'permDefault': 0o000,
 'permDirDefault': 0o775,
 'permLog': 0o600,
 'permDefault': 0o000,
 'permDirDefault': 0o775,
 'permLog': 0o600,
 'permDefault': 0o000,
 'permDirDefault': 0o775,
 'permLog': 0o600,
```

The numbers still behave as if they were regular integers, e.g. `octal_number("644") == 420`