### PR TITLE
Roll back DiskQueue consolidation on failure instead of deleting state

### DIFF
--- a/sarracenia/diskqueue.py
+++ b/sarracenia/diskqueue.py
@@ -390,9 +390,31 @@ class DiskQueue():
 
         self.now = sarracenia.nowflt()
         self.retry_cache = {}
+        previous_msg_count = self.msg_count
+        previous_msg_count_new = self.msg_count_new
         N = 0
+        fp = None
 
-        # put this in try/except in case ctrl-c breaks something
+        def rollback():
+            try:
+                if fp is not None:
+                    fp.close()
+            except Exception:
+                pass
+            try:
+                if self.housekeeping_fp is not None:
+                    self.housekeeping_fp.close()
+            except Exception:
+                pass
+
+            self.housekeeping_fp = None
+            try:
+                os.unlink(self.housekeeping_path)
+            except Exception:
+                pass
+
+            self.msg_count = previous_msg_count
+            self.msg_count_new = previous_msg_count_new
 
         try:
             self.close()
@@ -400,14 +422,11 @@ class DiskQueue():
                 os.unlink(self.housekeeping_path)
             except Exception:
                 pass
-            fp = open(self.housekeeping_path, 'w')
-            fp.close()
 
             i = 0
             last = None
 
-            fp = self.queue_fp
-            self.housekeeping_fp = open(self.housekeeping_path, 'a')
+            self.housekeeping_fp = open(self.housekeeping_path, 'w')
 
             logger.debug('has queue %s', os.path.isfile(self.queue_file))
 
@@ -448,36 +467,40 @@ class DiskQueue():
             logger.debug('retrieved %d from the %d retry', N - j, i)
 
             self.housekeeping_fp.close()
+            self.housekeeping_fp = None
 
-        except Exception as Err:
-            logger.error("something went wrong")
-            logger.debug('Exception details: ', exc_info=True)
+            if N == 0:
+                try:
+                    os.unlink(self.housekeeping_path)
+                except Exception:
+                    pass
+            else:
+                os.replace(self.housekeeping_path, self.queue_file)
 
-        # no more retry
+        except (KeyboardInterrupt, SystemExit):
+            rollback()
+            raise
+        except Exception as err:
+            rollback()
+            logger.error("could not consolidate %s retry queue: %s", self.name, err)
+            logger.debug('Exception details:', exc_info=True)
+            return
 
         self.msg_count = N
         if N == 0:
             logger.debug('%s No retry in list', self.name)
-            try:
-                os.unlink(self.housekeeping_path)
-            except Exception:
-                pass
-
-        # housekeeping file becomes new retry
-
         else:
             logger.info( f"{self.name} Number of messages in retry list {N:d}" )
-            try:
-                os.rename(self.housekeeping_path, self.queue_file)
-            except Exception:
-                logger.error("Something went wrong with rename")
 
-        # cleanup
-        self.msg_count_new = 0
+        self.msg_count_new = previous_msg_count_new
         try:
             os.unlink(self.new_path)
-        except Exception:
-            pass
+        except FileNotFoundError:
+            self.msg_count_new = 0
+        except OSError as err:
+            logger.error("could not remove consolidated %s retry input: %s", self.name, err)
+        else:
+            self.msg_count_new = 0
 
         elapse = sarracenia.nowflt() - self.now
         logger.debug('on_housekeeping elapse %f', elapse)

--- a/tests/sarracenia/diskqueue_test.py
+++ b/tests/sarracenia/diskqueue_test.py
@@ -302,6 +302,125 @@ def test_on_housekeeping(tmp_path, caplog):
     assert log_found_NumMessages == True
     assert log_found_Elapsed == True
 
