### PR TITLE
WIS2 Improvements - 1699

### DIFF
--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -623,10 +623,20 @@ class MQTT(Moth):
                 logger.info( f"User Property: {mqttMessage.properties.UserProperty}")
 
         self.metrics['rxByteCount'] += len(mqttMessage.payload)
+
+        try:
+            json_payload = json.loads(mqttMessage.payload.decode("utf-8"))
+        except Exception as ex:
+            json_payload = None
+
         try:
             if hasattr( mqttMessage.properties , 'UserProperty'):
                 [ headers.update({k:v}) for k,v in mqttMessage.properties.UserProperty ]
-            message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
+            if json_payload and 'conformsTo' in json_payload:
+                # If conformsTo field is found, a WIS2 message has been received.
+                message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['conformsTo'], self.o)
+            else:
+                message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
 
         except Exception as ex:
             logger.error( f"ignored malformed message: {mqttMessage.payload}" )
@@ -634,7 +644,7 @@ class MQTT(Moth):
             logger.error('Exception details: ', exc_info=True)
             self.metrics['rxBadCount'] += 1
             return None
-
+        
         if self.o['exchange']:
             message['exchange'] = mqttMessage.topic.split('/')[0]
             message['_deleteOnPost'] |= set( ['exchange' ])

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -641,6 +641,9 @@ class MQTT(Moth):
                 elif 'version' in json_payload:
                     # version is the legacy field that preceeds the conformsTo field. If found, a WIS2 message has been received.
                     message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['version'], self.o)
+                else:
+                    # Add a fallback state
+                    message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
 
             else:
                 message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -624,6 +624,8 @@ class MQTT(Moth):
 
         self.metrics['rxByteCount'] += len(mqttMessage.payload)
 
+        #logger.debug(f"MQTT properties {mqttMessage.properties}")
+
         try:
             json_payload = json.loads(mqttMessage.payload.decode("utf-8"))
         except Exception as ex:
@@ -632,9 +634,14 @@ class MQTT(Moth):
         try:
             if hasattr( mqttMessage.properties , 'UserProperty'):
                 [ headers.update({k:v}) for k,v in mqttMessage.properties.UserProperty ]
-            if json_payload and 'conformsTo' in json_payload:
-                # If conformsTo field is found, a WIS2 message has been received.
-                message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['conformsTo'], self.o)
+            if json_payload:
+                if 'conformsTo' in json_payload:
+                    # If conformsTo field is found, a WIS2 message has been received.
+                    message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['conformsTo'], self.o)
+                elif 'version' in json_payload:
+                    # version is the legacy field that preceeds the conformsTo field. If found, a WIS2 message has been received.
+                    message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['version'], self.o)
+
             else:
                 message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
 

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -614,6 +614,7 @@ class MQTT(Moth):
                 headers['content-type'] = mqttMessage.properties.ContentType
             else:
                 logger.warning('message is missing content-type header')
+                mqttMessage.properties.ContentType = None
 
             if hasattr(mqttMessage, 'payload'): 
                 logger.info( f"payload: type: {type(mqttMessage.payload)}"
@@ -627,26 +628,9 @@ class MQTT(Moth):
         #logger.debug(f"MQTT properties {mqttMessage.properties}")
 
         try:
-            json_payload = json.loads(mqttMessage.payload.decode("utf-8"))
-        except Exception as ex:
-            json_payload = None
-
-        try:
             if hasattr( mqttMessage.properties , 'UserProperty'):
                 [ headers.update({k:v}) for k,v in mqttMessage.properties.UserProperty ]
-            if json_payload:
-                if 'conformsTo' in json_payload:
-                    # If conformsTo field is found, a WIS2 message has been received.
-                    message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['conformsTo'], self.o)
-                elif 'version' in json_payload:
-                    # version is the legacy field that preceeds the conformsTo field. If found, a WIS2 message has been received.
-                    message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, json_payload['version'], self.o)
-                else:
-                    # Add a fallback state
-                    message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
-
-            else:
-                message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
+            message = PostFormat.importAny( mqttMessage.payload.decode('utf-8'), headers, mqttMessage.properties.ContentType, self.o)
 
         except Exception as ex:
             logger.error( f"ignored malformed message: {mqttMessage.payload}" )

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -70,7 +70,7 @@ class Wis(PostFormat):
             try:
                 GeoJSONBody=json.loads(body)
             except Exception as ex:
-                logger.warning(f'expected geojson, decode error: {ex}')
+                logger.warning(f'Expected json, decode error: {ex}')
                 logger.debug('Exception details: ', exc_info=True)
                 return None
 
@@ -79,7 +79,7 @@ class Wis(PostFormat):
                     t=GeoJSONBody['properties']['pubtime']
                     msg['pubTime'] = t[0:4]+t[5:7]+t[8:13]+t[14:16]+t[17:-1]
                 else:
-                    logger.error( 'invalid message missing pubtime (WMO mandatory field)' )
+                    logger.error( 'Invalid message missing pubtime (WMO mandatory field)' )
   
                 for h in GeoJSONBody['properties']:
                     if h not in [ 'pubtime' ]:
@@ -87,7 +87,7 @@ class Wis(PostFormat):
 
             #logger.warning( f" headers: {headers}, msg: {msg}  ... GeoJSONBody: {GeoJSONBody}  ")
             if not 'type' in GeoJSONBody:
-                logger.warning( 'Invalid message. Missing type field(WMO mandatory field)' )
+                logger.warning( 'Invalid message. Missing type field (WMO mandatory field)' )
 
             if 'geometry' in GeoJSONBody :
                 if GeoJSONBody['geometry'] is not None:
@@ -98,7 +98,7 @@ class Wis(PostFormat):
             if not ( 'version' in GeoJSONBody or 'conformsTo' in GeoJSONBody ):
                 logger.warning( 'Invalid message. Missing either version or conformsTo field (WMO Mandatory field)' )
 
-            # Use by default the MQTT 'topic' as part of the relPath. Fallback to 'data_id'. If neither is found, log a warning and leave relPath unset.
+            # Use by default the MQTT 'topic' as part of the relPath. Topic is a mandatory field in MQTT. If the topic is not found, log an error and return the message as is.
             if 'topic' in headers:
                 msg['relPath'] = headers['topic']
             #elif 'properties' in GeoJSONBody and ('data_id' in GeoJSONBody['properties']):

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -107,6 +107,9 @@ class Wis(PostFormat):
                 logger.error( 'Invalid message. All MQTT streams should be accompanied with a topic.')
                 return msg
            
+            # Links can only hold ONE value of 'canonical', 'update' or 'deletion'. All other links provided are not references to the source data.
+            # See https://wmo-im.github.io/wis2-notification-message/standard/wis2-notification-message-STABLE.html#_1_17_links section I.
+            # TODO: Read metadata held inside additional links fields?
             if 'links' in GeoJSONBody:
                 urlstr = GeoJSONBody['links'][0]['href']
                 url = urllib.parse.urlparse( urlstr )

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -49,9 +49,16 @@ class Wis(PostFormat):
           v04 is returned as the version from the JSON message.
           See https://wmo-im.github.io/wis2-notification-message/standard/wis2-notification-message-STABLE.html#_conformance_2
         """
-        for content in content_type:
-            if content.find('wis.wmo.int'): return True
-            if content.find('v04'): return True
+
+        try:
+            json_payload = json.loads(payload)
+        except Exception as ex:
+            logger.warning(f'Expected json, decode error: {ex}')
+            logger.debug('Exception details: ', exc_info=True)
+            return False
+
+        if 'version' in json_payload and json_payload['version'] == 'v04': return True
+        if 'conformsTo' in json_payload and 'wis.wmo.int' in json_payload['conformsTo'][0]: return True
         return False
 
     @staticmethod

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -40,16 +40,18 @@ class Wis(PostFormat):
 
     @staticmethod
     def content_type():
-        return 'application/geo+json'
+        return 'application/json'
 
     @staticmethod
     def mine(payload, headers, content_type, options) -> bool:
         """
