### PR TITLE
Give malformed geometry an explicit disposition instead of bypassing the filter

### DIFF
--- a/sarracenia/flowcb/filter/geometry.py
+++ b/sarracenia/flowcb/filter/geometry.py
@@ -85,9 +85,10 @@ class Geometry(FlowCB):
                 #We're just going to trust that geometry is a properly formatted GeoJSON object
                 # Ultimately, if it's not, some of the logic in following sections will fail, and we'll have to catch those errors then
                 message_geometry = json.loads(m['geometry'])
-            except json.decoder.JSONDecodeError as err:
+            except (json.decoder.JSONDecodeError, TypeError) as err:
                 logger.error(f"error parsing message geometry: {err}; {m}")
-                raise
+                worklist.failed.append(m)
+                continue
             
 
             accept_message = False

--- a/tests/sarracenia/flowcb/filter/geometry_test.py
+++ b/tests/sarracenia/flowcb/filter/geometry_test.py
@@ -153,14 +153,19 @@ def test_after_accept():
 
 
     #Tests where message geometry is invalid JSON
+    options.geometry_maxDistance = 10
     geojson = sarracenia.flowcb.filter.geometry.Geometry(options)
 
     worklist = make_worklist()
     #failed
-    worklist.incoming.append(make_message("pointB"))
-    worklist.incoming[0]['geometry'] = 'lkjasdf'
-    with pytest.raises(json.decoder.JSONDecodeError):
-        geojson.after_accept(worklist)
+    malformed = make_message("pointB")
+    malformed['geometry'] = 'lkjasdf'
+    worklist.incoming.append(malformed)
+    worklist.incoming.append(make_message("pointA"))
+    geojson.after_accept(worklist)
+    assert worklist.failed == [malformed]
+    assert len(worklist.incoming) == 1
+    assert worklist.incoming[0]['geometry'] == features['pointA']
 
 
     #Tests missing geometry in config
@@ -174,4 +179,3 @@ def test_after_accept():
 
     geojson.after_accept(worklist)
     assert len(worklist.rejected) == 2
-


### PR DESCRIPTION
##### What
Invalid geometry JSON was re-raised before the incoming list was replaced. The normal dispatcher caught it and left the message in incoming (bypassing the filter); in debug mode it aborted the run.

##### Change
Catch the JSON or type error, route the message to failed, and continue so later messages are still evaluated and valid geometry still filters normally.

##### Test
A new test confirms a malformed message goes to failed while a following valid message is still processed. It fails on the current code and passes with the change. Unit CI is green.
