### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,15 +1,11 @@
 FROM ubuntu:latest
 
-LABEL maintainer="Peter.Silva@ssc-spc.gc.ca"
+LABEL maintainer="ssc.sscdatarouting-spcroutagededonnees.spc@ssc-spc.gc.ca"
 
 ENV TZ="Etc/UTC" \
     DEBIAN_FRONTEND="noninteractive" \
     BUILD_PACKAGES="build-essential" 
 
-# deps copied from setup.py requires= ...  
+# deps copied from setup.py requires= and debian/control
 
-RUN apt-get update ; apt-get install -y python3-amqp python3-appdirs python3-dateparser python3-humanfriendly python3-humanize python3-jsonpickle python3-netifaces python3-paramiko python3-pip python3-psutil python3-watchdog  
-
-
-# need version >= 1.5.1 to get MQTT v5 support, not in repos of 20.04 ... so get from pip.
-RUN pip3 install --no-cache-dir --break-system-packages --user paho-mqtt
+RUN apt-get update ; apt-get install -y python3-amqp python3-appdirs python3-dateparser python3-humanfriendly python3-humanize python3-jsonpickle python3-netifaces python3-paho-mqtt python3-paramiko python3-pip python3-psutil python3-watchdog  


### PR DESCRIPTION
I did this a couple months ago and forgot about it.

The Dockerfile was previously pip installing Paho, but Ubuntu's version of Paho has been >= 1.5.1 since Ubuntu 22.04, and we use `ubuntu:latest` as our base image, so that's not necessary anymore.

I also updated the contact email.