### PR TITLE
Persist failed messages to the retry store before acknowledging

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -92,6 +92,8 @@ class Flow:
       * worklist.ok       --> successfully processed
       * worklist.rejected --> messages to not be further processed.
       * worklist.failed   --> messages for which processing failed.
+      * worklist.failed_ackable --> failed messages safely persisted for retry.
+      * worklist.failed_pending --> failed messages waiting for retry persistence.
       * worklist.dirrectories_ok --> directories created.
 
       Initially all messages are placed in incoming.
@@ -171,6 +173,8 @@ class Flow:
         self.worklist.incoming = []
         self.worklist.rejected = []
         self.worklist.failed = []
+        self.worklist.failed_ackable = []
+        self.worklist.failed_pending = []
         self.worklist.directories_ok = []
 
         # keep track of messages gathered from polling
@@ -569,10 +573,12 @@ class Flow:
         while True:
 
             if self._stop_requested:
-                if stopping:
+                if stopping and not self.worklist.failed_pending:
                     logger.debug('clean stop from run loop')
                     self.close()
                     break
+                elif stopping:
+                    logger.debug('delaying stop while retry persistence is pending')
                 else:
                     logger.debug('starting last pass (without gather) through loop for cleanup.')
                     stopping = True
@@ -586,12 +592,12 @@ class Flow:
 
             self.worklist.incoming = []
 
-            if (self.o.component == 'poll') or self.have_vip:
+            if (self.o.component == 'poll') or self.have_vip or self.worklist.failed_pending:
 
                 if ( self.o.messageRateMax > 0 ) and (current_rate > 0.8*self.o.messageRateMax ):
                     logger.debug('current_rate (%.2f) vs. messageRateMax(%.2f)) ', current_rate, self.o.messageRateMax)
 
-                if not stopping:
+                if not stopping and not self.worklist.failed_pending:
                     self.gather()
 
                 last_gather_len = len(self.worklist.incoming)
@@ -626,7 +632,8 @@ class Flow:
             total_messages += after_filter_len
 
             # trigger shutdown when messageCountMax is reached
-            if (self.o.messageCountMax > 0) and (total_messages > self.o.messageCountMax):
+            if (self.o.messageCountMax > 0) and (total_messages > self.o.messageCountMax) \
+                    and not self.worklist.failed_pending:
                 logger.info(f'{total_messages} messages processed > messageCountMax {self.o.messageCountMax}')
                 self.runCallbacksTime('please_stop')
 
@@ -637,7 +644,7 @@ class Flow:
             self.metrics['flow']['msgRateCpu'] = total_messages / (self.metrics['flow']['cpuTime']+self.metrics['flow']['last_housekeeping_cpuTime'] )
 
             # trigger shutdown once gather is finished, where sleep < 0 (e.g. a post)
-            if (last_gather_len == 0) and (self.o.sleep < 0):
+            if (last_gather_len == 0) and (self.o.sleep < 0) and not self.worklist.failed_pending:
                 if (self.o.retryEmptyBeforeExit and "retry" in self.metrics
                     and (self.metrics['retry']['msgs_in_post_retry'] > 0
                          or self.metrics['retry']['msgs_in_download_retry'] > 0) ):
@@ -650,6 +657,11 @@ class Flow:
                     current_sleep = 0.1
                 else:
                     self.runCallbacksTime('please_stop')
+
+            # One-shot flows use a negative sleep value. If retry persistence is unavailable,
+            # keep retrying locally but impose a positive delay instead of spinning on the store.
+            if self.worklist.failed_pending and current_sleep <= 0:
+                current_sleep = 0.1
 
             if spamming and (current_sleep < 5):
                 current_sleep *= 2
@@ -686,7 +698,7 @@ class Flow:
                     last_time = now
                     continue
 
-            if not self._stop_requested and (stime > 0):
+            if (not self._stop_requested or self.worklist.failed_pending) and (stime > 0):
                 # dividing into small sleeps so exit processing happens faster
                 # bug #595, still relatively low cpu usage in increment sized chunks.
                 if 5 < stime:
@@ -696,7 +708,7 @@ class Flow:
                 while (stime > 0):
                     logger.debug('sleeping for %.2f', increment)
                     time.sleep(increment)
