### PR TITLE
Fix issue #1590: no log message for failed posts

### DIFF
--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -179,7 +179,6 @@ class Retry(FlowCB):
         to_retry = self.__filter_by_retry_count(worklist.failed)
 
         self.post_retry.put(to_retry)
-        worklist.failed=[]
 
     def metricsReport(self) -> dict:
         """Returns the number of messages in the download_retry and post_retry queues.


### PR DESCRIPTION
Implemented the fix suggested by @andreleblanc11 for issue #1590.

Because the retry.py plugin was resetting `worklist.failed = []` inside its own `after_post` callback, the `after_post` in log.py would never log its "failed to post..." message.

https://github.com/MetPX/sarracenia/blob/525741da0195ccea43a0deede830e5e0e8582b9b/sarracenia/flowcb/log.py#L193-L198

The `worklist.failed` list gets reset to `[]` at the end of the `post` method in `Flow`, so the extra reset in retry.py wasn't necessary and caused unexpected behaviour.