### PR TITLE
some fixes for messages without size header.

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1376,7 +1376,8 @@ class Flow:
     def write_inline_file(self, msg) -> bool:
         """
            write local file based on a message with inlined content.
-
+           
+           side effect: msg['size'] will be set to the correct size of the downloaded file.
         """
         # make sure directory exists, create it if not
         if not os.path.isdir(msg['new_dir']):
@@ -1401,6 +1402,7 @@ class Flow:
             data = b64decode(msg['content']['value'])
         else:
             data = msg['content']['value'].encode(msg['content']['encoding'])
+
 
         if self.o.identity_method.startswith('cod,'):
             algo_method = self.o.identity_method[4:]
@@ -1427,16 +1429,22 @@ class Flow:
             'value': onfly_algo.value
         }
 
-        if ((msg['size'] > 0) and len(data) != msg['size']):
+        if ('size' in msg) and (msg['size'] > 0) and len(data) != msg['size']:
             if self.o.acceptSizeWrong:
                 logger.warning(
                     "acceptSizeWrong data size is (%d bytes) vs. expected: (%d bytes)"
                     % (len(data), msg['size']))
+                # size mismatches should not be propagated downstream. Downstream should see the correct size.
+                msg['size'] = len(data)
             else:
                 logger.warning(
                     "decoded data size (%d bytes) does not have expected size: (%d bytes)"
                     % (len(data), msg['size']))
                 return False
+        else:
+            # If there is not size in the message, then it cannot mismatch? Alternative would be it always mismatches, which would be useless.
+            # so need to assume that if the size field is missing, then whatever size is received is correct.
+            msg['size'] = len(data)
 
         data_algo.update(data)
 
@@ -1984,7 +1992,7 @@ class Flow:
 
             # all non-files taken care of above... rest of routine is normal file download.
 
-            if self.o.fileSizeMax > 0 and msg['size'] > self.o.fileSizeMax:
+            if self.o.fileSizeMax > 0 and 'size' in msg and msg['size'] > self.o.fileSizeMax:
                 self.reject(msg, 413, f"Payload Too Large {msg.getIDStr()}")
                 continue
 
@@ -3064,7 +3072,7 @@ class Flow:
                 self.reject(msg, 422, f"new_file message field missing, do not know name of file to write. skipping." )
                 continue
 
-            if self.o.fileSizeMax > 0 and msg['size'] > self.o.fileSizeMax: 
+            if 'size' in msg and self.o.fileSizeMax > 0 and msg['size'] > self.o.fileSizeMax: 
                 self.reject(msg, 413, f"Payload Too Large {msg.getIDStr()}") 
                 continue
 

--- a/sarracenia/flowcb/filter/wmo00_accumulate.py
+++ b/sarracenia/flowcb/filter/wmo00_accumulate.py
@@ -229,7 +229,7 @@ class Wmo00_accumulate(FlowCB):
         output_file.close()
         msg = sarracenia.Message.fromFileData(self.accumulated_file, self.o, os.stat(self.accumulated_file))
 
-        if msg['size'] > 0 : 
+        if 'size' in msg and msg['size'] > 0 : 
             logger.info( f"accumulated file {self.accumulated_file} written {msg['size']} bytes, {record_no-1} records" )
             worklist.incoming.append(msg)
         else:

--- a/sarracenia/flowcb/work/check.py
+++ b/sarracenia/flowcb/work/check.py
@@ -59,14 +59,17 @@ class Check(FlowCB):
                 continue
 
             logger.info(f"identity     {msg['identity']} " )
-            logger.info(f"filesize   {msg['size']} ")
+            if 'size' in msg:
+                logger.info(f"filesize   {msg['size']} ")
     
             lstat = os.stat(local_file)
-            fsiz = lstat[stat.ST_SIZE]
+
+            if 'size' in msg:
+                fsiz = lstat[stat.ST_SIZE]
     
-            if fsiz != msg['size']:
-                logger.error( f"filesize differ (corrupted ?)  lf {fsiz:d}  msg {msg['size']:d}" )
-                self.size_mismatches+=1
+                if fsiz != msg['size']:
+                    logger.error( f"filesize differ (corrupted ?)  lf {fsiz:d}  msg {msg['size']:d}" )
+                    self.size_mismatches+=1
     
             self.o.post_baseUrl = msg['baseUrl']
             self.o.identity_method = msg['identity']['method']


### PR DESCRIPTION
close #1754

Normally, a notification message should include the size of the file to be transferred. Following Postel's maxim, we want to handle it being missing elegantly:

* when the field is missing, don't crash #1754
* When we finish downloading a file, we know it's actual size, and if the field is missing it should be added.

