### PR TITLE
Key post retries by publisher identity so reconfiguration cannot misroute

### DIFF
--- a/sarracenia/flowcb/post/message.py
+++ b/sarracenia/flowcb/post/message.py
@@ -37,6 +37,30 @@ class Message(FlowCB):
         #else:
         #    logger.error( f"no publishers for {self.o.component}/{self.o.config}")
 
+    @staticmethod
+    def _publisher_identity(publisher):
+        identity = {}
+        for key in ['broker', 'exchange', 'topicPrefix', 'format']:
+            if key in publisher:
+                identity[key] = str(publisher[key]) if key == 'broker' else copy.deepcopy(publisher[key])
+        return identity
+
+    def _publisher_index(self, message):
+        retry_identity = message.get('publisher_identity')
+        if retry_identity is not None:
+            for index, publisher in enumerate(self.o.publishers):
+                if retry_identity == self._publisher_identity(publisher):
+                    message['publisher_index'] = index
+                    return index
+            return None
+
+        index = message.get('publisher_index')
+        if type(index) is not int or index < 0 or index >= len(self.posters):
+            return None
+
+        message['publisher_identity'] = self._publisher_identity(self.o.publishers[index])
+        message['_deleteOnPost'].add('publisher_identity')
+        return index
 
     def post(self, worklist):
         old_ok = worklist.ok
@@ -46,16 +70,20 @@ class Message(FlowCB):
             i=0
             failures=[]
             if 'publisher_index' in m:
-                i=m['publisher_index']
-                p=self.posters[i]
-                if hasattr(p,'putNewMessage'):
-                    try:
-                        if not p.putNewMessage(m):
+                i = self._publisher_index(m)
+                if i is None:
+                    logger.warning("publisher for retry is no longer configured: %s", m.get('publisher_identity'))
+                    failures.append(m.get('publisher_index', -1))
+                else:
+                    p = self.posters[i]
+                    if hasattr(p, 'putNewMessage'):
+                        try:
+                            if not p.putNewMessage(m):
+                                failures.append(i)
+                        except Exception as e:
+                            logger.warning("putNewMessage crashed %s", e)
+                            logger.debug("Exception details:", exc_info=True)
                             failures.append(i)
-                    except Exception as e:
-                        logger.warning(f"putNewMessage crashed {e}")
-                        logger.debug("Exception details:", exc_info=True)
-                        failures.append(i)
             else:
                 for p in self.posters:
                     if hasattr(p,'putNewMessage'):
@@ -81,6 +109,9 @@ class Message(FlowCB):
             if len(failures)<1:
                 if 'post_failures' in m:
                    del m['post_failures']
+                if 'publisher_identity' in m:
+                    del m['publisher_identity']
+                    m['_deleteOnPost'].discard('publisher_identity')
                 worklist.ok.append(m)
             else:
                 m['post_failures'] = failures

--- a/tests/sarracenia/flowcb/post/message__post_test.py
+++ b/tests/sarracenia/flowcb/post/message__post_test.py
@@ -1,6 +1,95 @@
-import pytest
-from tests.conftest import *
-#from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-import sarracenia.config
+import jsonpickle
+
+import sarracenia
 import sarracenia.flowcb.post.message
+
+
+class Options:
+
+    def __init__(self, publishers):
+        self.post_broker = True
+        self.publishers = publishers
+
+    def dictify(self):
+        return {'publishers': self.publishers}
+
+
+def publisher(name):
+    return {
+        'broker': 'amqp://%s.example' % name,
+        'exchange': ['xs_%s' % name],
+        'topicPrefix': ['v03', 'post'],
+        'format': 'v03',
+    }
+
+
+def message_for_publisher(index):
+    message = sarracenia.Message()
+    message['publisher_index'] = index
+    message['_deleteOnPost'] = {'publisher_index'}
+    return message
+
+
+def worklist(message):
+    return SimpleNamespace(ok=[message], failed=[])
+
+
+def test_retry_follows_original_publisher_after_reorder():
+    publisher_a = publisher('a')
+    publisher_b = publisher('b')
+    failed_b = MagicMock()
+    failed_b.putNewMessage.return_value = False
+
+    with patch('sarracenia.moth.Moth.pubFactory', side_effect=[MagicMock(), failed_b]):
+        callback = sarracenia.flowcb.post.message.Message(Options([publisher_a, publisher_b]))
+
+    message = message_for_publisher(1)
+    first_attempt = worklist(message)
+    callback.post(first_attempt)
+
+    assert first_attempt.ok == []
+    assert first_attempt.failed == [message]
+    message = jsonpickle.decode(jsonpickle.encode(message))
+
+    retry_b = MagicMock()
+    retry_b.putNewMessage.return_value = True
+    wrong_a = MagicMock()
+    with patch('sarracenia.moth.Moth.pubFactory', side_effect=[retry_b, wrong_a]):
+        reordered = sarracenia.flowcb.post.message.Message(Options([publisher_b, publisher_a]))
+
+    retry = worklist(message)
+    reordered.post(retry)
+
+    retry_b.putNewMessage.assert_called_once_with(message)
+    wrong_a.putNewMessage.assert_not_called()
+    assert retry.ok == [message]
+    assert retry.failed == []
+
+
+def test_retry_stays_failed_when_original_publisher_is_removed():
+    publisher_a = publisher('a')
+    publisher_b = publisher('b')
+    failed_b = MagicMock()
+    failed_b.putNewMessage.return_value = False
+
+    with patch('sarracenia.moth.Moth.pubFactory', side_effect=[MagicMock(), failed_b]):
+        callback = sarracenia.flowcb.post.message.Message(Options([publisher_a, publisher_b]))
+
+    message = message_for_publisher(1)
+    first_attempt = worklist(message)
+    callback.post(first_attempt)
+    message = jsonpickle.decode(jsonpickle.encode(message))
+
+    remaining_a = MagicMock()
+    with patch('sarracenia.moth.Moth.pubFactory', return_value=remaining_a):
+        reconfigured = sarracenia.flowcb.post.message.Message(Options([publisher_a]))
+
+    retry = worklist(message)
+    reconfigured.post(retry)
+
+    remaining_a.putNewMessage.assert_not_called()
+    assert retry.ok == []
+    assert retry.failed == [message]


### PR DESCRIPTION
##### What
The post callback stored a positional publisher_index. Removing a publisher raised IndexError with no disposition, and reordering publishers silently sent a retry to the wrong broker.

##### Change
Tag retries with a stable publisher identity (broker, exchange, topicPrefix, format) and resolve to the current index on replay. A missing publisher routes the message to failed. The stored identity is password-masked, so no credential is written to the retry queue.

##### Test
New tests cover the removed-publisher and reordered-publisher cases. They fail on the current code and pass with the change. Unit CI is green.

A message persisted by older code before upgrading can misroute once if a reorder happened across the upgrade boundary; identity that was never stored cannot be recovered.
