### PR TITLE
Do not truncate an existing SFTP target on a transient stat error

### DIFF
--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -21,6 +21,7 @@
 #
 #
 
+import errno
 import logging, paramiko, os, sys, time
 from paramiko import *
 from stat import *
@@ -502,7 +503,9 @@ class Sftp(Transfer):
            else:
                try:
                    self.sftp.stat(remote_file)
-               except:
+               except OSError as ex:
+                   if not isinstance(ex, FileNotFoundError) and ex.errno != errno.ENOENT:
+                       raise
                    rfp = self.sftp.file(remote_file, 'wb', bufSize)
                    rfp.close()
 

--- a/tests/sarracenia/transfer/sftp_test.py
+++ b/tests/sarracenia/transfer/sftp_test.py
@@ -94,7 +94,7 @@ class Test_SftpConnectCleanup:
             m.close.assert_called_once()
 
 
-class TestSftpMultipartPut:
+class Test_SftpMultipartPut:
 
     @staticmethod
     def make_transfer():

--- a/tests/sarracenia/transfer/sftp_test.py
+++ b/tests/sarracenia/transfer/sftp_test.py
@@ -1,7 +1,9 @@
-import pytest
-from unittest.mock import patch, MagicMock
-
+import errno
 import logging
+from types import SimpleNamespace
+from unittest.mock import call, patch, MagicMock
+
+import pytest
 
 import sarracenia
 import sarracenia.config
@@ -90,3 +92,49 @@ class Test_SftpConnectCleanup:
 
         for m in mock_ssh_instances:
             m.close.assert_called_once()
+
+
+class TestSftpMultipartPut:
+
+    @staticmethod
+    def make_transfer():
+        transfer = Sftp.__new__(Sftp)
+        transfer.o = SimpleNamespace(timeout=5, bufSize=8192, nofsetstat=False)
+        transfer.sftp = MagicMock()
+        transfer.compat_mode = False
+        transfer.readlocal_write = MagicMock(return_value=4)
+        return transfer
+
+    @patch('sarracenia.transfer.sftp.alarm_cancel')
+    @patch('sarracenia.transfer.sftp.alarm_set')
+    def test_transient_stat_failure_does_not_open_target(self, _alarm_set, _alarm_cancel):
+        transfer = self.make_transfer()
+        transient_error = OSError(errno.EIO, 'temporary server failure')
+        transfer.sftp.stat.side_effect = transient_error
+
+        with pytest.raises(OSError) as raised:
+            transfer.put({}, 'part.bin', 'target.bin', remote_offset=4, length=4)
+
+        assert raised.value is transient_error
+        transfer.sftp.file.assert_not_called()
+        transfer.readlocal_write.assert_not_called()
+
+    @patch('sarracenia.transfer.sftp.alarm_cancel')
+    @patch('sarracenia.transfer.sftp.alarm_set')
+    def test_missing_target_is_created_before_multipart_update(self, _alarm_set, _alarm_cancel):
+        transfer = self.make_transfer()
+        transfer.sftp.stat.side_effect = FileNotFoundError(errno.ENOENT, 'missing')
+        create_handle = MagicMock()
+        update_handle = MagicMock()
+        transfer.sftp.file.side_effect = [create_handle, update_handle]
+
+        written = transfer.put({}, 'part.bin', 'target.bin', remote_offset=4, length=4)
+
+        assert written == 4
+        assert transfer.sftp.file.call_args_list == [
+            call('target.bin', 'wb', 8192),
+            call('target.bin', 'r+b', 8192),
+        ]
+        create_handle.close.assert_called_once_with()
+        update_handle.seek.assert_called_once_with(4, 0)
+        transfer.readlocal_write.assert_called_once_with('part.bin', 0, 4, update_handle)


### PR DESCRIPTION
##### What
In the multipart put path, any stat exception was treated as the target being absent and the file was opened with wb, so a transient stat error truncated an existing target.

##### Change
Only treat FileNotFoundError or ENOENT as absence; re-raise other stat errors instead of truncating. First-block creation still works.

##### Test
New tests cover the transient-stat and first-block cases. They fail on the current code and pass with the change. Unit CI is green.