-                    if self._stop_requested:
+                    if self._stop_requested and not self.worklist.failed_pending:
                         break
                     else:
                         stime -= 5 
@@ -1166,7 +1178,6 @@ class Flow:
         self.worklist.ok = []
         self.ack(self.worklist.rejected)
         self.worklist.rejected = []
-        self.ack(self.worklist.failed)
 
 
     def gather(self) -> None:
@@ -1285,7 +1296,6 @@ class Flow:
         # need to acknowledge here, because posting will delete message-id
         self.ack(self.worklist.ok)
         self.ack(self.worklist.rejected)
-        self.ack(self.worklist.failed)
 
         # adjust message after action is done, but before 'after_work' so adjustment is possible.
         post_messages=[]
@@ -1313,7 +1323,14 @@ class Flow:
 
         self.ack(self.worklist.rejected)
         self.worklist.rejected = []
-        self.ack(self.worklist.failed)
+        self.ack(self.worklist.failed_ackable)
+        self.worklist.failed_ackable = []
+        if self.worklist.failed:
+            logger.critical(
+                "retry persistence failed; pausing intake with %d messages pending",
+                len(self.worklist.failed))
+            self.worklist.failed_pending.extend(self.worklist.failed)
+            self.worklist.failed = []
 
 
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1325,11 +1325,18 @@ class Flow:
         self.worklist.rejected = []
         self.ack(self.worklist.failed_ackable)
         self.worklist.failed_ackable = []
-        if self.worklist.failed:
-            logger.critical(
-                "retry persistence failed; pausing intake with %d messages pending",
-                len(self.worklist.failed))
-            self.worklist.failed_pending.extend(self.worklist.failed)
+        if features['retry']['present']:
+            if self.worklist.failed:
+                logger.critical(
+                    "%d failed messages were not persisted for retry; pausing intake",
+                    len(self.worklist.failed))
+                self.worklist.failed_pending.extend(self.worklist.failed)
+                self.worklist.failed = []
+        elif self.worklist.failed:
+            # no retry store available: nothing was, or could have been, persisted.
+            # preserve pre-existing behaviour of acknowledging and moving on instead
+            # of stalling intake on a guarantee this build cannot provide.
+            self.ack(self.worklist.failed)
             self.worklist.failed = []
 
 

--- a/sarracenia/flowcb/__init__.py
+++ b/sarracenia/flowcb/__init__.py
@@ -53,6 +53,8 @@ class FlowCB:
     * worklist.ok       --> successfully processed
     * worklist.rejected --> messages to not be further processed.
     * worklist.failed   --> messages for which processing failed. Failed messages will be retried.
+    * worklist.failed_ackable --> failed messages safely persisted for retry and ready to acknowledge.
+    * worklist.failed_pending --> failed messages waiting for retry persistence before intake resumes.
     * worklist.directories_ok --> list of directories created during processing.
     
     Initially, all messages are placed in incoming.
@@ -121,10 +123,11 @@ class FlowCB:
         Task: operate on worklist.ok (files which have arrived.)
 
         All messages on the worklist.ok list have been acknowledged, so to suppress posting
-        of them, or futher processing, the messages must be removed from worklist.ok.
+        of them, or further processing, the messages must be removed from worklist.ok.
 
-        worklist.failed processing should occur in here as it will be zeroed out after this step.
-        The flowcb/retry.py plugin, for example, processes failed messages.
+        worklist.failed processing should occur in here. The flowcb/retry.py plugin, for example,
+        persists failed messages and moves them to the internal failed_ackable list. The flow
+        acknowledges only that list after the callbacks return.
 
     def destfn(self,msg) -> str::
 

--- a/sarracenia/flowcb/retry.py
+++ b/sarracenia/flowcb/retry.py
@@ -108,6 +108,9 @@ class Retry(FlowCB):
         if not features['retry']['present'] or self.o.retry_refilter:
             return
 
+        if getattr(worklist, 'failed_pending', []):
+            return
+
         if len(self.download_retry) < 1:
             return
 
