### PR TITLE
Settle poison AMQP deliveries so the consumer does not stall

### DIFF
--- a/sarracenia/moth/amqp.py
+++ b/sarracenia/moth/amqp.py
@@ -129,7 +129,13 @@ class AMQP(Moth):
             else:
                 content_type = None
 
-            msg = PostFormat.importAny( body, raw_msg.headers, content_type, self.o )
+            try:
+                msg = PostFormat.importAny(body, raw_msg.headers, content_type, self.o)
+            except Exception as err:
+                logger.error('Decode failed, discarding message: %s', err)
+                logger.debug('Exception details: ', exc_info=True)
+                self.channel.basic_ack(raw_msg.delivery_info['delivery_tag'])
+                return None
             if not msg:
                 logger.error('Decode failed, discarding message')
                 self.channel.basic_ack( raw_msg.delivery_info['delivery_tag'])

--- a/tests/sarracenia/moth/amqp_test.py
+++ b/tests/sarracenia/moth/amqp_test.py
@@ -1,10 +1,34 @@
-import pytest
-from tests.conftest import *
-from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-import sarracenia.config
-import sarracenia.moth
 import sarracenia.moth.amqp
+
+
+def malformed_json_delivery(channel):
+    return SimpleNamespace(
+        body=b'1',
+        properties={'content_type': 'application/json'},
+        headers={},
+        delivery_info={'delivery_tag': 41, 'routing_key': 'v03.post.test', 'exchange': 'xpublic'},
+        channel=channel,
+    )
+
+
+def test_getNewMessage_acknowledges_decoder_exception():
+    props = {
+        'broker': MagicMock(),
+        'subscriptions': [{'queue': {'name': 'q_test'}}],
+        'subscription_index': 0,
+        'message_strategy': {'stubborn': False},
+    }
+    moth = sarracenia.moth.amqp.AMQP(props, is_subscriber=True)
+    moth.connection = SimpleNamespace(connected=True)
+    moth.channel = MagicMock()
+    moth.channel.basic_get.return_value = malformed_json_delivery(moth.channel)
+
+    assert moth.getNewMessage() is None
+    moth.channel.basic_ack.assert_called_once_with(41)
+    assert moth.metrics['rxBadCount'] == 1
 
 
 class Test_AMQPDefaultOptions:

--- a/tests/sarracenia/moth/amqpconsumer_test.py
+++ b/tests/sarracenia/moth/amqpconsumer_test.py
@@ -1,6 +1,30 @@
-import pytest
-from tests.conftest import *
-#from unittest.mock import Mock
+import queue
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
-import sarracenia.config
 import sarracenia.moth.amqpconsumer
+
+
+def test_getNewMessage_acknowledges_decoder_exception():
+    props = {
+        'broker': MagicMock(),
+        'subscriptions': [{'queue': {'name': 'q_test'}}],
+        'subscription_index': 0,
+        'message_strategy': {'stubborn': False},
+    }
+    moth = sarracenia.moth.amqpconsumer.AMQPConsumer(props, is_subscriber=True)
+    moth.connection = MagicMock(connected=True)
+    moth.channel = MagicMock()
+    moth._raw_msg_q = queue.Queue()
+    raw_message = SimpleNamespace(
+        body=b'1',
+        properties={'content_type': 'application/json'},
+        headers={},
+        delivery_info={'delivery_tag': 42, 'routing_key': 'v03.post.test', 'exchange': 'xpublic'},
+        channel=moth.channel,
+    )
+    moth._raw_msg_q.put(raw_message)
+
+    assert moth.getNewMessage() is None
+    moth.channel.basic_ack.assert_called_once_with(42)
+    assert moth.metrics['rxBadCount'] == 1


### PR DESCRIPTION
##### What
An AMQP delivery that failed to decode (for example a scalar JSON value) returned without being settled, so it consumed prefetch and was redelivered forever on reconnect.

##### Change
On a decode failure, log and acknowledge the poison delivery so prefetch is freed. The fix lives in the shared _msgRawToDict, so it covers both the AMQP and AMQPConsumer paths, with no double-ack.

##### Test
New tests feed real scalar-JSON poison and assert exactly one ack plus a bumped bad counter. Unit CI is green.
