### PR TITLE
Patch #1760

### DIFF
--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -34,7 +34,12 @@ Returns:
 
 import logging
 
-import os, resource, socket, time, random
+import os, socket, time, random
+# resource library only available on Unix systems
+try:
+    import resource
+except ImportError:
+    resource = None
 from sarracenia.flowcb import FlowCB
 from sarracenia import naturalSize, naturalTime, user_cache_dir, nowstr
 from sarracenia.featuredetection import features
@@ -131,22 +136,22 @@ class Resources(FlowCB):
                 time.sleep(self.randomSleep)
 
 
-        # Flush buffered output before exec replaces the process.
-        sys.stdout.flush()
-        sys.stderr.flush()
-
-        # Close inherited file descriptors (sockets, pipes, open files) that
-        # os.execl would otherwise leak into the new process image.
-        # Keep stdin/stdout/stderr (0-2) open.
-        try:
-            max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-            if max_fd == resource.RLIM_INFINITY:
-                max_fd = 1024
-            os.closerange(3, max_fd)
-        except Exception:
-            logger.debug('fd cleanup before execl failed', exc_info=True)
-
         if sys.platform.startswith(('linux', 'cygwin', 'darwin', 'aix')):
+            # Flush buffered output before exec replaces the process.
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+            # Close inherited file descriptors (sockets, pipes, open files) that
+            # os.execl would otherwise leak into the new process image.
+            # Keep stdin/stdout/stderr (0-2) open.
+            try:
+                max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+                if max_fd == resource.RLIM_INFINITY:
+                    max_fd = 1024
+                os.closerange(3, max_fd)
+            except Exception:
+                logger.debug('fd cleanup before execl failed', exc_info=True)
+
             # Unix* (Linux / Windows/Cygwin / MacOS / AIX) Specific restart
             os.execl(sys.executable, sys.executable, *sys.argv)
         elif sys.platform.startswith('win32'):

--- a/sarracenia/flowcb/housekeeping/resources.py
+++ b/sarracenia/flowcb/housekeeping/resources.py
@@ -137,20 +137,21 @@ class Resources(FlowCB):
 
 
         if sys.platform.startswith(('linux', 'cygwin', 'darwin', 'aix')):
-            # Flush buffered output before exec replaces the process.
-            sys.stdout.flush()
-            sys.stderr.flush()
+            if resource is not None:
+                # Flush buffered output before exec replaces the process.
+                sys.stdout.flush()
+                sys.stderr.flush()
 
-            # Close inherited file descriptors (sockets, pipes, open files) that
-            # os.execl would otherwise leak into the new process image.
-            # Keep stdin/stdout/stderr (0-2) open.
-            try:
-                max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-                if max_fd == resource.RLIM_INFINITY:
-                    max_fd = 1024
-                os.closerange(3, max_fd)
-            except Exception:
-                logger.debug('fd cleanup before execl failed', exc_info=True)
+                # Close inherited file descriptors (sockets, pipes, open files) that
+                # os.execl would otherwise leak into the new process image.
+                # Keep stdin/stdout/stderr (0-2) open.
+                try:
+                    max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+                    if max_fd == resource.RLIM_INFINITY:
+                        max_fd = 1024
+                    os.closerange(3, max_fd)
+                except Exception:
+                    logger.debug('fd cleanup before execl failed', exc_info=True)
 
             # Unix* (Linux / Windows/Cygwin / MacOS / AIX) Specific restart
             os.execl(sys.executable, sys.executable, *sys.argv)


### PR DESCRIPTION
#1760

I moved all of the file descriptor closing logic into the condition that verifies the OS being ran is linux/unix. 

I tested on my Windows system. Diff below shows pip3 package file on the left vs. sarracenia windows package file on right.