-          return true if the message conforms to the wis.wmo.int format as reported in the conformsTo field.
+          return true if the message conforms to the wis.wmo.int format as reported in the conformsTo field OR;
+          v04 is returned as the version from the JSON message.
           See https://wmo-im.github.io/wis2-notification-message/standard/wis2-notification-message-STABLE.html#_conformance_2
         """
         for content in content_type:
             if content.find('wis.wmo.int'): return True
+            if content.find('v04'): return True
         return False
 
     @staticmethod
@@ -85,21 +87,25 @@ class Wis(PostFormat):
 
             #logger.warning( f" headers: {headers}, msg: {msg}  ... GeoJSONBody: {GeoJSONBody}  ")
             if not 'type' in GeoJSONBody:
-                logger.warning( 'invalid message missing type (WMO mandatory field)' )
+                logger.warning( 'Invalid message. Missing type field(WMO mandatory field)' )
 
             if 'geometry' in GeoJSONBody :
                 if GeoJSONBody['geometry'] is not None:
                     msg['geometry'] = GeoJSONBody['geometry']
             else:
-                logger.warning( 'invalid message missing geometry (WMO mandatory field)' )
+                logger.warning( 'Invalid message. Missing geometry (WMO mandatory field)' )
 
-            if not ( 'version' in GeoJSONBody and GeoJSONBody['version'] == 'v04' ):
-                logger.warning( 'invalide message missing version (WMO Mandatory field)' )
+            if not ( 'version' in GeoJSONBody or 'conformsTo' in GeoJSONBody ):
+                logger.warning( 'Invalid message. Missing either version or conformsTo field (WMO Mandatory field)' )
 
-            if ('data_id' in msg) and ('topic' in headers):
-                msg['relPath'] = headers['topic'] + '/' + msg['data_id']
+            # Use by default the MQTT 'topic' as part of the relPath. Fallback to 'data_id'. If neither is found, log a warning and leave relPath unset.
+            if 'topic' in headers:
+                msg['relPath'] = headers['topic']
+            #elif 'properties' in GeoJSONBody and ('data_id' in GeoJSONBody['properties']):
+            #    msg['relPath'] = GeoJSONBody['properties']['data_id']
             else:
-                logger.warning( 'invalid message missing data_id (WMO mandatory field)' )
+                logger.error( 'Invalid message. All MQTT streams should be accompanied with a topic.')
+                return msg
            
             if 'links' in GeoJSONBody:
                 urlstr = GeoJSONBody['links'][0]['href']
@@ -110,8 +116,15 @@ class Wis(PostFormat):
                 msg['links'] = GeoJSONBody['links']
                 msg['baseUrl'] = url.scheme + '://' + url.netloc
                 msg['retrievePath' ] = urlstr[len(msg['baseUrl']):] 
+
+                # The topic normally doesn't hold the filename inside its structure. It is however present in the href link, to fetch the data.
+                # Extract this filename value when possible.
+                if url.path.split('/')[-1] != '':
+                    if msg['relPath'][-1] != '/':
+                        msg['relPath'] += '/'
+                    msg['relPath'] += url.path.split('/')[-1]
             else:
-                logger.warning( 'message missing links (WMO mandatory field)' )
+                logger.warning( 'Invalid message. Missing links field (WMO mandatory field)' )
 
             return msg
 
@@ -120,7 +133,7 @@ class Wis(PostFormat):
             """
            given a v03 (internal) message, produce an encoded version.
        """
-            GeoJSONBody={ 'type': 'Feature', 'geometry': None, 'properties':{}, 'version':'v04' }
+            GeoJSONBody={ 'type': 'Feature', 'geometry': None, 'properties':{}, 'conformsTo': ["http://wis.wmo.int/spec/wnm/1/conf/core"]  }
 
             for literal in [ 'geometry', 'properties' ]:
                 if literal in body:

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -116,7 +116,11 @@ class Wis(PostFormat):
                 msg['size']  = GeoJSONBody['links'][0]['length']
                 if 'type' in GeoJSONBody['links'][0]:
                     msg['contentType']  = GeoJSONBody['links'][0]['type']
+                # We may want to keep using the links field for plugins. We don't want to repost this field however. 
+                # It will get re-created from the poster configuration if WIS2 post_format is used.
                 msg['links'] = GeoJSONBody['links']
+                msg['_deleteOnPost'] |= set( ['links' ])
+
                 msg['baseUrl'] = url.scheme + '://' + url.netloc
                 msg['retrievePath' ] = urlstr[len(msg['baseUrl']):] 
 

--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -45,10 +45,11 @@ class Wis(PostFormat):
     @staticmethod
     def mine(payload, headers, content_type, options) -> bool:
         """
