### PR TITLE
fix GitHub Actions compress logs errors

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -75,6 +75,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          killall sr3_cpost sr3_cpump flow_post.sh
           sr3 stop --dangerWillRobinson=1
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -68,6 +68,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          killall sr3_cpost sr3_cpump flow_post.sh
           sr3 stop --dangerWillRobinson=1
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -73,6 +73,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          killall sr3_cpost sr3_cpump flow_post.sh
           sr3 stop --dangerWillRobinson=1
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *

--- a/.github/workflows/flow_multi.yml
+++ b/.github/workflows/flow_multi.yml
@@ -73,6 +73,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          killall sr3_cpost sr3_cpump flow_post.sh
           sr3 stop --dangerWillRobinson=1
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -74,6 +74,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
+          killall sr3_cpost sr3_cpump flow_post.sh
           sr3 stop --dangerWillRobinson=1
           cd ${HOME}/.cache/sr3/
           tar -czf ${HOME}/cache_sr3.tar.gz *


### PR DESCRIPTION
Sometimes we get these errors. It's because there are a few processes that are not being stopped by the `sr3 stop` command at the end. Normally `flow_cleanup.sh` stops these, but flow cleanup is not run in the GitHub Actions tests, so I just added an extra command.

```
Run sr3 stop --dangerWillRobinson=1
Stopping: sending SIGTERM ...................... ( 22 ) Done
Waiting 1 sec. to check if 22 processes stopped (try: 0)
Waiting 2 sec. to check if 12 processes stopped (try: 1)
Waiting 4 sec. to check if 4 processes stopped (try: 2)
All stopped after try 2

tar: log/srposter_f00.log: file changed as we read it
tar: sanitizing: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
Error: Process completed with exit code 2.
```