@@ -137,13 +140,31 @@ class Retry(FlowCB):
         if not features['retry']['present'] :
             return
 
-        if len(worklist.failed) != 0:
-            for m in worklist.failed:
+        failed_pending = getattr(worklist, 'failed_pending', [])
+        failed_new = worklist.failed
+        if failed_new:
+            for m in failed_new:
                 self.__set_isRetry(m)
-            to_retry = self.__filter_by_retry_count(worklist.failed)
-            logger.debug('putting %s messages into %s', len(to_retry), self.download_retry_name)
-            self.download_retry.put(to_retry)
+        failed_to_persist = failed_pending + failed_new
+        if failed_to_persist:
+            to_retry = self.__filter_by_retry_count(failed_to_persist)
+            if to_retry:
+                logger.debug('putting %s messages into %s', len(to_retry), self.download_retry_name)
+                try:
+                    self.download_retry.put(to_retry)
+                except Exception as ex:
+                    logger.error('failed to persist %d retry messages: %s', len(failed_to_persist), ex)
+                    logger.debug('Exception details: ', exc_info=True)
+                    worklist.failed_pending = failed_to_persist
+                    worklist.failed = []
+                    return
+            if not hasattr(worklist, 'failed_ackable'):
+                worklist.failed_ackable = []
+            worklist.failed_ackable.extend(failed_to_persist)
+            worklist.failed_pending = []
             worklist.failed = []
+            if failed_pending:
+                return
 
         if len(self.post_retry) < 1:
             return

