### PR TITLE
SFTP *upload* performance improvement

### DIFF
--- a/docs/source/Reference/sr3_credentials.7.rst
+++ b/docs/source/Reference/sr3_credentials.7.rst
@@ -41,6 +41,7 @@ passwords and settings needed by components.  The format is one entry per line. 
 
 - **sftp://user5:password5@host**
 - **sftp://user6:password6@host:22  ssh_keyfile=/users/local/.ssh/id_dsa**
+- **sftp://user5:password5@host  sftp_compat_mode**
 
 - **ftp://user7:password7@host  passive,binary**
 - **ftp://user8:password8@host:2121  active,ascii**
@@ -82,6 +83,7 @@ Supported details:
 - ``bearer_token=<token>`` (or ``bt=<token>``) - (HTTP) Bearer token for authentication
 - ``login_method=<PLAIN|AMQPLAIN|EXTERNAL|GSSAPI>`` - (AMQP) By default, the login method will be automatically determined. This can be overriden by explicity specifying a login method, which may be required if a broker supports multiple methods and an incorrect one is automatically selected.
 - ``implicit_ftps`` - (FTPS) Use implicit FTPS (otherwise, explicit FTPS is used). Setting this will also set ``tls`` to True.
+- ``sftp_compat_mode`` - (SFTP) Disable some performance enhancements (prefetch reads, pipelined writes) that could potentially cause compatibility issues with certain SFTP servers.
 - Details for the S3 protocol:
     - ``s3_endpoint=<url>`` - use a specific endpoint, such as a non-Amazon S3 service.
     - ``s3_session_token=<string>`` - when specifying credentials for S3, the username field is used as the "Access Key ID", the password as the "Secret Access Key". Sometimes a Session Token is also required, and can be provided with this option.

--- a/docs/source/fr/Reference/sr3_credentials.7.rst
+++ b/docs/source/fr/Reference/sr3_credentials.7.rst
@@ -40,6 +40,7 @@ ainsi que les paramètres nécessaires aux composants.  Le format est d'une entr
 
 - **sftp://user5:password5@host**
 - **sftp://user6:password6@host:22  ssh_keyfile=/users/local/.ssh/id_dsa**
+- **sftp://user5:password5@host  sftp_compat_mode**
 
 - **ftp://user7:password7@host  passive,binary**
 - **ftp://user8:password8@host:2121  active,ascii**
@@ -82,6 +83,7 @@ Détails pris en charge :
 - ``bearer_token=<token>`` (ou ``bt=<token>``) - (HTTP) Jeton Bearer pour l’authentification
 - ``login_method=<PLAIN|AMQPLAIN|EXTERNAL|GSSAPI>`` - (AMQP) Par défaut, la méthode de connexion sera automatiquement
 - ``implicit_ftps`` - (FTPS) Utilisez FTPS implicite (sinon, FTPS explicite est utilisé). Définir ceci définira également ``tls`` sur True.
+- ``sftp_compat_mode`` - (SFTP) Désactiver certaines améliorations de performances (lecture préchargée, écritures pipelinées) susceptibles d'entraîner des problèmes de compatibilité avec certains serveurs SFTP.
 - Détails du protocole S3:
     - ``s3_endpoint=<url>`` - utiliser un point de terminaison spécifique, comme un service non Amazon S3.
     - ``s3_session_token=<string>`` - lors de la spécification des informations d'identification pour S3, le champ du nom d'utilisateur est utilisé comme « ID de clé d'accès », le mot de passe comme « clé d'accès secrète ». Parfois, un jeton de session est également requis et peut être fourni avec cette option.

--- a/sarracenia/config/credentials.py
+++ b/sarracenia/config/credentials.py
@@ -111,6 +111,7 @@ class Credential:
         login_method (str): force a specific login method for AMQP (PLAIN,
             AMQPLAIN, EXTERNAL or GSSAPI)
         implicit_ftps (bool): use implicit FTPS, defaults to ``False`` (i.e. explicit FTPS)
+        sftp_compat_mode (bool): disable performance improvements in SFTP code, use paramiko defaults instead
 
     Usage:
 
@@ -148,6 +149,7 @@ class Credential:
         self.s3_anonymous = False
         self.azure_credentials = None
         self.implicit_ftps = False