```
PS C:\Users\LeBlaA12> Compare-Object (Get-Content C:\Users\LeBlaA12\AppData\Local\Python\pythoncore-3.14-64\Lib\site-packages\sarracenia\flowcb\housekeeping\resources.py) (Get-Content C:\Users\LeBlaA12\AppData\Local\Programs\metpx-sr3\pkgs\sarracenia\flowcb\housekeeping\resources.py)

InputObject                                                                      SideIndicator
-----------                                                                      -------------
import os, socket, time, random                                                  =>
# resource library only available on Unix systems                                =>
try:                                                                             =>
    import resource                                                              =>
except ImportError:                                                              =>
    resource = None                                                              =>
            # Flush buffered output before exec replaces the process.            =>
            sys.stdout.flush()                                                   =>
            sys.stderr.flush()                                                   =>
            # Close inherited file descriptors (sockets, pipes, open files) that =>
            # os.execl would otherwise leak into the new process image.          =>
            # Keep stdin/stdout/stderr (0-2) open.                               =>
            try:                                                                 =>
                max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]           =>
                if max_fd == resource.RLIM_INFINITY:                             =>
                    max_fd = 1024                                                =>
                os.closerange(3, max_fd)                                         =>
            except Exception:                                                    =>
                logger.debug('fd cleanup before execl failed', exc_info=True)    =>
import os, resource, socket, time, random                                        <=
        # Flush buffered output before exec replaces the process.                <=
        sys.stdout.flush()                                                       <=
        sys.stderr.flush()                                                       <=
        # Close inherited file descriptors (sockets, pipes, open files) that     <=
        # os.execl would otherwise leak into the new process image.              <=
        # Keep stdin/stdout/stderr (0-2) open.                                   <=
        try:                                                                     <=
            max_fd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]               <=
            if max_fd == resource.RLIM_INFINITY:                                 <=
                max_fd = 1024                                                    <=
            os.closerange(3, max_fd)                                             <=
        except Exception:                                                        <=
            logger.debug('fd cleanup before execl failed', exc_info=True)        <=
```

Windows installed sr3 package (patched) can run without crashing

```
PS C:\Users\LeBlaA12> sr3 foreground subscribe\ping
2026-08-19 10:46:21,407 16628 [INFO] sarracenia.config finalize subscribe/ping.conf overriding batch for consistency with messageCountMax: 10
.2026-08-19 10:46:22,392 [ERROR] 12780 sarracenia.config.credentials isValid credential UrlParseResult(scheme='amqps', netloc='anonymous@hpfx.collab.science.gc.ca', path='/', params='', query='', fragment='') not found
2026-08-19 10:46:22,392 [CRITICAL] 12780 root validate_urlstr bad credential amqps://anonymous@hpfx.collab.science.gc.ca/
2026-08-19 10:46:22,404 [INFO] 12780 sarracenia.config finalize subscribe/ping overriding batch for consistency with messageCountMax: 10
2026-08-19 10:46:22,420 [INFO] 12780 sarracenia.config finalize subscribe/ping overriding batch for consistency with messageCountMax: 10
2026-08-19 10:46:22,692 [INFO] 12780 sarracenia.moth.amqp _queueDeclare queue declared q_anonymous.subscribe.ping.${USER}_SSC-8YW1TG3.cmc.ec.gc.ca_07889823 (as: amqps://anonymous@hpfx.collab.science.gc.ca/), (messages waiting: 84)
2026-08-19 10:46:22,692 [INFO] 12780 sarracenia.moth.amqp getSetup binding q_anonymous.subscribe.ping.${USER}_SSC-8YW1TG3.cmc.ec.gc.ca_07889823 with v02.post.# to xpublic (as: amqps://anonymous@hpfx.collab.science.gc.ca/)
```

Pip3 package still fails 

```
PS C:\Users\LeBlaA12> python -m sarracenia.sr foreground subscribe\ping
2026-08-19 10:47:14,250 28052 [INFO] sarracenia.config finalize subscribe/ping.conf overriding batch for consistency with messageCountMax: 10
.2026-08-19 10:47:14,743 [ERROR] 20256 sarracenia.config.credentials isValid credential UrlParseResult(scheme='amqps', netloc='anonymous@hpfx.collab.science.gc.ca', path='/', params='', query='', fragment='') not found
2026-08-19 10:47:14,743 [CRITICAL] 20256 root validate_urlstr bad credential amqps://anonymous@hpfx.collab.science.gc.ca/
2026-08-19 10:47:14,750 [INFO] 20256 sarracenia.config finalize subscribe/ping overriding batch for consistency with messageCountMax: 10
2026-08-19 10:47:14,769 [INFO] 20256 sarracenia.config finalize subscribe/ping overriding batch for consistency with messageCountMax: 10
2026-08-19 10:47:14,795 [CRITICAL] 20256 sarracenia.flow loadCallbacks flowCallback plugin sarracenia.flowcb.housekeeping.resources.Resources did not load: No module named 'sarracenia.flowcb.sarracenia'
```