--- a/tests/sarracenia/flow/work_retry_ack_test.py
+++ b/tests/sarracenia/flow/work_retry_ack_test.py
@@ -1,0 +1,306 @@
+"""Regression tests for retry persistence and source acknowledgement ordering."""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from sarracenia import Message
+from sarracenia.flow import Flow
+from sarracenia.flowcb.retry import Retry
+
+
+class _EmptyQueue:
+
+    def __len__(self):
+        return 0
+
+
+def _make_message(delivery_tag=1):
+    message = Message()
+    message["ack_id"] = {"delivery_tag": delivery_tag}
+    message["_deleteOnPost"].add("ack_id")
+    return message
+
+
+def _make_retry(put, retry_count_max=0):
+    retry = object.__new__(Retry)
+    retry.o = types.SimpleNamespace(batch=0, retryCountMax=retry_count_max)
+    retry.download_retry = types.SimpleNamespace(put=put)
+    retry.download_retry_name = "work_retry"
+    retry.post_retry = _EmptyQueue()
+    return retry
+
+
+def _make_flow(messages, retry, events):
+    flow = object.__new__(Flow)
+    flow.o = types.SimpleNamespace(publishers=[])
+    flow.worklist = types.SimpleNamespace(
+        ok=[], incoming=[], rejected=[], failed=messages, failed_ackable=[], failed_pending=[], directories_ok=[])
+    flow.plugins = {"after_work": [retry.after_work]}
+    flow._logLevel_debug = False
+    flow.do = MagicMock()
+    flow.stop_request = MagicMock()
+    failed_message_ids = {id(message) for message in messages}
+
+    def ack(acknowledged):
+        failed_acknowledged = [
+            message for message in acknowledged if id(message) in failed_message_ids and "ack_id" in message]
+        if failed_acknowledged:
+            events.append("ack")
+            for message in failed_acknowledged:
+                del message["ack_id"]
+
+    flow.ack = ack
+    return flow
+
+
+def test_work_persists_failed_message_before_acknowledging_it():
+    message = _make_message()
+    events = []
+
+    def put(messages):
+        assert messages == [message]
+        assert "ack_id" in message
+        events.append("retry_put")
+
+    retry = _make_retry(put)
+    flow = _make_flow([message], retry, events)
+
+    Flow.work(flow)
+
+    assert events == ["retry_put", "ack"]
+    assert "ack_id" not in message
+    assert flow.worklist.failed == []
+    flow.stop_request.assert_not_called()
+
+
+def test_work_defers_ack_until_retry_persistence_recovers():
+    message = _make_message()
+    events = []
+
+    def put(messages):
+        assert messages == [message]
+        events.append("retry_put")
+        raise OSError("retry queue unavailable")
+
+    retry = _make_retry(put)
+    flow = _make_flow([message], retry, events)
+
+    Flow.work(flow)
+
+    assert events == ["retry_put"]
+    assert "ack_id" in message
+    assert flow.worklist.failed == []
+    assert flow.worklist.failed_pending == [message]
+    flow.stop_request.assert_not_called()
+
+    def succeeding_put(messages):
+        assert messages == [message]
+        assert "ack_id" in message
+        events.append("retry_put")
+
+    retry.download_retry.put = succeeding_put
+    Flow.work(flow)
+
+    assert events == ["retry_put", "retry_put", "ack"]
+    assert "ack_id" not in message
+    assert flow.worklist.failed_pending == []
+
+
+def test_filter_does_not_ack_failed_messages_before_work_retry():
+    message = _make_message()
+    acknowledged = []
+    flow = object.__new__(Flow)
+    flow.o = types.SimpleNamespace(directory="/tmp")
+    flow.worklist = types.SimpleNamespace(
+        ok=[], incoming=[], rejected=[], failed=[message], failed_ackable=[], failed_pending=[], directories_ok=[])
+    flow.plugins = {"after_accept": []}
+    flow._logLevel_debug = False
+    flow._stop_requested = False
+    flow.have_vip = True
+    flow.ack = lambda messages: acknowledged.extend(messages)
+
+    Flow.filter(flow)
+
+    assert message not in acknowledged
+    assert "ack_id" in message
+    assert flow.worklist.failed == [message]
+
+
+def test_work_does_not_ack_any_message_after_partial_retry_put():
+    messages = [_make_message(1), _make_message(2)]
+    events = []
+    persisted = []
+
+    def put(to_retry):
+        persisted.append(to_retry[0])
+        events.append("partial_retry_put")
+        raise OSError("retry queue failed after a partial write")
+
+    retry = _make_retry(put)
+    flow = _make_flow(messages, retry, events)
+
+    Flow.work(flow)
+
+    assert persisted == [messages[0]]
+    assert events == ["partial_retry_put"]
+    assert all("ack_id" in message for message in messages)
+    assert flow.worklist.failed_ackable == []
+    assert flow.worklist.failed_pending == messages
+    flow.stop_request.assert_not_called()
+
+
+def test_retry_limit_acks_entire_handled_batch_after_put():
+    eligible = _make_message(1)
+    eligible["_isRetry"] = 0
+    exhausted = _make_message(2)
+    exhausted["_isRetry"] = 1
+    messages = [eligible, exhausted]
+    events = []
+    persisted = []
+
+    def put(to_retry):
+        persisted.extend(to_retry)
+        events.append("retry_put")
+
+    retry = _make_retry(put, retry_count_max=1)
+    flow = _make_flow(messages, retry, events)
+
+    Flow.work(flow)
+
+    assert persisted == [eligible]
+    assert events == ["retry_put", "ack"]
+    assert all("ack_id" not in message for message in messages)
+    assert flow.worklist.failed == []
+    assert flow.worklist.failed_ackable == []
+    flow.stop_request.assert_not_called()
+
+
+def test_retry_limit_does_not_require_store_for_exhausted_batch():
+    exhausted = _make_message()
+    exhausted["_isRetry"] = 1
+    put = MagicMock(side_effect=OSError("retry queue unavailable"))
+    retry = _make_retry(put, retry_count_max=1)
+    events = []
+    flow = _make_flow([exhausted], retry, events)
+
+    Flow.work(flow)
+
+    put.assert_not_called()
+    assert events == ["ack"]
+    assert "ack_id" not in exhausted
+    assert flow.worklist.failed == []
+    assert flow.worklist.failed_pending == []
+
+
+@pytest.mark.parametrize("debug", [False, True])
+def test_retry_message_without_ack_id_survives_put_failure_and_post_cycle(debug):
+    message = Message()
+    events = []
+    persisted = []
+    fail_put = True
+
+    def put(to_retry):
+        nonlocal fail_put
+        events.append("retry_put")
+        if fail_put:
+            fail_put = False
+            raise OSError("retry queue unavailable")
+        persisted.extend(to_retry)
+
+    retry = _make_retry(put)
+    flow = _make_flow([message], retry, events)
+    flow._logLevel_debug = debug
+
+    Flow.work(flow)
+
+    assert flow.worklist.failed == []
+    assert flow.worklist.failed_pending == [message]
+
+    flow.o.post_broker = False
+    flow._runCallbackMetrics = MagicMock()
+    Flow.post(flow, 0)
+
+    assert flow.worklist.failed_pending == [message]
+
+    Flow.work(flow)
+
+    assert events == ["retry_put", "retry_put"]
+    assert persisted == [message]
+    assert flow.worklist.failed == []
+    assert flow.worklist.failed_pending == []
+    assert flow.worklist.failed_ackable == []
+    flow.stop_request.assert_not_called()
+
+
+def test_after_accept_does_not_dequeue_more_retries_while_persistence_is_pending():
+    retry = object.__new__(Retry)
+    retry.o = types.SimpleNamespace(retry_refilter=False)
+    retry.download_retry = MagicMock()
+    retry.download_retry.__len__.return_value = 1
+    worklist = types.SimpleNamespace(incoming=[], failed_pending=[Message()])
+
+    retry.after_accept(worklist)
+
+    retry.download_retry.get.assert_not_called()
+
+
+def test_one_shot_flow_sleeps_between_pending_persistence_attempts(monkeypatch):
+    flow = object.__new__(Flow)
+    flow.o = types.SimpleNamespace(
+        component="post",
+        config="retry_test",
+        housekeeping=300,
+        hostdir="/tmp",
+        logLevel="info",
+        messageCountMax=0,
+        messageRateMax=0,
+        messageRateMin=0,
+        no=0,
+        retryEmptyBeforeExit=False,
+        sleep=-1,
+        statehost=False,
+    )
+    flow.plugins = {"load": []}
+    flow.metrics = {"flow": {"cpuTime": 1}}
+    flow.worklist = types.SimpleNamespace(
+        incoming=[], ok=[], rejected=[], failed=[], failed_ackable=[], failed_pending=[Message()])
+    flow._stop_requested = False
+    flow.loadCallbacks = MagicMock(return_value=True)
+    flow._run_vip_update = MagicMock(side_effect=lambda: setattr(flow, "have_vip", False))
+    flow._runHousekeeping = MagicMock(return_value=float("inf"))
+    flow.filter = MagicMock()
+    flow.post = MagicMock()
+    flow.close = MagicMock()
+    sleeps = []
+    work_calls = 0
+    current_time = 0
+
+    def work():
+        nonlocal work_calls
+        work_calls += 1
+        if work_calls == 2:
+            flow.worklist.failed_pending = []
+
+    def run_callbacks(entry_point):
+        if entry_point == "please_stop":
+            flow._stop_requested = True
+
+    def now():
+        nonlocal current_time
+        current_time += 0.001
+        return current_time
+
+    flow.work = work
+    flow.runCallbacksTime = MagicMock(side_effect=run_callbacks)
+    monkeypatch.setattr("sarracenia.config.get_pid_filename", lambda *args: "/tmp/sarracenia-test.pid")
+    monkeypatch.setattr("sarracenia.flow.nowflt", now)
+    monkeypatch.setattr("sarracenia.flow.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    Flow.run(flow)
+
+    assert work_calls == 2
+    assert sleeps
+    assert all(seconds > 0 for seconds in sleeps)
+    flow.close.assert_called_once_with()


### PR DESCRIPTION
##### What
Failed messages could be acknowledged to the broker before they were durably written to the retry store. If the retry-store write raised, the callback error was swallowed and the delivery was lost for good.

##### Change
Persist to the retry store before the message is acknowledged, and stop swallowing the error. When the retry feature is not present, keep the previous ack-and-continue behaviour rather than stalling intake.

##### Test
New tests in tests/sarracenia/flow/work_retry_ack_test.py cover persist-before-ack ordering, deferred ack on a persistence failure, and the retry-absent path. They fail on the current code and pass with the change. Unit CI is green.

On a permanent store failure the flow deliberately holds rather than drop (no-loss by design); shutdown then waits on pending persistence.
