### PR TITLE
Accept comma-separated to_clusters destinations

### DIFF
--- a/sarracenia/flowcb/accept/toclusters.py
+++ b/sarracenia/flowcb/accept/toclusters.py
@@ -38,7 +38,8 @@ class ToClusters(FlowCB):
     def after_accept(self, worklist):
         new_incoming = []
         for message in worklist.incoming:
-            if message['to_clusters'] in self.o.msgToClusters:
+            destinations = [destination.strip() for destination in message['to_clusters'].split(',')]
+            if any(destination in self.o.msgToClusters for destination in destinations):
                 new_incoming.append(message)
             else:
                 worklist.rejected.append(message)

--- a/tests/sarracenia/flowcb/accept/toclusters_test.py
+++ b/tests/sarracenia/flowcb/accept/toclusters_test.py
@@ -45,9 +45,15 @@ def test_after_accept(caplog):
     toclusters = ToClusters(options)
 
     worklist = make_worklist()
-    worklist.incoming = [make_message('GoodCluster'), make_message('AnotherGoodCluster'), make_message('BadCluster')]
+    worklist.incoming = [
+        make_message('GoodCluster'),
+        make_message('BadCluster, AnotherGoodCluster, ThirdCluster'),
+        make_message('BadCluster,ThirdCluster')
+    ]
 
     toclusters.after_accept(worklist)
 
     assert len(worklist.incoming) == 2
     assert len(worklist.rejected) == 1
+    assert worklist.incoming[1]['to_clusters'] == 'BadCluster, AnotherGoodCluster, ThirdCluster'
+    assert worklist.rejected[0]['to_clusters'] == 'BadCluster,ThirdCluster'


### PR DESCRIPTION
##### What
The toclusters accept callback compared the whole comma-joined to_clusters value as one string, so a permitted destination such as DD in "DD,DDI.CMC,DDI.EDM" was discarded and acknowledged.

##### Change
Split to_clusters on commas, strip each token, and accept if any token matches the configured clusters.

##### Test
New tests cover single, mixed, and whitespaced destination lists. They fail on the current code and pass with the change. Unit CI is green.