+        self.sftp_compat_mode = False
 
     def __str__(self):
         """Returns attributes of the Credential object as a readable string.
@@ -175,7 +177,7 @@ class Credential:
             if scheme.startswith('ftp'):
                 alist = [ 'passive', 'binary', 'tls', 'prot_p', 'login_method', 'implicit_ftps' ]
             elif scheme.startswith('sftp'):
-                alist = [ 'ssh_keyfile' ]
+                alist = [ 'ssh_keyfile', 'sftp_compat_mode' ]
             elif scheme.startswith('amqp') or scheme.startswith('mqtt'):
                 alist = [ 'login_method' ]
             elif scheme.startswith('amq1'):
@@ -461,6 +463,8 @@ class CredentialDB:
                 elif keyword == 'implicit_ftps':
                     details.implicit_ftps = True
                     details.tls = True
+                elif keyword == 'sftp_compat_mode':
+                    details.sftp_compat_mode = True
                 else:
                     logger.warning(f"bad credential option ({keyword})")
 

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -190,7 +190,7 @@ class Transfer():
         """
         now=nowflt()
         if now-self.lastLog > self.logMinimumInterval:
-            logger.info( f"{naturalSize(sz)} written so far.")
+            logger.info( f"{naturalSize(sz)} written so far. ({naturalSize(self.byteRate)}/s)")
             self.lastLog=now
 
     def local_read_close(self, src):

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -224,10 +224,9 @@ class Sftp(Transfer):
                 self.ssh.connect(self.host,self.port,self.user,self.password, \
                                  pkey=None,key_filename=self.ssh_keyfile,\
                                  timeout=self.o.timeout)
-            #if ssh_keyfile != None :
-            #  key=DSSKey.from_private_key_file(ssh_keyfile,password=None)
 
             sftp = self.ssh.open_sftp()
+
             if self.o.timeout != None:
                 logger.debug('sr_sftp connect setting timeout %f', self.o.timeout)
                 channel = sftp.get_channel()
@@ -268,6 +267,7 @@ class Sftp(Transfer):
             self.user = url.username
             self.password = url.password
             self.ssh_keyfile = details.ssh_keyfile
+            self.compat_mode = details.sftp_compat_mode
 
             if url.username == '': self.user = None
             if url.password == '': self.password = None
@@ -509,6 +509,11 @@ class Sftp(Transfer):
         # read from local_file and write to rfp
 
         try:
+            if not self.compat_mode:
+                # MAX_REQUEST_SIZE does not work here (at least when the destination is OpenSSH)
+                # performance improvement: pipelined mode
+                rfp.set_pipelined(pipelined=True)
+
             rw_length = self.readlocal_write(local_file, local_offset,
                                              length, rfp)
 


### PR DESCRIPTION
Paramiko SFTP performance is terrible. We can use binaries (accelThreshold, accelScpCommand) to get better performance, but this change makes the built in Paramiko SFTP a lot faster for *uploads* without that.

It just adds a call [`set_pipelined(pipelined=True)`](https://docs.paramiko.org/en/latest/api/sftp.html#paramiko.sftp_file.SFTPFile.set_pipelined) after opening the remote file.

This can be turned off by adding `sftp_compat_mode` to the credential if it causes any issues with a particular feed/server.

There is no change to downloads here. I've tested a variety of things to improve download speed but the results are underwhelming and they involve tweaking things like the [window size](https://docs.paramiko.org/en/latest/api/sftp.html#paramiko.sftp_client.SFTPClient.from_transport). These tweaks seem more likely to cause problems so I'm going to hold off on those changes for now.

### Test Results

Using a sender that sends to sftp://localhost/.

Upload speed before the change (i.e. with `sftp_compat_mode` used) -- <1.0 MiB/s:

```
2026-06-11 19:42:13,084 [INFO] 1249368 sarracenia.flowcb.log after_work sent ok: /tmp/sender/tmp/aspyras.tar.gz size: 267.0MiB (279956035) rate: 1022.0KiB/s (1046491.53 B/s)
```

Upload speed after the change -- 18.9 MiB/sec:

```
2026-06-11 19:37:02,415 [INFO] 1249277 sarracenia.flowcb.log after_work sent ok: /tmp/sender/tmp/aspyras.tar.gz size: 267.0MiB (279956035) rate: 18.9MiB/s (19831424.87 B/s)
```