### PR TITLE
Fix messages getting lost when `inflight N` (aka `fileAgeMin`) used in a post config

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -9,7 +9,6 @@ on:
       - v2_dev
       - stable
       - v2_stable
-      - test_fix_retryEmptyBeforeExit
 
     paths-ignore:
       - '.github/**'
@@ -52,7 +51,6 @@ jobs:
         run: |
           cd ${HOME}; pwd; ls ; 
           echo hoho
-          cd ${HOME}/sr_insects/; git pull; git checkout wait_for_post_test2; git pull
           cd ${HOME}/sr_insects/${{ matrix.which_test }}; ./flow_setup.sh
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided

--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -9,6 +9,7 @@ on:
       - v2_dev
       - stable
       - v2_stable
+      - test_fix_retryEmptyBeforeExit
 
     paths-ignore:
       - '.github/**'
@@ -51,6 +52,7 @@ jobs:
         run: |
           cd ${HOME}; pwd; ls ; 
           echo hoho
+          cd ${HOME}/sr_insects/; git pull; git checkout wait_for_post_test2; git pull
           cd ${HOME}/sr_insects/${{ matrix.which_test }}; ./flow_setup.sh
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -642,8 +642,8 @@ class Flow:
                     and (self.metrics['retry']['msgs_in_post_retry'] > 0
                          or self.metrics['retry']['msgs_in_download_retry'] > 0) ):
                     logger.info("retryEmptyBeforeExit=True and there are still messages in the retry queues"
-                                + f"(post: {self.metrics['retry']['msgs_in_post_retry']}, "
-                                + f"download: {self.metrics['retry']['msgs_in_download_retry']})")
+                                + f" (post: {self.metrics['retry']['msgs_in_post_retry']}, "
+                                + f"work: {self.metrics['retry']['msgs_in_download_retry']})")
                     # Messages can't be retried before housekeeping has run, so run it right now
                     next_housekeeping = now - 1
                     # sleep for a bit (self.o.sleep is <0)

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -642,10 +642,10 @@ class Flow:
                     and (self.metrics['retry']['msgs_in_post_retry'] > 0
                          or self.metrics['retry']['msgs_in_download_retry'] > 0) ):
                     logger.info( f"retryEmptyBeforeExit=True and there are still "
-                        f"{self.metrics['retry']['msgs_in_post_retry']} messages in the post retry queue.")
+                        f"{self.metrics['retry']['msgs_in_post_retry']} messages in the retry queue(s).")
                     # Messages can't be retried before housekeeping has run, so run it right now
                     next_housekeeping = now - 1
-                    # sleep for a bit (self.o.sleep is 0 so using a non-zero value here)
+                    # sleep for a bit (self.o.sleep is <0)
                     current_sleep = 0.1
                 else:
                     self.runCallbacksTime('please_stop')

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -639,7 +639,8 @@ class Flow:
             # trigger shutdown once gather is finished, where sleep < 0 (e.g. a post)
             if (last_gather_len == 0) and (self.o.sleep < 0):
                 if (self.o.retryEmptyBeforeExit and "retry" in self.metrics
-                    and self.metrics['retry']['msgs_in_post_retry'] > 0):
+                    and (self.metrics['retry']['msgs_in_post_retry'] > 0
+                         or self.metrics['retry']['msgs_in_download_retry'] > 0) ):
                     logger.info( f"retryEmptyBeforeExit=True and there are still "
                         f"{self.metrics['retry']['msgs_in_post_retry']} messages in the post retry queue.")
                     # Messages can't be retried before housekeeping has run, so run it right now

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -641,8 +641,9 @@ class Flow:
                 if (self.o.retryEmptyBeforeExit and "retry" in self.metrics
                     and (self.metrics['retry']['msgs_in_post_retry'] > 0
                          or self.metrics['retry']['msgs_in_download_retry'] > 0) ):
-                    logger.info( f"retryEmptyBeforeExit=True and there are still "
-                        f"{self.metrics['retry']['msgs_in_post_retry']} messages in the retry queue(s).")
+                    logger.info("retryEmptyBeforeExit=True and there are still messages in the retry queues"
+                                + f"(post: {self.metrics['retry']['msgs_in_post_retry']}, "
+                                + f"download: {self.metrics['retry']['msgs_in_download_retry']})")
                     # Messages can't be retried before housekeeping has run, so run it right now
                     next_housekeeping = now - 1
                     # sleep for a bit (self.o.sleep is <0)

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -160,6 +160,7 @@ class Disk(NoDupe):
             max_mtime = self.now + 100
 
         for m in worklist.incoming:
+            m_is_retry = m.isRetry()
             if ('mtime' in m) :
                 mtime=timestr2flt(m['mtime'])
                 if mtime < min_mtime:
@@ -168,14 +169,17 @@ class Disk(NoDupe):
                     m.setReport(406,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
                     worklist.rejected.append(m)
                     continue
-                elif mtime > max_mtime:
+                # too new messages should only be *rejected* in polls. In other components, too new messages
+                # are put into the work retry list and get retried until they become old enough to be processed.
+                # The logic in Flow handles the retry stuff; if a msg is not a retry, nodupe can reject it.
+                elif mtime > max_mtime and not m_is_retry:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
                     m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
                     worklist.rejected.append(m)
                     continue
 
-            if m.isRetry() or self.check_message(m):
+            if m_is_retry or self.check_message(m):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -176,11 +176,12 @@ class Disk(NoDupe):
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
                     m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
-                    logger.warning( f"file {m['relPath']} too young: queueing for retry later")
                     worklist.rejected.append(m)
                     continue
                 # Messages that are too new, that are not polls and that are retries should get re-appended to the retry list.
+                # When retry_refilter is off, the fileAgeMin check in flow gets bypassed
                 elif mtime > max_mtime and m_is_retry:
+                    logger.warning( f"file {m['relPath']} too young: queueing for retry later")
                     worklist.failed.append(m)
                     continue
 

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -160,7 +160,6 @@ class Disk(NoDupe):
             max_mtime = self.now + 100
 
         for m in worklist.incoming:
-            m_is_retry = m.isRetry()
             if ('mtime' in m) :
                 mtime=timestr2flt(m['mtime'])
                 if mtime < min_mtime:
@@ -169,23 +168,24 @@ class Disk(NoDupe):
                     m.setReport(406,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
                     worklist.rejected.append(m)
                     continue
-                # too new messages should only be *rejected* in polls. In other components, too new messages
-                # are put into the work retry list and get retried until they become old enough to be processed.
-                # The logic in Flow handles the retry stuff; if a msg is not a retry, nodupe can reject it.
+                # too new messages should only be *rejected* in polls.
                 elif mtime > max_mtime and self.o.component in [ 'poll' ]:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
                     m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
                     worklist.rejected.append(m)
                     continue
-                # Messages that are too new, that are not polls and that are retries should get re-appended to the retry list.
-                # When retry_refilter is off, the fileAgeMin check in flow gets bypassed
-                elif mtime > max_mtime and m_is_retry:
+                # in non-poll components, files that are too new are put into the work retry list and get retried
+                # until they become old enough to be processed. The logic in Flow normally handles that, except it
+                # gets bypassed when a message is being retried with retry_refilter=False, so check again here.
+                # (the fileAgeMin check in Flow is a bit redundant and could be deleted, except then the fileAgeMin
+                #  check wouldn't work when nodupe is disabled, so we're keeping it in both places.)
+                elif mtime > max_mtime:
                     logger.warning( f"file {m['relPath']} too young: queueing for retry later")
                     worklist.failed.append(m)
                     continue
 
-            if m_is_retry or self.check_message(m):
+            if m.isRetry() or self.check_message(m):
                 new_incoming.append(m)
             else:
                 m['_deleteOnPost'] |= set(['reject'])

--- a/sarracenia/flowcb/nodupe/disk.py
+++ b/sarracenia/flowcb/nodupe/disk.py
@@ -172,11 +172,16 @@ class Disk(NoDupe):
                 # too new messages should only be *rejected* in polls. In other components, too new messages
                 # are put into the work retry list and get retried until they become old enough to be processed.
                 # The logic in Flow handles the retry stuff; if a msg is not a retry, nodupe can reject it.
-                elif mtime > max_mtime and not m_is_retry:
+                elif mtime > max_mtime and self.o.component in [ 'poll' ]:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
                     m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
+                    logger.warning( f"file {m['relPath']} too young: queueing for retry later")
                     worklist.rejected.append(m)
+                    continue
+                # Messages that are too new, that are not polls and that are retries should get re-appended to the retry list.
+                elif mtime > max_mtime and m_is_retry:
+                    worklist.failed.append(m)
                     continue
 
             if m_is_retry or self.check_message(m):

--- a/sarracenia/flowcb/nodupe/redis.py
+++ b/sarracenia/flowcb/nodupe/redis.py
@@ -151,8 +151,6 @@ class Redis(NoDupe):
 
         if self.o.fileAgeMin > 0:
             max_mtime = self.now - self.o.fileAgeMin
-        elif type(self.o.inflight) in [ int, float ] and self.o.inflight > 0:
-            max_mtime = self.now - self.o.inflight
         else:
             # FIXME: should we add some time here to allow for different clocks?
             #        100 seconds in the future? hmm...
@@ -167,11 +165,21 @@ class Redis(NoDupe):
                     m.setReport(406,  f"{m['mtime']} too old (nodupe check), oldest allowed {timeflt2str(min_mtime)}" )
                     worklist.rejected.append(m)
                     continue
-                elif mtime > max_mtime:
+                # too new messages should only be *rejected* in polls.
+                elif mtime > max_mtime and self.o.component in [ 'poll' ]:
                     m['_deleteOnPost'] |= set(['reject'])
                     m['reject'] = f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}"
                     m.setReport(425,  f"{m['mtime']} too new (nodupe check), newest allowed {timeflt2str(max_mtime)}" )
                     worklist.rejected.append(m)
+                    continue
+                # in non-poll components, files that are too new are put into the work retry list and get retried
+                # until they become old enough to be processed. The logic in Flow normally handles that, except it
+                # gets bypassed when a message is being retried with retry_refilter=False, so check again here.
+                # (the fileAgeMin check in Flow is a bit redundant and could be deleted, except then the fileAgeMin
+                #  check wouldn't work when nodupe is disabled, so we're keeping it in both places.)
+                elif mtime > max_mtime:
+                    logger.warning( f"file {m['relPath']} too young: queueing for retry later")
+                    worklist.failed.append(m)
                     continue
 
             if m.isRetry() or self._is_new(m):

--- a/tests/sarracenia/flowcb/nodupe/__nodupe___test.py
+++ b/tests/sarracenia/flowcb/nodupe/__nodupe___test.py
@@ -228,7 +228,7 @@ def test_after_accept__WithFileAges(tmp_path, capsys):
         BaseOptions.inflight = 0
 
         message_now = nowflt() + 10
-        message_new_mtime = timeflt2str(message_now)
+        message_new_mtime = timeflt2str(message_now + 10000)
         message_old_mtime = timeflt2str(message_now - 10000)
 
         message_old = make_message()
@@ -262,30 +262,30 @@ def test_after_accept__WithFileAges(tmp_path, capsys):
 
         nodupe_redis.after_accept(worklist_redis)
 
-        assert len(worklist_disk.rejected) == len(worklist_redis.rejected) == 2
+        assert len(worklist_disk.rejected) == len(worklist_redis.rejected) == 1
         assert worklist_disk.rejected[0]['reject'].count(message_old_mtime + " too old (nodupe check), oldest allowed") \
             == worklist_redis.rejected[0]['reject'].count(message_old_mtime + " too old (nodupe check), oldest allowed") \
             == 1
-        
-        assert worklist_disk.rejected[1]['reject'].count(message_new_mtime + " too new (nodupe check), newest allowed") \
-            == worklist_redis.rejected[1]['reject'].count(message_new_mtime + " too new (nodupe check), newest allowed") \
-            == 1
+
+        # too new message go into worklist.failed when component is not a poll
+        assert len(worklist_disk.failed) == len(worklist_redis.failed) == 1
 
 @pytest.mark.depends(on=['sarracenia/flowcb/nodupe/disk_test.py', 'sarracenia/flowcb/nodupe/redis_test.py'])
-def test_after_accept__InFlight(tmp_path, capsys):
+def test_after_accept__WithFileAges_poll(tmp_path, capsys):
     with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-        from sarracenia import nowflt, timeflt2str
+        from sarracenia import nowflt, nowstr, timeflt2str
 
         BaseOptions = Options()
         BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
         BaseOptions.redisqueue_serverurl = "redis://Never.Going.To.Resolve:6379/0"
-        BaseOptions.config = "test_after_accept__InFlight.conf"
+        BaseOptions.config = "test_after_accept__WithFileAges.conf"
         BaseOptions.cfg_run_dir = str(tmp_path)
         BaseOptions.no = 5
-        BaseOptions.inflight = 1000
+        BaseOptions.inflight = 0
+        BaseOptions.component = 'poll'
 
         message_now = nowflt() + 10
-        message_new_mtime = timeflt2str(message_now)
+        message_new_mtime = timeflt2str(message_now + 10000)
         message_old_mtime = timeflt2str(message_now - 10000)
 
         message_old = make_message()
@@ -293,32 +293,37 @@ def test_after_accept__InFlight(tmp_path, capsys):
         message_new = make_message()
         message_new['mtime'] = message_new_mtime
 
-        #Redis
-        nodupe_redis = NoDupe_Redis(BaseOptions)
-        nodupe_redis.o.nodupe_ttl = 100000
-        nodupe_redis.now = message_now
-        nodupe_redis.on_start()
-
-        worklist_redis = copy.deepcopy(WorkList)
-        worklist_redis.incoming = [message_old, message_new]
-        nodupe_redis.after_accept(worklist_redis)
-        
         #Disk
         nodupe_disk = NoDupe_Disk(BaseOptions)
         nodupe_disk.o.nodupe_ttl = 100000
+        nodupe_disk.o.fileAgeMin = 1000
+        nodupe_disk.o.fileAgeMax = 1000
         nodupe_disk.now = message_now
         nodupe_disk.on_start()
 
         worklist_disk = copy.deepcopy(WorkList)
         worklist_disk.incoming = [message_old, message_new]
+
         nodupe_disk.after_accept(worklist_disk)
 
-        assert len(worklist_disk.rejected) == len(worklist_redis.rejected) == 1
-        assert len(worklist_disk.incoming) == len(worklist_redis.incoming) == 1
-        assert worklist_disk.incoming[0]['mtime'] == worklist_redis.incoming[0]['mtime'] == message_old_mtime
+        #Redis
+        nodupe_redis = NoDupe_Redis(BaseOptions)
+        nodupe_redis.o.nodupe_ttl = 100000
+        nodupe_redis.o.fileAgeMin = 1000
+        nodupe_redis.o.fileAgeMax = 1000
+        nodupe_redis.now = message_now
+        nodupe_redis.on_start()
 
-        # FIXME: Peter found these failing, and did not understand them enought to get them to pass.
-        #    it looks like the nodupe classes changed and this didn't follow, so the test is now slightly wrong.
-        #assert worklist_redis.rejected[0]['reject'].count(message_new_mtime + " too new (nodupe check), newest allowed") \
-        #    == worklist_disk.rejected[0]['reject'].count(message_new_mtime + " too new (nodupe check), newest allowed") \
-        #    == 1
+        worklist_redis = copy.deepcopy(WorkList)
+        worklist_redis.incoming = [message_old, message_new]
+
+        nodupe_redis.after_accept(worklist_redis)
+
+        assert len(worklist_disk.rejected) == len(worklist_redis.rejected) == 2
+        assert worklist_disk.rejected[0]['reject'].count(message_old_mtime + " too old (nodupe check), oldest allowed") \
+            == worklist_redis.rejected[0]['reject'].count(message_old_mtime + " too old (nodupe check), oldest allowed") \
+            == 1
+
+        assert worklist_disk.rejected[1]['reject'].count(message_new_mtime + " too new (nodupe check), newest allowed") \
+            == worklist_redis.rejected[1]['reject'].count(message_new_mtime + " too new (nodupe check), newest allowed") \
+            == 1

--- a/tests/sarracenia/flowcb/nodupe/disk_test.py
+++ b/tests/sarracenia/flowcb/nodupe/disk_test.py
@@ -562,30 +562,32 @@ def test_after_accept__WithFileAges(tmp_path, capsys):
     message_old = make_message()
     message_old['mtime'] = timeflt2str(nodupe.now - 10000)
     message_new = make_message()
-    message_new['mtime'] = nowstr()
-    
+    message_new['mtime'] = timeflt2str(nodupe.now + 10000)
+
     after_accept_worklist__WithFileAges = copy.deepcopy(WorkList)
     after_accept_worklist__WithFileAges.incoming = [message_old, message_new]
 
     nodupe.after_accept(after_accept_worklist__WithFileAges)
-
-    assert len(after_accept_worklist__WithFileAges.rejected) == 2
+    
+    assert len(after_accept_worklist__WithFileAges.rejected) == 1
     assert after_accept_worklist__WithFileAges.rejected[0]['reject'].count(message_old['mtime'] + " too old (nodupe check), oldest allowed")
-    #PS do not know what this is or why it is failing.
-    #assert after_accept_worklist__WithFileAges.rejected[1]['reject'].count(message_new['mtime'] + " too new (nodupe check), newest allowed")
+    # when component is not poll, messages that are too new (fileAgeMin) should get queued for retry
+    assert len(after_accept_worklist__WithFileAges.failed) == 1
 
-@pytest.mark.depends(on=['test_check_message'])
-def test_after_accept__InFlight(tmp_path, capsys):
+def test_after_accept__WithFileAges_poll(tmp_path, capsys):
     from sarracenia import nowflt, nowstr, timeflt2str
 
     BaseOptions = Options()
     BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
     BaseOptions.cfg_run_dir = str(tmp_path)
     BaseOptions.no = 5
-    BaseOptions.inflight = 1000
+    BaseOptions.inflight = 0
+    BaseOptions.component = 'poll'
 
     nodupe = Disk(BaseOptions)
     nodupe.o.nodupe_ttl = 100000
+    nodupe.o.fileAgeMin = 1000
+    nodupe.o.fileAgeMax = 1000
 
     nodupe.open()
     nodupe.now = nowflt() + 10
@@ -593,17 +595,16 @@ def test_after_accept__InFlight(tmp_path, capsys):
     message_old = make_message()
     message_old['mtime'] = timeflt2str(nodupe.now - 10000)
     message_new = make_message()
-    message_new['mtime'] = nowstr()
-    
-    test_after_accept__InFlight = copy.deepcopy(WorkList)
-    test_after_accept__InFlight.incoming = [message_old, message_new]
+    message_new['mtime'] = timeflt2str(nodupe.now + 10000)
 
-    nodupe.after_accept(test_after_accept__InFlight)
+    after_accept_worklist__WithFileAges = copy.deepcopy(WorkList)
+    after_accept_worklist__WithFileAges.incoming = [message_old, message_new]
 
-    assert len(test_after_accept__InFlight.rejected) == 1
-    assert len(test_after_accept__InFlight.incoming) == 1
-    assert test_after_accept__InFlight.incoming[0]['mtime'] == message_old['mtime']
-    # PS do not know what this is testing, but it fails... no idea how to fix.
-    #   implementation changed... message formats were misunderstood... tests slightly wrong.
-    #assert test_after_accept__InFlight.rejected[0]['reject'].count(message_new['mtime'] + " too new (nodupe check), newest allowed")
+    nodupe.after_accept(after_accept_worklist__WithFileAges)
+
+    assert len(after_accept_worklist__WithFileAges.rejected) == 2
+    assert after_accept_worklist__WithFileAges.rejected[0]['reject'].count(message_old['mtime'] + " too old (nodupe check), oldest allowed")
+    # when component is poll, both messages should be rejected, none should be put in failed
+    assert len(after_accept_worklist__WithFileAges.failed) == 0
+    assert after_accept_worklist__WithFileAges.rejected[1]['reject'].count(message_new['mtime'] + " too new (nodupe check), newest allowed")
 

--- a/tests/sarracenia/flowcb/nodupe/redis_test.py
+++ b/tests/sarracenia/flowcb/nodupe/redis_test.py
@@ -264,8 +264,44 @@ def test_after_accept__WithFileAges(tmp_path, capsys):
         message_old = make_message()
         message_old['mtime'] = timeflt2str(nodupe.now - 10000)
         message_new = make_message()
-        message_new['mtime'] = nowstr()
+        message_new['mtime'] = timeflt2str(nodupe.now + 10000)
         
+        test_after_accept__WithFileAges_worklist = copy.deepcopy(WorkList)
+        test_after_accept__WithFileAges_worklist.incoming = [message_old, message_new]
+
+        nodupe.after_accept(test_after_accept__WithFileAges_worklist)
+
+        assert len(test_after_accept__WithFileAges_worklist.rejected) == 1
+        assert test_after_accept__WithFileAges_worklist.rejected[0]['reject'].count(message_old['mtime'] + " too old (nodupe check), oldest allowed")
+        # when component is not poll, messages that are too new (fileAgeMin) should get queued for retry
+        assert len(test_after_accept__WithFileAges_worklist.failed) == 1
+
+@pytest.mark.depends(on=['test__is_new'])
+def test_after_accept__WithFileAges_poll(tmp_path, capsys):
+    with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
+        from sarracenia import nowflt, nowstr, timeflt2str
+
+        BaseOptions = Options()
+        BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+        BaseOptions.config = "test_after_accept__WithFileAges.conf"
+        BaseOptions.nodupe_redis_keybase = "redis_test__" + BaseOptions.config.split(".")[0]
+        BaseOptions.cfg_run_dir = str(tmp_path)
+        BaseOptions.no = 5
+        BaseOptions.inflight = 0
+        BaseOptions.component = 'poll'
+
+        nodupe = Redis(BaseOptions)
+        nodupe.o.nodupe_ttl = 100000
+        nodupe.o.fileAgeMin = 1000
+        nodupe.o.fileAgeMax = 1000
+
+        nodupe.now = nowflt() + 10
+
+        message_old = make_message()
+        message_old['mtime'] = timeflt2str(nodupe.now - 10000)
+        message_new = make_message()
+        message_new['mtime'] = timeflt2str(nodupe.now + 10000)
+
         test_after_accept__WithFileAges_worklist = copy.deepcopy(WorkList)
         test_after_accept__WithFileAges_worklist.incoming = [message_old, message_new]
 
@@ -273,37 +309,6 @@ def test_after_accept__WithFileAges(tmp_path, capsys):
 
         assert len(test_after_accept__WithFileAges_worklist.rejected) == 2
         assert test_after_accept__WithFileAges_worklist.rejected[0]['reject'].count(message_old['mtime'] + " too old (nodupe check), oldest allowed")
+        # when component is poll, both messages should be rejected, none should be put in failed
+        assert len(test_after_accept__WithFileAges_worklist.failed) == 0
         assert test_after_accept__WithFileAges_worklist.rejected[1]['reject'].count(message_new['mtime'] + " too new (nodupe check), newest allowed")
-
-@pytest.mark.depends(on=['test__is_new'])
-def test_after_accept__InFlight(tmp_path, capsys):
-    with patch(target="redis.from_url", new=fakeredis.FakeStrictRedis.from_url, ):
-        from sarracenia import nowflt, nowstr, timeflt2str
-
-        BaseOptions = Options()
-        BaseOptions.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
-        BaseOptions.config = "test_after_accept__InFlight.conf"
-        BaseOptions.nodupe_redis_keybase = "redis_test__" + BaseOptions.config.split(".")[0] 
-        BaseOptions.cfg_run_dir = str(tmp_path)
-        BaseOptions.no = 5
-        BaseOptions.inflight = 1000
-
-        nodupe = Redis(BaseOptions)
-        nodupe.o.nodupe_ttl = 100000
-
-        nodupe.now = nowflt() + 10
-
-        message_old = make_message()
-        message_old['mtime'] = timeflt2str(nodupe.now - 10000)
-        message_new = make_message()
-        message_new['mtime'] = nowstr()
-        
-        test_after_accept__InFlight_worklist = copy.deepcopy(WorkList)
-        test_after_accept__InFlight_worklist.incoming = [message_old, message_new]
-
-        nodupe.after_accept(test_after_accept__InFlight_worklist)
-
-        assert len(test_after_accept__InFlight_worklist.rejected) == 1
-        assert len(test_after_accept__InFlight_worklist.incoming) == 1
-        assert test_after_accept__InFlight_worklist.incoming[0]['mtime'] == message_old['mtime']
-        assert test_after_accept__InFlight_worklist.rejected[0]['reject'].count(message_new['mtime'] + " too new (nodupe check), newest allowed")


### PR DESCRIPTION
Closes #1724 and fixes two bugs.

`fileAgeMin` works in two ways:
- in polls, messages for files that are too new are *rejected* (because they will be noticed again the next time the poll runs)
- in other components, they are placed into the work retry diskqueue and should sit there waiting until they become old enough to process

The latter was not working right. If the files were *still too new* when retrieved from the diskqueue, the nodupe code (used by poll) would *reject* those messages.

This was a rare situation, because we usually have the housekeeping interval set larger than `fileAgeMin`, but in the flow tests, we use `retryEmptyBeforeExit True`, which triggers housekeeping to run much sooner.

There was also another bug, where `retryEmptyBeforeExit` was only looking at the post retry queue and ignoring the work (download) retry queue. This fixes that too, now it will only exit when the post and work retry queues are both empty.

I think the flakey broker test should be pretty reliable after this, although we'll need to monitor it. 