### PR TITLE
Bound the MQTT close wait for pending publishes

### DIFF
--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -843,16 +843,26 @@ class MQTT(Moth):
 
             if hasattr(self, 'pending_publishes'):
                 ebo=0.1
+                total_wait = 0.0
+                max_wait = self.o['timeout'] if 'timeout' in self.o else 300
                 while  len(self.pending_publishes) >0:
-                    logger.info( f'waiting {ebo} seconds for last {len(self.pending_publishes)} messages to publish')
+                    if total_wait >= max_wait:
+                        logger.warning('gave up waiting for %d pending publishes after %.1f seconds',
+                                       len(self.pending_publishes), total_wait)
+                        break
+                    wait_for = min(ebo, max_wait - total_wait)
+                    logger.info('waiting %s seconds for last %d messages to publish', wait_for,
+                                len(self.pending_publishes))
                     if len(self.unexpected_publishes) < 10:
                         logger.info( f'messages acknowledged before publish?: {self.unexpected_publishes}')
                     if len(self.pending_publishes) < 10:
                         logger.info( f'messages awaiting publish: {self.pending_publishes}')
-                    time.sleep(ebo)
+                    time.sleep(wait_for)
+                    total_wait += wait_for
                     if ebo < 64:
                         ebo *= 2
-                logger.info('no more pending messages')
+                else:
+                    logger.info('no more pending messages')
             self.client.disconnect()
             self.client.loop_stop()
         self.connected=False

--- a/sarracenia/moth/mqtt.py
+++ b/sarracenia/moth/mqtt.py
@@ -844,7 +844,7 @@ class MQTT(Moth):
             if hasattr(self, 'pending_publishes'):
                 ebo=0.1
                 total_wait = 0.0
-                max_wait = self.o['timeout'] if 'timeout' in self.o else 300
+                max_wait = self.o['timeout'] if self.o.get('timeout', 0) > 0 else 300
                 while  len(self.pending_publishes) >0:
                     if total_wait >= max_wait:
                         logger.warning('gave up waiting for %d pending publishes after %.1f seconds',

--- a/tests/sarracenia/moth/mqtt_close_test.py
+++ b/tests/sarracenia/moth/mqtt_close_test.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+
+from sarracenia.moth.mqtt import MQTT
+
+
+def make_publisher(timeout):
+    mqtt = MQTT.__new__(MQTT)
+    mqtt.client = MagicMock()
+    mqtt.client.is_connected.return_value = True
+    mqtt.connected = True
+    mqtt.is_subscriber = False
+    mqtt.pending_publishes = [17]
+    mqtt.unexpected_publishes = []
+    mqtt.o = {'timeout': timeout}
+    return mqtt
+
+
+def test_close_stops_waiting_at_timeout():
+    mqtt = make_publisher(0.25)
+    waits = []
+
+    with patch('sarracenia.moth.mqtt.time.sleep', side_effect=waits.append):
+        mqtt.close()
+
+    assert waits == [0.1, 0.15]
+    assert mqtt.pending_publishes == [17]
+    mqtt.client.disconnect.assert_called_once_with()
+    mqtt.client.loop_stop.assert_called_once_with()
+    assert mqtt.connected is False
+
+
+def test_close_preserves_successful_pending_publish_drain():
+    mqtt = make_publisher(1)
+    waits = []
+
+    def acknowledge(wait_for):
+        waits.append(wait_for)
+        mqtt.pending_publishes.clear()
+
+    with patch('sarracenia.moth.mqtt.time.sleep', side_effect=acknowledge):
+        mqtt.close()
+
+    assert waits == [0.1]
+    mqtt.client.disconnect.assert_called_once_with()
+    mqtt.client.loop_stop.assert_called_once_with()
+    assert mqtt.connected is False


### PR DESCRIPTION
##### What
On close, MQTT waited in an unbounded loop for pending publishes to complete. A permanently pending message id made a child process hang forever.

##### Change
Wait up to the configured timeout, then give up with a warning; call disconnect and loop_stop on both paths so no thread leaks. A timeout of 0 is treated as unset (falls back to the default) so it does not drop pending publishes at close.

##### Test
New tests cover the timeout-bound path and the normal-drain path. Unit CI is green.
