### PR TITLE
Issue1699 - Corrections

### DIFF
--- a/sarracenia/postformat/wis.py
+++ b/sarracenia/postformat/wis.py
@@ -52,9 +52,7 @@ class Wis(PostFormat):
 
         try:
             json_payload = json.loads(payload)
-        except Exception as ex:
-            logger.warning(f'Expected json, decode error: {ex}')
-            logger.debug('Exception details: ', exc_info=True)
+        except:
             return False
 
         if 'version' in json_payload and json_payload['version'] == 'v04': return True


### PR DESCRIPTION
I should've done a `git rebase` instead of a merge...

I added the changes from my previous PR to our dev environment. We started getting spammed with the following errors in the logs.

```
2026-06-11 02:08:31,928 [WARNING] sarracenia.postformat.wis mine Expected json, decode error: Extra data: line 1 column 26 (char 25)
```

I didn't realize that all `postformat` subclasses get loaded when sarracenia starts via 

https://github.com/MetPX/sarracenia/blob/ff0303c3d8fb77924035651dec06aebc20009b64/sarracenia/postformat/__init__.py#L125-L136

This is done so that sarracenia is able to accept all formats on ingestion via the `mine` function.

I suppressed the exception logging so now it will stay silent on failure.