### PR TITLE
fix bug after implementing octal_number changes

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1698,7 +1698,7 @@ class Flow:
         else:
             mode=self.o.permDirDefault
 
-        if type(mode) is not int:
+        if isinstance(mode, str):
             mode=int(mode,base=8)
 
         try:


### PR DESCRIPTION
```
    self.do()
  File "/home/sarra/.local/lib/python3.10/site-packages/sarracenia/flow/__init__.py", line 1220, in do
    self.do_download()
  File "/home/sarra/.local/lib/python3.10/site-packages/sarracenia/flow/__init__.py", line 1978, in do_download
    if self.do_fileOp(msg, new_path):
  File "/home/sarra/.local/lib/python3.10/site-packages/sarracenia/flow/__init__.py", line 1866, in do_fileOp
    if self.mkdir(msg):
  File "/home/sarra/.local/lib/python3.10/site-packages/sarracenia/flow/__init__.py", line 1702, in mkdir
    mode=int(mode,base=8)
TypeError: int() can't convert non-string with explicit base
```

mode is not an `int` anymore after `octal_number` was changed in #1693. I'm not sure how this slipped through the tests. I think it might be because `sr3` was not installed using `pip3 install -e .` (editable mode) on the dirt server where I ran my tests, so the code changes didn't take effect.

This fixes the one case where this seemed to cause a problem. The fix here is safer code, because `int(something, base=?)` only works when something is a string.

fwiw, `isinstance(some_octal_number_instance, int)` **will** return True, but the more explicit `type(some_octal_number) is int` does not:

```
>>> from sarracenia.config import octal_number

>>> some_octal_number = octal_number(0o123)

>>> some_octal_number
0o123

# compare octal_number instance with octal int literal
>>> some_octal_number == 0o123
True

# compare octal_number instance with decimal int literal
>>> some_octal_number == 83
True

>>> type(some_octal_number)
<class 'sarracenia.config.octal_number'>

>>> type(some_octal_number) == int
False

>>> type(some_octal_number) is int
False

# this works, it knows octal_number is a child of int
>>> isinstance(some_octal_number, int)
True
```