+
+def test_on_housekeeping__partial_failure_preserves_new(tmp_path):
+    options = Options()
+    options.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(options, 'test_housekeeping_partial_failure')
+
+    m1 = make_message()
+    m2 = make_message()
+    m2['pubTime'] = "20200118151049.356378078"
+    dq.put([m1, m2])
+
+    with open(dq.new_path, 'rb') as source:
+        original_new = source.read()
+
+    original_msg_to_json = dq.msgToJSON
+    calls = 0
+
+    def fail_on_second_message(message):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected partial consolidation failure")
+        return original_msg_to_json(message)
+
+    with patch.object(dq, 'msgToJSON', side_effect=fail_on_second_message):
+        dq.on_housekeeping()
+
+    assert dq.msg_count == 0
+    assert dq.msg_count_new == 2
+    assert len(dq) == 2
+    assert os.path.isfile(dq.new_path)
+    assert not os.path.exists(dq.queue_file)
+    assert not os.path.exists(dq.housekeeping_path)
+    assert dq.housekeeping_fp is None
+
+    with open(dq.new_path, 'rb') as source:
+        assert source.read() == original_new
+
+    dq.on_housekeeping()
+    assert dq.msg_count == 2
+    assert dq.msg_count_new == 0
+    assert dq.get(2) == [m1, m2]
+
+
+def test_on_housekeeping__replace_failure_preserves_new(tmp_path):
+    options = Options()
+    options.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(options, 'test_housekeeping_replace_failure')
+
+    message = make_message()
+    dq.put([message])
+
+    with open(dq.new_path, 'rb') as source:
+        original_new = source.read()
+
+    with patch('sarracenia.diskqueue.os.replace',
+               side_effect=OSError("injected replace failure")):
+        dq.on_housekeeping()
+
+    assert dq.msg_count == 0
+    assert dq.msg_count_new == 1
+    assert len(dq) == 1
+    assert os.path.isfile(dq.new_path)
+    assert not os.path.exists(dq.queue_file)
+    assert not os.path.exists(dq.housekeeping_path)
+    assert dq.housekeeping_fp is None
+
+    with open(dq.new_path, 'rb') as source:
+        assert source.read() == original_new
+
+    dq.on_housekeeping()
+    assert dq.get() == [message]
+
+
+@pytest.mark.parametrize('exception_type', [KeyboardInterrupt, SystemExit])
+def test_on_housekeeping__control_exception_rolls_back(tmp_path, exception_type):
+    options = Options()
+    options.pid_filename = str(tmp_path) + os.sep + "pidfilename.txt"
+    dq = DiskQueue(options, 'test_housekeeping_control_exception')
+
+    m1 = make_message()
+    m2 = make_message()
+    m2['pubTime'] = "20200118151049.356378078"
+    dq.put([m1, m2])
+
+    with open(dq.new_path, 'rb') as source:
+        original_new = source.read()
+
+    original_msg_to_json = dq.msgToJSON
+    calls = 0
+
+    def interrupt_second_message(message):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise exception_type()
+        return original_msg_to_json(message)
+
+    with pytest.raises(exception_type):
+        with patch.object(dq, 'msgToJSON', side_effect=interrupt_second_message):
+            dq.on_housekeeping()
+
+    assert dq.msg_count == 0
+    assert dq.msg_count_new == 2
+    assert len(dq) == 2
+    assert dq.housekeeping_fp is None
+    assert dq.new_fp is None
+    assert dq.queue_fp is None
+    assert os.path.isfile(dq.new_path)
+    assert not os.path.exists(dq.queue_file)
+    assert not os.path.exists(dq.housekeeping_path)
+
+    with open(dq.new_path, 'rb') as source:
+        assert source.read() == original_new
+
+    dq.on_housekeeping()
+    assert dq.get(2) == [m1, m2]
+
+
 def test_diskqueue(tmp_path, caplog):
     """ DiskQueue integration test, tests the behaviour of the class, mimicking how it's actually used in sr3.
     """
@@ -533,4 +652,3 @@ def test_msg_get_from_file__all_corrupted(tmp_path):
 
     assert fp_out is None
     assert msg is None
-


### PR DESCRIPTION
##### What
During housekeeping consolidation, an I/O error could delete the .new file and the main queue and reset the count to zero, discarding already-acknowledged retries.

##### Change
Write the consolidated result to a temp file, atomically replace the queue file, then remove .new. On any error, roll back (restore the counts, remove the temp) before the .new deletion, so nothing is lost.

##### Test
New tests assert the queue and counts survive an injected consolidation error and that the messages are recoverable afterward. They fail on the current code and pass with the change. Unit CI is green.
