### PR TITLE
Fix local file and symlink polling message handling

### DIFF
--- a/sarracenia/flowcb/poll/__init__.py
+++ b/sarracenia/flowcb/poll/__init__.py
@@ -489,18 +489,18 @@ class Poll(FlowCB):
 
                 ok = sarracenia.Message.fromFileInfo(path, self.o, lstat)
                 if os.path.islink(path):
-                    if 'size' in msg:
-                        del msg['size']
+                    if 'size' in ok:
+                        del ok['size']
                     if not self.o.follow_symlinks:
                         try: 
                             ok['fileOp'] = { 'link': os.readlink(path) } 
-                            if 'Identity' in msg:
-                                 del ok['Identity']
+                            if 'identity' in ok:
+                                 del ok['identity']
                         except:
                             logger.error(f"cannot read link {path} message dropped")
                             logger.debug('Exception details: ', exc_info=True)
                             ok=None
-                return ok
+                return [ok] if ok else []
 
         post_relPath = destDir + '/' + remote_file
 

--- a/tests/sarracenia/flowcb/poll/local_symlink_test.py
+++ b/tests/sarracenia/flowcb/poll/local_symlink_test.py
@@ -1,0 +1,41 @@
+import os
+
+import pytest
+
+import sarracenia
+import sarracenia.config
+from sarracenia.flowcb.poll import Poll
+
+
+def make_poll(base_dir, follow_symlinks):
+    options = sarracenia.config.no_file_config()
+    options.post_baseUrl = 'file:'
+    options.publishers = [{'baseUrl': 'file:', 'baseDir': str(base_dir)}]
+    options.follow_symlinks = follow_symlinks
+    options.fileEvents = ['create', 'modify', 'link']
+    options.identity_method = 'random'
+
+    poll = Poll.__new__(Poll)
+    poll.o = options
+    return poll
+
+
+@pytest.mark.parametrize('follow_symlinks', [False, True])
+def test_poll_file_post_returns_local_symlink_message(tmp_path, follow_symlinks):
+    target = tmp_path / 'target.dat'
+    target.write_bytes(b'weather data')
+    link = tmp_path / 'product.dat'
+    link.symlink_to(target.name)
+    poll = make_poll(tmp_path, follow_symlinks)
+
+    messages = poll.poll_file_post(None, str(tmp_path), link.name)
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], sarracenia.Message)
+    assert 'size' not in messages[0]
+    if follow_symlinks:
+        assert 'fileOp' not in messages[0]
+        assert 'identity' in messages[0]
+    else:
+        assert messages[0]['fileOp'] == {'link': os.readlink(link)}
+        assert 'identity' not in messages[0]


### PR DESCRIPTION
##### What
Local-file polling returned a single Message where a list was expected, so extend added the message dict keys to the flow. The symlink path referenced an unbound variable and raised, discarding the poll cycle.

##### Change
Return a single-element list for a regular file, and fix the symlink path to use the bound message variable and the correct lowercase identity key.

##### Test
New tests cover the regular-file and symlink cases. They fail on the current code and pass with the change. Unit CI is green.
