### PR TITLE
refactor key filter plugin

### DIFF
--- a/sarracenia/flowcb/accept/key_filter.py
+++ b/sarracenia/flowcb/accept/key_filter.py
@@ -12,8 +12,16 @@ https://github.com/MetPX/sarracenia/blob/development/sarracenia/flowcb/accept/su
 The key filtering applies *after* sr3's built-in regex filtering. This plugin assumes you will use a small number
 of accept/reject statements and potentially hundreds of accept_key/reject_key statements.
 
-If key_group= is not defined, key filtering will be skipped for that mask (if the mask is accept, all files matching
+If key_groups= is not defined, key filtering will be skipped for that mask (if the mask is accept, all files matching
 will be accepted, and if it's reject, all files matching will be rejected).
+
+You can either specify one group number, or multiple separated by commas. If multiple groups are specified, by default
+they will be concatenated together (joined with no separator). If key_filter_join_str is set in the config, they
+will be joined by the specified string/character. By setting ``key_filter_join_str _``, you can replicate the
+behaviour Sundew used to derive keys (it would use *all* groups in a given regex and join them with _). This plugin
+allows the user to specify which groups are used (in case you want to use some groups in the directory but not the
+key, or vice-versa). Sundew reference:
+https://github.com/MetPX/Sundew/blob/main/doc/man/pxRouting.7.rst#generate-a-product-key
 
 
 Example Config 1:
@@ -30,7 +38,7 @@ Example Config 1:
     directory /
     # Bulletins with Sundew AHL filename format, T1T2A1A2ii_CCCC...
     #                                    ⮦ this is the group used as the key
-    accept  .*MSC-BULLETINS.*/([A-Z]{4}[0-9]{2}_[A-Z]{4}).*  key_group=1
+    accept  .*MSC-BULLETINS.*/([A-Z]{4}[0-9]{2}_[A-Z]{4}).*  key_groups=1
 
     accept  .*key_filtering_not_applied_for_files_matching_this.*
 
@@ -46,7 +54,21 @@ Example Config 2:
 
     directory /${1}
     #                                    ⮦ this is the group used as the key
-    accept  .*MSC-RADAR.*/(urp.*?)/.*(CAS[A-Z]{2}).*  key_group=2
+    accept  .*MSC-RADAR.*/(urp.*?)/.*(CAS[A-Z]{2}).*  key_groups=2
+
+
+Example Config 3 (multiple groups like Sundew):
+
+    acceptUnmatched False
+
+    callback accept.key_filter
+    key_filter_join_str _
+
+    accept_key txt:AQ_:AIRNOW:CMQ:ASCII
+
+    directory /${1}/
+    # key generated would be txt:AQ_:AIRNOW:CMQ:ASCII
+    accept  .*SOURCE/([0-9]{2})/.*(txt:AQ).*(:AIRNOW:.*:ASCII)  key_groups=2,3
 """
 
 import logging
@@ -63,39 +85,69 @@ class Key_filter(FlowCB):
 
         self.o.add_option('accept_key', 'list', [])
         self.o.add_option('reject_key', 'list', [])
+        self.o.add_option('key_filter_join_str', 'str', '')
 
         self._accept_keys = [ k.strip() for k in self.o.accept_key ]
         self._reject_keys = [ k.strip() for k in self.o.reject_key ]
 
         # determine *which* group number is used to match against keys for each defined accept/reject mask
-        self._group_num_for_mask = []
+        self._group_nums_for_mask = []
         for mask in self.o.masks:
             # pattern, maskDir, maskFileOption, mask_regexp, accepting, mirror, strip, pstrip, flatten, args = mask
             pattern, _, _, _, accepting, _, _, _, _, mask_args = mask
 
             if not accepting:
-                self._group_num_for_mask.append(-1)
+                self._group_nums_for_mask.append(None)
                 continue
 
-            key_group_args = [ arg for arg in mask_args if 'key_group=' in arg]
+            key_groups_args = [ arg for arg in mask_args if 'key_groups=' in arg]
 
-            n_key_group = len(key_group_args)
+            n_key_groups = len(key_groups_args)
             m_str = f"mask accept {pattern}"
 
-            if n_key_group < 1:
-                logger.warning(f"{m_str} missing key_group=, all files matching this pattern will be accepted")
-                self._group_num_for_mask.append(-1)
-            elif n_key_group > 1:
-                raise Exception(f"{m_str} has > 1 key_group= defined, only one group number is allowed")
+            if n_key_groups < 1:
+                logger.warning(f"{m_str} missing key_groups=, all files matching this pattern will be accepted")
+                self._group_nums_for_mask.append(None)
+            elif n_key_groups > 1:
+                raise Exception(f"{m_str} has > 1 key_groups= defined, use comma-separated values " +
+                                "(e.g. key_groups=1,2,3). Multiple instances of key_groups= is not supported")
             else:
-                _, num = key_group_args[0].split("key_group=")
+                _, num = key_groups_args[0].split("key_groups=")
                 try:
-                    group_num = int(num.strip())
-                    if group_num <= 0:
-                        raise Exception(f"{m_str} has invalid group number (< 1): {group_num}")
-                    self._group_num_for_mask.append(group_num)
+                    group_nums = [ int(n) for n in num.strip().split(',')]
+                    for n in group_nums:
+                        if n <= 0:
+                            raise Exception(f"{m_str} has an invalid group number (< 1): {group_nums}")
+                    self._group_nums_for_mask.append(group_nums)
                 except Exception as e:
-                    raise Exception(f"{m_str} has invalid {key_group_args}, {e}, fix your config")
+                    raise Exception(f"{m_str} has invalid {key_groups_args}, {e}, fix your config")
+
+    def derive_key(self, msg):
+        """ Given a message and the config, derive a key.
+            Returns the key. The key is also stored inside the message, in the ``msg['key_filter_key']``.
+            If the mask does not have key_group= then this will return None.
+            The message must already contain `_mask_index` and `_matches`.
+        """
+        # get the key from the regex groups
+        group_nums = self._group_nums_for_mask[msg['_mask_index']]
+        match = msg['_matches']
+
+        # None is used for masks that don't have key_groups=
+        if group_nums is None:
+            return None
+
+        # if a valid group number if specified but not present in the regex, it's a config error
+        # exception will be raised here, this will log an error but the caller needs to handle it
+        try:
+            key = self.o.key_filter_join_str.join(match[n] for n in group_nums)
+        except Exception as e:
+            logger.error(f"key_groups={self._group_nums_for_mask[msg['_mask_index']]}"
+                             +f" not in {self.o.masks[msg['_mask_index']]} ({e})")
+            raise
+        msg['key_filter_key'] = key
+        msg['_deleteOnPost'].add('key_filter_key')
+
+        return key
 
     def after_accept(self, worklist):
         new_incoming = []
@@ -115,22 +167,15 @@ class Key_filter(FlowCB):
                     msg.setReport(404, "could not determine key for key_filter plugin and acceptUnmatched disabled")
                 continue
 
-            # get the key from the regex groups
-            group_num = self._group_num_for_mask[msg['_mask_index']]
-            match = msg['_matches']
-
-            # -1 is used for masks that don't have key_group=
-            if group_num <= 0:
-                new_incoming.append(msg)
-                continue
-
-            # if a valid group number if specified but not present in the regex, it's a config error
             try:
-                key = match[group_num]
+                key = self.derive_key(msg)
                 logger.debug("key=%s for %s", key, msg.getIDStr())
+                if key is None:
+                    new_incoming.append(msg)
+                    continue
             except Exception as e:
-                logger.error(f"rejecting {msg.getIDStr()}, "
-                             +f"key_group={group_num} not in {self.o.masks[msg['_mask_index']]} ({e})")
+                logger.error(f"rejecting {msg.getIDStr()}, key_groups={self._group_nums_for_mask[msg['_mask_index']]}"
+                             +f" not in {self.o.masks[msg['_mask_index']]} ({e})")
                 worklist.rejected.append(msg)
                 msg.setReport(404, "could not determine key for key_filter plugin")
                 continue


### PR DESCRIPTION
@petersilva pointed out some useful information in https://github.com/MetPX/sarracenia/pull/1697#issuecomment-4547408494

Sundew would generate keys based on the accept regex groups in the receiver config. I've updated my plugin to allow multiple regex groups to be used as the key (before it only allowed one possible group).

Using a config like this, you can replicate the Sundew key generation:

```
acceptUnmatched False

callback accept.key_filter
# key will have an _ between each regex group
key_filter_join_str _

accept_key txt:AQ_:AIRNOW:CMQ:ASCII

directory /${1}/

# for example filename: 20070515.txt:AQ1245Z:AIRNOW:CMQ:ASCII
# key generated would be: txt:AQ_:AIRNOW:CMQ:ASCII
accept  .*SOURCE/([0-9]{2})/.*(txt:AQ).*(:AIRNOW:.*:ASCII)  key_groups=2,3
```

Key derivation is also separated into a method, so someone could subclass this plugin and change the after_accept.