### PR TITLE
Read ordinary file downloads through EOF instead of the announced length

### DIFF
--- a/sarracenia/transfer/file.py
+++ b/sarracenia/transfer/file.py
@@ -132,7 +132,7 @@ class File(Transfer):
             if self.sumalgo: self.sumalgo.set_path(remote_file)
 
             # download
-            rw_length = self.read_write(src, dst, length)
+            rw_length = self.read_write(src, dst, length if exactLength else 0)
         finally:
             self.local_read_close(src)
             self.local_write_close(dst)

--- a/tests/sarracenia/transfer/transfer_file_test.py
+++ b/tests/sarracenia/transfer/transfer_file_test.py
@@ -83,6 +83,34 @@ def test_get_closes_handles_on_read_error():
         # this would eventually fail under a low ulimit.
 
 
+@pytest.mark.parametrize(
+    'exact_length, expected',
+    [
+        (False, b'0123456789'),
+        (True, b'012'),
+    ],
+)
+def test_get_only_limits_exact_length_transfers(tmp_path, exact_length, expected):
+    options = make_options()
+    xfer = File('file', options)
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    (source_dir / 'data').write_bytes(b'0123456789')
+    destination = tmp_path / 'destination'
+    xfer.cwd = str(source_dir)
+
+    transferred = xfer.get(
+        sarracenia.Message(),
+        'data',
+        str(destination),
+        length=3,
+        exactLength=exact_length,
+    )
+
+    assert transferred == len(expected)
+    assert destination.read_bytes() == expected
+
+
 def test_get_no_fd_leak_over_many_transfers():
     """Transfer many files via file:// and verify no fd accumulation.
 


### PR DESCRIPTION
##### What
File.get truncated ordinary downloads to the announced length. A 10-byte source announced as 3 returned only 3 bytes, which the flow could accept as complete.

##### Change
Read the whole file when exactLength is not set, and keep honouring the length for genuine ranged/multipart blocks (remote_offset is only nonzero when exactLength is true). This mirrors the existing read_writelocal behaviour.

##### Test
A new parametrized test covers the full-file and ranged cases. It fails on the current code and passes with the change. Unit CI is green.
