### PR TITLE
doc #1753 sftp: prefer ~/.ssh/config over ssh_keyfile in credentials.conf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,8 @@ metpx-sr3 (3.03.00rc1) UNRELEASED; urgency=medium
   * ai tools applied, many bugs found & fixed. (perf) means no behaviour change
     only improved performance.
   * many fixes to tests: unit, flow, etc...
+  * doc #1753 sftp: document using ~/.ssh/config rather than ssh_keyfile in
+    credentials.conf, so accelerated (scp) transfers use the same settings.
   * fix #38, #1637 Stateful queue binding: editing subtopics works properly.
   * fix #38 Stateful queue binding: queue parameter changes flagged.
   * fix #1627 log when putNewMessage crashes (message publish failure.)

--- a/docs/source/Reference/sr3_credentials.7.rst
+++ b/docs/source/Reference/sr3_credentials.7.rst
@@ -72,7 +72,9 @@ You may need to specify additional options for specific credential entries. Thes
 
 Supported details:
 
-- ``ssh_keyfile=<path>`` - (SFTP) Path to SSH keyfile
+- ``ssh_keyfile=<path>`` - (SFTP) Path to SSH keyfile. For SFTP, prefer an entry in
+  ``~/.ssh/config`` instead, see `SFTP and ~/.ssh/config`_ below. ``ssh_keyfile`` is not
+  seen by the ``scp`` command used for accelerated transfers.
 - ``passive`` - (FTP) Use passive mode
 - ``active`` - (FTP) Use active mode
 - ``binary`` - (FTP) Use binary mode
@@ -99,6 +101,61 @@ Note::
  character, its URL encoded equivalent can be supplied.  In the last example above, 
  **%2f** means that the actual password is: **/dot8**
  The next to last password is:  **De:olonize**. ( %3a being the url encoded value for a colon character. )
+
+
+SFTP and ~/.ssh/config
+----------------------
+
+For SFTP, put the connection settings in ``~/.ssh/config`` rather than in
+``credentials.conf``, and leave out the ``credentials.conf`` entry entirely.
+
+Sarracenia has two ways of moving a file over SFTP. Ordinary transfers use the paramiko
+library, which Sarracenia configures from ``credentials.conf``. Transfers larger than
+``accelThreshold`` are handed to the ``scp`` command instead (see ``accelScpCommand``).
+``scp`` reads ``~/.ssh/config`` and knows nothing about ``credentials.conf``, so anything
+recorded only there is invisible to it. A key named by ``ssh_keyfile`` works for ordinary
+transfers and is silently missing from accelerated ones, which shows up as a configuration
+that works until a file crosses ``accelThreshold``.
+
+Settings in ``~/.ssh/config`` avoid that, because both paths read them: ``scp`` natively,
+and paramiko because Sarracenia looks the host up in ``~/.ssh/config`` itself and picks up
+``HostName``, ``User``, ``Port`` and ``IdentityFile``.
+
+Define a stanza naming the host, the account and the key::
+
+    Host weather-pump
+        HostName sftp.example.com
+        User sarra
+        IdentityFile ~/.ssh/id_ecdsa_weather_pump
+        IdentitiesOnly yes
+
+Then use the alias as the host name wherever the server appears::
+
+    sendTo sftp://weather-pump/
+
+and add nothing to ``credentials.conf`` for it.
+
+The alias is a label, not a host name, so a server reachable several ways can have one
+stanza per way, each with its own alias, and a server that moves only needs its stanza
+edited.
+
+Do not put a port number in the URL. Give the port in the stanza instead::
+
+    Host weather-pump-alt
+        HostName sftp.example.com
+        Port 2222
+        User sarra
+        IdentityFile ~/.ssh/id_ecdsa_weather_pump
+
+A port in the URL is not passed on to ``scp`` correctly, so an accelerated transfer to
+``sftp://sarra@host:2222/`` fails while an ordinary transfer to the same URL succeeds.
+
+Note::
+ Sarracenia only consults ``~/.ssh/config`` when the credential does not already answer
+ the question: when no user is known, or when neither a key nor a password was supplied.
+ A ``credentials.conf`` entry carrying a user and a password takes precedence and the
+ stanza is not read. Omitting the entry is the reliable way to have ``~/.ssh/config``
+ apply.
 
 
 SEE ALSO


