### PR TITLE
Fix #1714 putAccelerated errors not being caught

### DIFF
--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -28,6 +28,7 @@ import logging
 import os
 import random
 import signal
+import subprocess
 import stat
 import sys
 import time
@@ -474,6 +475,21 @@ class Transfer():
 
     def gethttpsUrl(self, path):
         return None
+
+    def runAccelCommand(self, cmd, exc_prefix=''):
+        """ Run a command, capture stderr. exc_prefix is a string that is added to the beginning of the
+            exception message.
+            Raises Exception if the command returns non-zero.
+        """
+        exc_prefix += ' '
+        p = subprocess.Popen(cmd, stderr=subprocess.PIPE)
+        _, stderr = p.communicate()
+        if p.returncode != 0:
+            try:
+                stderr = stderr.decode().strip()
+            except Exception:
+                pass
+            raise Exception(f"{exc_prefix}failed: {stderr} (cmd used: {' '.join(cmd)})")
 
 # batteries included.
 import sarracenia.transfer.file

--- a/sarracenia/transfer/__init__.py
+++ b/sarracenia/transfer/__init__.py
@@ -481,7 +481,6 @@ class Transfer():
             exception message.
             Raises Exception if the command returns non-zero.
         """
-        exc_prefix += ' '
         p = subprocess.Popen(cmd, stderr=subprocess.PIPE)
         _, stderr = p.communicate()
         if p.returncode != 0:
@@ -489,7 +488,7 @@ class Transfer():
                 stderr = stderr.decode().strip()
             except Exception:
                 pass
-            raise Exception(f"{exc_prefix}failed: {stderr} (cmd used: {' '.join(cmd)})")
+            raise Exception(f"{exc_prefix} failed: {stderr} (cmd used: {' '.join(cmd)})")
 
 # batteries included.
 import sarracenia.transfer.file

--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -25,7 +25,7 @@ from sarracenia.transfer import Transfer
 
 import sarracenia
 
-import os, stat, subprocess, sys, time
+import os, stat, sys, time
 
 import logging
 
@@ -152,9 +152,10 @@ class File(Transfer):
         cmd = cmd.replace('%d', arg2).split()
 
         logger.info(f"accel_cp:  {' '.join(cmd)}")
-        p = subprocess.Popen(cmd)
-        p.wait()
-        if p.returncode != 0:
+        try:
+            self.runAccelCommand(cmd)
+        except Exception as e:
+            logger.error(e)
             return -1
         sz = os.stat(arg2).st_size
         return sz

--- a/sarracenia/transfer/ftp.py
+++ b/sarracenia/transfer/ftp.py
@@ -20,7 +20,7 @@
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
 #
 
-import ftplib, os, subprocess, sys, time, ssl
+import ftplib, os, sys, time, ssl
 import logging
 from sarracenia.transfer import Transfer
 from sarracenia.transfer import alarm_cancel, alarm_set, alarm_raise
@@ -364,9 +364,10 @@ class Ftp(Transfer):
         cmd = cmd.replace('%d', arg2).split()
 
         logger.info(f"accel_ftp:  {' '.join(cmd)}")
-        p = subprocess.Popen(cmd)
-        p.wait()
-        if p.returncode != 0:
+        try:
+            self.runAccelCommand(cmd)
+        except Exception as e:
+            logger.error(e)
             return -1
         sz = os.stat(arg2).st_size
         return sz
@@ -487,10 +488,7 @@ class Ftp(Transfer):
         cmd = cmd.replace('%d', arg2).split()
 
         logger.info(f"accel_ftp:  {' '.join(cmd)}")
-        p = subprocess.Popen(cmd)
-        p.wait()
-        if p.returncode != 0:
-            return -1
+        self.runAccelCommand(cmd, 'putAccelerated')
         # FIXME: faking success... not sure how to check really.
         sz = int(msg['size'])
         return sz

--- a/sarracenia/transfer/https.py
+++ b/sarracenia/transfer/https.py
@@ -26,7 +26,6 @@ import logging
 import os
 import sarracenia
 import ssl
-import subprocess
 import sys
 
 from sarracenia.transfer import Transfer
@@ -237,10 +236,10 @@ class Https(Transfer):
             cmd = [cmd[0]] + cmd[1:]
 
         logger.info(f"accel_wget: {' '.join(cmd)}")
-        p = subprocess.Popen(cmd)
-        p.wait()
-        if p.returncode != 0:
-            logger.warning( f"binary accelerator {cmd} returned: {p.returncode}" )
+        try:
+            self.runAccelCommand(cmd)
+        except Exception as e:
+            logger.error(e)
             return -1
         # FIXME: length is not validated.
         return length

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -21,7 +21,7 @@
 #
 #
 
-import logging, paramiko, os, subprocess, sys, time
+import logging, paramiko, os, sys, time
 from paramiko import *
 from stat import *
 
@@ -399,9 +399,10 @@ class Sftp(Transfer):
         cmd = self.o.accelScpCommand.replace('%s', arg1)
         cmd = cmd.replace('%d', arg2).split()
         logger.info(f"accel_sftp:  {' '.join(cmd)}")
-        p = subprocess.Popen(cmd)
-        p.wait()
-        if p.returncode != 0:
+        try:
+            self.runAccelCommand(cmd)
+        except Exception as e:
+            logger.error(e)
             return -1
         sz = os.stat(arg2).st_size
         return sz
@@ -548,10 +549,7 @@ class Sftp(Transfer):
         cmd = cmd.replace('%d', arg2).split()
 
         logger.info(f"accel_sftp:  {' '.join(cmd)}")
-        p = subprocess.Popen(cmd)
-        p.wait()
-        if p.returncode != 0:
-            return -1
+        self.runAccelCommand(cmd, 'putAccelerated')
         # FIXME: faking success... not sure how to check really.
         sz = int(msg['size'])
         return sz


### PR DESCRIPTION
Issue #1714 describes the problem and has example logs. If an accelerated upload failed (`putAccelerated`) the error was not caught. Flow would think the transfer succeeded and move on.

I replaced the Popen call and return code checking inside the transfer classes with a wrapper method. This reduces some repeated code and captures stderr for better error logging.

`getAccelerated` worked fine, but I changed it to use the wrapper function too. Because the download code in Flow correctly deals with `-1` returned by getAccelerated, I kept that to minimize changes (rather than throwing the Exception up to Flow like putAccelerated does).