### PR TITLE
add try/except to handle race conditions in check for existing inflight file

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -2021,12 +2021,12 @@ class Flow:
 
             # assert new_inflight_path is set.
 
-            if os.path.exists(msg['new_inflight_path']):
+            if self.o.inflight and os.path.exists(msg['new_inflight_path']):
 
-                if self.o.inflight:
+                try:
                     how_old = time.time() - os.path.getmtime(msg['new_inflight_path'])
-                    #FIXME: if mtime > 5 minutes, perhaps rm it, and continue? what if transfer crashed?
-                    #       Added this with fixed value, should it be a setting?
+                    # if file exists and mtime > 5 minutes, rm it, and continue. previous transfer likely crashed
+                    #FIXME: Added this with fixed value, should it be a setting?
                     if how_old > 300:
                         os.unlink( msg['new_inflight_path'] )
                         logger.info(
@@ -2034,8 +2034,13 @@ class Flow:
                     else:
                         logger.warning(
                             f"inflight file already exists. race condition, deferring transfer of {msg['new_path']}" )
-                    self.worklist.failed.append(msg)
-                    continue
+                # in case file gets deleted after the exists check but before the getmtime or unlink calls
+                except FileNotFoundError:
+                    logger.warning(
+                        f"inflight file already existed. race condition, deferring transfer of {msg['new_path']}")
+
+                self.worklist.failed.append(msg)
+                continue
                 # overwriting existing file.
 
             # FIXME: decision of whether to download, goes here.


### PR DESCRIPTION
closes #1748

We've seen this race condition cause sr3 to crash during broker patching. When the broker connection is reset, any unacked messages will likely get redelivered to another instance, but the original instance still has the message in its local worklist. Both try to process the message, if the timing is right, one of them will crash.

This wraps the existing code in a try/except to catch FileNotFoundErrors that could be raised by `os.path.getmtime` or `os.unlink`.