### PR TITLE
Fix api examples

### DIFF
--- a/.github/workflows/flow_basic.yml
+++ b/.github/workflows/flow_basic.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.osver }}
   
     name: Maintenance test on ${{ matrix.osver }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     
     steps:
       - uses: actions/checkout@v6

--- a/sarracenia/examples/flow_api_consumer.py
+++ b/sarracenia/examples/flow_api_consumer.py
@@ -14,8 +14,7 @@ cfg.topicPrefix = ['v02', 'post']
 cfg.component = 'subscribe'
 cfg.config = 'flow_demo'
 cfg.action = 'foreground'
-bindings = [ {'exchange':'xpublic', 'prefix':['v02', 'post'],
-                'sub':['*.WXO-DD.observations.swob-ml.#']}]
+bindings = [ {'exchange':'xpublic', 'topic':'v02.post.*.WXO-DD.observations.swob-ml.#'}]
 cfg.queueName = 'q_${BROKER_USER}_${HOSTNAME}_${QUEUESHARE}'
 cfg.download = True
 cfg.batch = 1
@@ -48,6 +47,7 @@ queue = {'name': 'q_anonymous_' + socket.getfqdn() + '_' + cfg.queueShare,
 cfg.subscriptions = sarracenia.config.subscription.Subscriptions( [ {
    'broker': cfg.broker,
    'bindings': bindings,
+   'bindings_to_remove': [],
    'queue' : queue
       } ] )
 

--- a/sarracenia/examples/moth_api_consumer.py
+++ b/sarracenia/examples/moth_api_consumer.py
@@ -45,7 +45,8 @@ queue = {'name': 'q_anonymous_' + socket.getfqdn() + '_' + options['queueShare']
 
 options['subscriptions'] = sarracenia.config.subscription.Subscriptions( [ { 
    'broker': options['broker'],
-   'bindings': [ { 'exchange':'xpublic', 'prefix': ['v02','post'], 'sub':['#'] } ],
+   'bindings': [ { 'exchange':'xpublic', 'topic':'v02.post.#' } ],
+   'bindings_to_remove': [],
    'queue' : queue
       } ] )
 


### PR DESCRIPTION
Changes made to the topic binding stuff broke the API examples. My fixes work when I run the examples locally. Now the "sr_insects test basic declare/cleanup, and python API " github actions test should pass too. 