### PR TITLE
flow_autoconfig.sh cleanup

### DIFF
--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -14,15 +14,14 @@ else
 fi
 
 # Install and configure dependencies
-sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
+#sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt update
 sudo apt -y upgrade
-sudo apt -y install python3-setuptools python3-magic python3-paramiko python3-requests python3-pyftpdlib
+sudo apt -y install python3-setuptools python3-magic python3-paramiko python3-requests python3-pyftpdlib \
+	            erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools \
+		    openssh-client openssh-server python3-pip rabbitmq-server xattr wget ncftp
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
-sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
-sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 
-sudo apt -y install wget ncftp
 
 
 ${pip_install} -U pip

--- a/travis/flow_autoconfig.sh
+++ b/travis/flow_autoconfig.sh
@@ -18,7 +18,7 @@ sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A
 sudo add-apt-repository -y ppa:ssc-hpc-chp-spc/metpx
 sudo apt update
 sudo apt -y upgrade
-sudo apt -y install python3-setuptools python3-magic python-setuptools python3-paramiko python3-requests python3-pyftpdlib
+sudo apt -y install python3-setuptools python3-magic python3-paramiko python3-requests python3-pyftpdlib
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install metpx-libsr3c metpx-libsr3c-dev metpx-sr3c
 sudo apt -y install erlang-nox erlang-diameter erlang-eldap findutils git librabbitmq4 net-tools openssh-client openssh-server python3-pip rabbitmq-server xattr wget 

--- a/travis/ssh_localhost.sh
+++ b/travis/ssh_localhost.sh
@@ -4,7 +4,8 @@ if [[ $(($check_wsl == "init" )) ]]; then
 	sudo service ssh start
 fi
 
-ssh localhost /bin/true
+# check if ssh already works *without asking for a password*
+ssh -oChallengeResponseAuthentication=no -oPasswordAuthentication=no -oStrictHostKeyChecking=no localhost /bin/true
 ssh_works=$?
 if [ ${ssh_works} -gt 0 ]; then
     echo "no ssh to localhost... must fix..."


### PR DESCRIPTION
- Removed `python-setuptools` (Python 2) which is failing to install (we have `python3-setuptools` in the list)
- Removed duplicate apt install line
- Moved other dependencies into one line
- Removed apt-key line because it wasn't doing anything (the add-apt-repository command seems to take care of key stuff, at least on recent Ubuntu versions)