### PR TITLE
change `chmod` to `permDefault` in poll default options to prevent posting files that user can't read

### DIFF
--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -49,8 +49,8 @@ verify that this will not cause any unexpected changes.
 
 *CHANGE*: polls are supposed to filter out files that are not readable by the user that is polling, using the
 ``permDefault`` option as a mask. This was not working correctly and has been fixed, but may cause polls to miss
-files that were previously being posted. If any poll configs depend on this broken behaviour, the ``permDefault``
-option may need to be adjusted.
+files that were previously being posted. If any poll configs depend on the old, broken behaviour, the ``permDefault``
+can be set to ``000`` to allow un-readable files to be posted.
 
 3.02.00
 -------

--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -47,6 +47,11 @@ in sr3. This version fixes the bug, but may cause existing ``accept`` or ``rejec
 differently (if received messages contain ``sundew_extension``). Existing configurations should be audited to
 verify that this will not cause any unexpected changes.
 
+*CHANGE*: polls are supposed to filter out files that are not readable by the user that is polling, using the
+``permDefault`` option as a mask. This was not working correctly and has been fixed, but may cause polls to miss
+files that were previously being posted. If any poll configs depend on this broken behaviour, the ``permDefault``
+option may need to be adjusted.
+
 3.02.00
 -------
 

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -50,7 +50,8 @@ aucun changement inattendu.
 *CHANGEMENT* : Les polls sont censés filtrer les fichiers qui ne sont pas lisibles par l’utilisateur qui interroge,
 en utilisant l’option ``permDefault`` comme masque. Cela ne fonctionnait pas correctement et a été corrigé, mais
 peut faire en sorte que ``polls`` ignore les fichiers qui étaient détectés avant ce changement. Si des
-configurations poll dépendent de ce comportement cassé, l’option ``permDefault`` peut avoir besoin d’être ajustée.
+configurations poll dépendent de l'ancien comportement défectueux, la valeur de ``permDefault`` peut être
+définie sur ``000`` pour autoriser l'envoi de fichiers illisibles.
 
 3.02.00
 -------

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -47,6 +47,11 @@ des instructions « accept » ou « reject » existantes (si les messages re
 est recommandé de vérifier les configurations existantes afin de s'assurer que cette mise à jour n'entraînera
 aucun changement inattendu.
 
+*CHANGEMENT* : Les polls sont censés filtrer les fichiers qui ne sont pas lisibles par l’utilisateur qui interroge,
+en utilisant l’option ``permDefault`` comme masque. Cela ne fonctionnait pas correctement et a été corrigé, mais
+peut faire en sorte que ``polls`` ignore les fichiers qui étaient détectés avant ce changement. Si des
+configurations poll dépendent de ce comportement cassé, l’option ``permDefault`` peut avoir besoin d’être ajustée.
+
 3.02.00
 -------
 

--- a/sarracenia/flow/poll.py
+++ b/sarracenia/flow/poll.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 default_options = {
     'blockSize': 1,
     'bufSize': 1024 * 1024,
-    'chmod': 0o400,
+    'permDefault': 0o400,
     'pollUrl': None,
     'follow_symlinks': False,
     'force_polling': False,

--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -389,9 +389,13 @@ class Poll(FlowCB):
 
         # assert at this point we have an sftp_obj...
         # filter out files we don't have the necessary permissions for.
-        if 'sftp_obj' in locals() and ((sftp_obj.st_mode
-                                        & self.o.permDefault) == self.o.permDefault):
+        if 'sftp_obj' in locals() and ((sftp_obj.st_mode & self.o.permDefault) == self.o.permDefault):
             return sftp_obj
+        elif 'sftp_obj' in locals() and not ((sftp_obj.st_mode & self.o.permDefault) == self.o.permDefault):
+            logger.debug("ignored file %s with permissions %s (permDefault mask: %s)", sftp_obj.longname,
+                                                                                       sftp_obj.st_mode,
+                                                                                       self.o.permDefault)
+            return None
         else:
             return None
 


### PR DESCRIPTION
The poll is not supposed to publish files that the poll user does not have permission to read. This causes download failures in the downstream sarra/subscriber.

[`permDefault` is supposed to act like a mask in a poll:](https://metpx.github.io/sarracenia/Reference/sr3_options.7.html#:~:text=when%20set%20in%20a%20polling%20component%2C%20permDefault%20has%20the%20of%20setting%20minimum%20permissions%20for%20a%20file%20to%20be%20accepted.%20(on%20an%20ls%20output%20that%20looks%20like%3A%20%E2%80%94r%E2%80%94%E2%80%93%2C%20like%20a%20chmod%20040%20%3Cfile%3E%20command).%20The%20permDefault%20options%20specifies%20a%20mask%2C%20that%20is%20the%20permissions%20must%20be%20at%20least%20what%20is%20specified.)

> when set in a polling component, permDefault has the of setting minimum permissions for a file to be accepted. (on an ls output that looks like: —r—–, like a chmod 040 <file> command). The permDefault options specifies a mask, that is the permissions must be at least what is specified.

The code for this was correct, but the default options in poll was using `chmod`, the old v2 name for `permDefault` and this was preventing `permDefault` from being applied correctly.

This deals with one part of #1689.