### PR TITLE
update to v7 tag for upload-artifact, should resolve nodejs20 warnings

### DIFF
--- a/.github/workflows/flow.yml
+++ b/.github/workflows/flow.yml
@@ -82,7 +82,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_amqp_consumer.yml
+++ b/.github/workflows/flow_amqp_consumer.yml
@@ -75,7 +75,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_mqtt.yml
+++ b/.github/workflows/flow_mqtt.yml
@@ -80,7 +80,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_multi.yml
+++ b/.github/workflows/flow_multi.yml
@@ -80,7 +80,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/flow_redis.yml
+++ b/.github/workflows/flow_redis.yml
@@ -81,7 +81,7 @@ jobs:
       
       - name: Save run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: sr3_${{ matrix.which_test }}_${{ matrix.osver }}_state_${{ github.sha }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -72,7 +72,7 @@ jobs:
       #     junitxml-title: Test Results
 
       - name: Upload pytest junit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: results-junit
           path: tests/junit/test-results.xml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ always() }}
       
       - name: Upload pytest HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: results-report
           path: tests/report.html
@@ -88,7 +88,7 @@ jobs:
         if: ${{ always() }}
       
       - name: Upload code coverage report (HTML)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: tests/coverage/html_report
@@ -96,7 +96,7 @@ jobs:
         if: ${{ always() }}
 
       - name: Upload code coverage report (LCOV)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: tests/coverage/coverage.lcov
@@ -104,7 +104,7 @@ jobs:
         if: ${{ always() }}
         
       - name: Upload code coverage report (XML)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-xml
           path: tests/coverage/coverage.xml


### PR DESCRIPTION
I think this will fix these warnings in the GitHub Actions.
<img width="2153" height="57" alt="image" src="https://github.com/user-attachments/assets/354a22a5-7057-4e17-be54-b2b643c3af2f" />

This is low priority, it can wait to be merged until after the release is finished.