### PR TITLE
Stop block reassembly from spinning forever on a short read

### DIFF
--- a/sarracenia/flowcb/block_reassembly.py
+++ b/sarracenia/flowcb/block_reassembly.py
@@ -208,8 +208,13 @@ class Block_reassembly(FlowCB):
             # copy data from block partition file into final destination.
             sz=self.o.bufSize if self.o.bufSize > byteCount else byteCount
             bytesTransferred=0
-            while bytesTransferred < byteCount: 
+            short_block = False
+            while bytesTransferred < byteCount:
                 b = pf.read(sz)
+                if not b:
+                    logger.error("block %s ended after %s of %s bytes", part_file, bytesTransferred, byteCount)
+                    short_block = True
+                    break
                 rf.write(b)
                 bytesTransferred += len(b)
                 bytesLeft = byteCount - bytesTransferred
@@ -217,6 +222,11 @@ class Block_reassembly(FlowCB):
 
             rf.close()
             pf.close()
+
+            if short_block:
+                worklist.failed.append(m)
+                flck.unlock()
+                continue
 
             # assert: block data is now in main file, so delete block
             os.unlink(part_file)

--- a/tests/sarracenia/flowcb/block_reassembly_test.py
+++ b/tests/sarracenia/flowcb/block_reassembly_test.py
@@ -1,6 +1,52 @@
 import pytest
 from tests.conftest import *
-#from unittest.mock import Mock
+from datetime import timedelta
+from unittest.mock import patch
+
+import flufl.lock
 
 import sarracenia.config
 import sarracenia.flowcb.block_reassembly
+
+
+class TestMessage(dict):
+
+    def setReport(self, code, message):
+        self.report = (code, message)
+
+
+def test_short_block_fails_without_holding_reassembly_lock(tmp_path):
+    options = sarracenia.config.default_config()
+    options.inflight = None
+    options.bufSize = 2
+    callback = sarracenia.flowcb.block_reassembly.Block_reassembly(options)
+    part_name = 'result§block_0,4_§'
+    part_path = tmp_path / part_name
+    part_path.write_bytes(b'ab')
+    message = TestMessage({
+        'blocks': {
+            'manifest': {0: {'size': 4}},
+            'number': 0,
+            'size': 4,
+        },
+        'new_dir': str(tmp_path),
+        'new_file': part_name,
+        'relPath': part_name,
+    })
+    worklist = type('Worklist', (), {
+        'ok': [message],
+        'failed': [],
+        'rejected': [],
+    })()
+
+    with patch('sarracenia.flowcb.block_reassembly.humanfriendly.parse_size', return_value=4):
+        callback.after_work(worklist)
+
+    assert worklist.ok == []
+    assert worklist.failed == [message]
+    assert worklist.rejected == []
+    assert part_path.read_bytes() == b'ab'
+
+    lock = flufl.lock.Lock(str(tmp_path / 'result.flufl_lock'))
+    lock.lock(timeout=timedelta(seconds=1))
+    lock.unlock()


### PR DESCRIPTION
##### What
On a short or EOF read, bytesTransferred did not advance, so the loop spun forever while holding the reassembly lock; the subprocess and .flufl_lock stayed alive until killed.

##### Change
Break on a short read, route the message to failed, retain the part file for retry, and release the lock. The manifest is not marked complete, so the file is never treated as done.

##### Test
A new regression test reproduces the EOF spin (it times out on the current code) and confirms the lock is released with the change. Unit CI is green.