### PR DESCRIPTION
##### What

Closes #1753 as documentation, per the discussion there.

`ssh_keyfile` in `credentials.conf` is used by ordinary sftp transfers and silently ignored
by accelerated ones. Transfers over `accelThreshold` are handed to `scp`, which reads
`~/.ssh/config` and cannot see `credentials.conf`. The symptom is a configuration that works
until a file crosses the threshold, so it presents as "large files fail" rather than as a
credential problem.

Settings in `~/.ssh/config` are read by both paths: `scp` natively, and paramiko because
`Sftp.credentials()` looks the host up in `~/.ssh/config` itself and takes `HostName`,
`User`, `Port` and `IdentityFile` from it.

##### Change

Adds a `SFTP and ~/.ssh/config` section to `sr3_credentials.7.rst` documenting a `Host`
stanza with no `credentials.conf` entry as the way to configure sftp, and points to it from
the `ssh_keyfile` entry under Credential Details.

It also records two things that are easy to lose an afternoon to:

- a port belongs in the stanza, not the URL. A port in the URL is not passed to `scp`
  correctly, so an accelerated transfer to `sftp://user@host:2222/` fails while an ordinary
  transfer to the same URL succeeds.
- `~/.ssh/config` is only consulted when the credential does not already answer the question
  (`transfer/sftp.py:285-286`). An entry carrying a user and a password takes precedence and
  the stanza is not read, so omitting the entry is the reliable way to have it apply.

Documentation only. No code changes.

##### Verified

Every statement in the new section was run against a real sftp server on unmodified
`development`, not reasoned about. Lab account whose `authorized_keys` holds only a
deliberately odd named key, so nothing succeeds by accident, plus a second sshd on 2222 for
the port case. 2 MB file, `accelThreshold 1M`, md5 compared against the source on the
successful runs.

| setup | ordinary | accelerated |
|---|---|---|
| `ssh_keyfile` in credentials.conf | works | fails, `Permission denied (publickey)` |
| ssh_config stanza, no credentials.conf entry | works | works |
| ssh_config stanza with `Port 2222`, alias in URL | works | works |
| port in the URL, key in credentials.conf | works | fails, `2222:/path: No such file` |

RST checked with docutils. The only diagnostics are the pre-existing `|today|` and
`|release|` substitutions that sphinx supplies at build time.

##### Not included

The French `docs/source/fr/Reference/sr3_credentials.7.rst` carries the matching
`ssh_keyfile` entry and is not updated here. I would rather that was done by someone who
writes French properly than guessed at, but I can attempt it if you would prefer it in the
same change.

Two unrelated defects turned up while testing this and are filed separately, both with
reproductions and no patch: #1755 (accelerated sftp fails when baseUrl contains a path) and
#1756 (accelerated transfers break on filenames containing spaces, across all five
accelerated call sites).

##### Fork CI

Run on my fork first: https://github.com/robjarawan/sarracenia/pull/136 - 32 pass, 6 fail.

The six failures are runner flakiness, not this change. The clearest evidence is that the
duplicate workflow runs on the same commit disagree with themselves:

```
dynamic_flow on ubuntu-22.04     2 pass, 1 fail
dynamic_flow on ubuntu-24.04     2 pass, 1 fail
flakey_broker on ubuntu-22.04    2 pass, 1 fail
flakey_broker on ubuntu-24.04    2 pass, 1 fail
Maintenance test on ubuntu-22.04 1 pass, 1 fail
Maintenance test on ubuntu-24.04 1 pass, 1 fail
```

Every job that failed also passed on another run of the same commit. The same jobs are
also currently failing on untouched `development` upstream.

This branch changes one .rst file and a changelog line, with no python or config touched,
so the flow tests cannot be reached by it.

A passing dynamic_flow run: https://github.com/robjarawan/sarracenia/actions/runs/30972432267/job/92199482505