-          return true if the message is in this encoding.
+          return true if the message conforms to the wis.wmo.int format as reported in the conformsTo field.
+          See https://wmo-im.github.io/wis2-notification-message/standard/wis2-notification-message-STABLE.html#_conformance_2
         """
-        if content_type == Wis.content_type():
-            return True
+        for content in content_type:
+            if content.find('wis.wmo.int'): return True
         return False
 
     @staticmethod


### PR DESCRIPTION
These code changes were made based on tests that I've made with the Meteo France global cache MQTT broker (globalbroker.meteo.fr).

## What's changed

- `version` is the old field that was used to determine conformance. This was replaced by `conformsTo` field and the code was adapted for this.
- The JSON data is being extracted prior to executing an `importAny` in the MQTT MOTH. This is to be able to extract the necessary fields to check for proper conformance.
- We are using the `topic` field to determine the `relPath` value inside of the message.

I've tested message ingestions from multiple different sources (UKMET and ECCC) and I didn't encounter any problems.

Here is what a message looks like when being posted in WIS2 format. The `source` field is being kept in the message.. I think we should probably remove that but I'm not sure if keeping it would cause problems.

```
2026-06-10 13:19:18,671 [INFO] sarracenia.moth.amqp putNewMessage raw message body: version: wis type: <class 'str'> {"type": "Feature", "geometry": null, "properties": {"data_id": "wis2/ca-eccc-msc/data/core/weather/experimental/SXCN40_KWAL_101311___51355", "datetime": null, "global-cache": "kr-kma-global-cache", "integrity": {"method": "sha512", "value": "V+H1+imbC7oQL77SHtaBrbbwCtRdEPZM0Ftm8rG2PR5+uiz8u9cO6PobagN0G6B1/O4xaNeehtpXsibtCf6R0g=="}, "metadata_id": "urn:wmo:md:ca-eccc-msc:02fd8740-af64-4ce0-af42-3c17c92cf02b", "source": "tfeed", "pubtime": "2026-06-10T13:12:41Z"}, "conformsTo": ["http://wis.wmo.int/spec/wnm/1/conf/core"], "id": "58d8a1fb-cda5-43cd-8843-e3a26846e0b9", "links": [{"rel": "canonical", "href": "http://my-server//net/local/home/leblanca/wis2/ca-eccc-msc/data/core/weather/experimental/SXCN40_KWAL_101311___51355.43322", "length": 181, "type": "text/plain"}]}

# I know this is posting to AMQP which is wrong for WIS2 format..
2026-06-10 13:19:18,672 [INFO] sarracenia.flowcb.log after_post posted to amqp://tfeed@localhost/,xs_tfeed, amqp://tfeed@localhost/,xs_tfeed, a file with baseUrl: http://my-server/ relPath: net/local/home/leblanca/wis2/ca-eccc-msc/data/core/weather/experimental/SXCN40_KWAL_101311___51355.43322 size: 181 id: V+H1+im
```

Here is what a sarracenia v03 message being posted looks like

```
2026-06-10 13:22:53,420 [INFO] sarracenia.moth.amqp putNewMessage raw message body: version: v03 type: <class 'str'> {"pubTime": "20260610T131305", "data_id": "wis2/ca-eccc-msc/data/core/weather/experimental/SR
CN40_KWAL_101312___35864", "integrity": {"method": "sha512", "value": "spzVgUvXMxs3uLDRVpjyNkJC0mWH78rwq2fKQjBct1/et50wsOwTXPh+juySi+8esw85WB02prdjUb5ss/+Wrw=="}, "datetime": null, "metadata_id": "urn:wmo:md:ca
-eccc-msc:02fd8740-af64-4ce0-af42-3c17c92cf02b", "global-cache": "jp-jma-global-cache", "relPath": "net/local/home/leblanca/wis2/ca-eccc-msc/data/core/weather/experimental/SRCN40_KWAL_101312___35864", "size": 2
44, "contentType": "text/plain", "baseUrl": "http://my-server/", "source": "tfeed", "identity": {"method": "sha512", "value": "spzVgUvXMxs3uLDRVpjyNkJC0mWH78rwq2fKQjBct1/et50wsOwTXPh+juySi+
8esw85WB02prdjUb5ss/+Wrw=="}}

2026-06-10 13:22:53,422 [INFO] sarracenia.flowcb.log after_post posted to amqp://tfeed@localhost/,xs_tfeed,v03.net.local.home.leblanca.wis2.ca-eccc-msc.data.core.weather.experimental amqp://tfeed@localhost/,xs_tfeed,v03.net.local.home.leblanca.wis2.ca-eccc-msc.data.core.weather.experimental a file with baseUrl: http://my-server/ relPath: net/local/home/leblanca/wis2/ca-eccc-msc/data/core/weather/experimental/SRCN40_KWAL_101312___35864 size: 244 id: spzVgUv
```