### PR TITLE
Do not silently drop a v2 on_file False message

### DIFF
--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -345,10 +345,7 @@ class V2Wrapper(FlowCB):
             if self.run_entry('on_file', m):
                 ok_to_post.append(m)
             else:
-                #worklist.failed.append(m)
-                pass
-                # FIXME: what should we do on failure of on_file plugin?
-                #     download worked, but on_file failed... hmm...
+                worklist.failed.append(m)
 
         worklist.ok = ok_to_post
 

--- a/tests/sarracenia/flowcb/v2wrapper_test.py
+++ b/tests/sarracenia/flowcb/v2wrapper_test.py
@@ -4,3 +4,28 @@ from tests.conftest import *
 
 import sarracenia.config
 import sarracenia.flowcb.v2wrapper
+
+
+def test_after_work_routes_on_file_failures_to_retry():
+    wrapper = object.__new__(sarracenia.flowcb.v2wrapper.V2Wrapper)
+    accepted = object()
+    failed = object()
+    rejected_on_post = object()
+    worklist = type('Worklist', (), {
+        'ok': [accepted, failed, rejected_on_post],
+        'failed': [],
+        'rejected': [],
+    })()
+
+    def run_entry(entry_point, message):
+        if entry_point == 'on_file':
+            return message is not failed
+        return message is not rejected_on_post
+
+    wrapper.run_entry = run_entry
+
+    wrapper.after_work(worklist)
+
+    assert worklist.ok == [accepted]
+    assert worklist.failed == [failed]
+    assert worklist.rejected == [rejected_on_post]


### PR DESCRIPTION
##### What
In the v2 wrapper, on_file returning False removed an already-acknowledged message from the ok list without adding it to failed or rejected, so it vanished with no record.

##### Change
Route the message to failed so it is logged, reported, and handled instead of dropped. Acknowledgement stays idempotent (no double-ack).

##### Test
A new test asserts the message lands in failed. It fails on the current code and passes with the change. Unit CI is green.

Automatic re-processing still requires post_broker to be configured; without it the change stops the silent drop but does not re-queue.
