### PR TITLE
clean up code targeting Python <= 3.5 (#1615)

### DIFF
--- a/sarracenia/rabbitmq_admin.py
+++ b/sarracenia/rabbitmq_admin.py
@@ -40,38 +40,24 @@ def exec_rabbitmqadmin(url, options, simulate=False):
         command += ' ' + options
 
         logger.debug('command = %s', command)
-        if sys.version_info.major < 3 or (sys.version_info.major == 3
-                                          and sys.version_info.minor < 5):
-            if logger: logger.debug("using subprocess.getstatusoutput")
+        cmdlin = command.replace("'", '')
+        cmdlst = cmdlin.split()
+        if logger:
+            logger.debug('using subprocess.run cmdlst=%s', ' '.join(cmdlst))
 
-            if simulate:
-                print(f"dry_run: {' '.join(command)}")
-                return 0, None
+        if simulate:
+            print(f"dry_run: {cmdlin}")
+            return 0, None
 
-            return subprocess.getstatusoutput(command)
-        else:
-            cmdlin = command.replace("'", '')
-            cmdlst = cmdlin.split()
-            if logger:
-                logger.debug('using subprocess.run cmdlst=%s', ' '.join(cmdlst))
-
-            if simulate:
-                print(f"dry_run: {cmdlin}")
-                return 0, None
-
-            rclass = subprocess.run(cmdlst, stdout=subprocess.PIPE)
-            if rclass.returncode == 0:
-                output = rclass.stdout
-                if type(output) == bytes: output = output.decode("utf-8")
-                return rclass.returncode, output
-            return rclass.returncode, None
+        rclass = subprocess.run(cmdlst, stdout=subprocess.PIPE)
+        if rclass.returncode == 0:
+            output = rclass.stdout
+            if type(output) == bytes: output = output.decode("utf-8")
+            return rclass.returncode, output
+        return rclass.returncode, None
     except:
-        if sys.version_info.major < 3 or (sys.version_info.major == 3
-                                          and sys.version_info.minor < 5):
-            if logger: logger.error( f"trying run command {command}" )
-        else:
-            if logger:
-                logger.error( f"trying run command {' '.join(cmdlst)}" )
+        if logger:
+            logger.error(f"trying run command {' '.join(cmdlst)}")
         if logger: logger.debug('Exception details:', exc_info=True)
 
     return 0, None

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -516,12 +516,7 @@ class sr_GlobalState:
                             p = pathlib.Path(pathname)
                             if p.suffix in ['.pid', '.qname', '.state', '.noVip']:
                                 try:
-                                    if sys.version_info[0] > 3 or sys.version_info[
-                                            1] > 4:
-                                        t = p.read_text().strip()
-                                    else:
-                                        with p.open() as f:
-                                            t = f.read().strip()
+                                    t = p.read_text().strip()
                                 except FileNotFoundError:
                                     logger.error( f"state file {pathname} disappeared (race condition, see #1571), skipping" )
                                     continue
@@ -645,12 +640,7 @@ class sr_GlobalState:
                                 if i != 0:
                                     p = pathlib.Path(filename)
                                     try:
-                                        if sys.version_info[0] > 3 or sys.version_info[
-                                                1] > 4:
-                                            t = p.read_text().strip()
-                                        else:
-                                            with p.open() as f:
-                                                t = f.read().strip()
+                                        t = p.read_text().strip()
                                     except FileNotFoundError:
                                         logger.error( f"pid file {filename} disappeared (race condition, see #1571), skipping." )
                                         continue
@@ -698,12 +688,7 @@ class sr_GlobalState:
                             if filename[-4:] == '.pid':
                                 p = pathlib.Path(filename)
                                 try:
-                                    if sys.version_info[0] > 3 or sys.version_info[
-                                            1] > 4:
-                                        t = p.read_text().strip()
-                                    else:
-                                        with p.open() as f:
-                                            t = f.read().strip()
+                                    t = p.read_text().strip()
                                 except FileNotFoundError:
                                     logger.error( f"pid file {filename} disappeared (race condition, see #1571), skipping cleanup" )
                                     continue


### PR DESCRIPTION
Fixes #1615.

Minimum supported Python is 3.6 (`setup.py`: `python_requires='>=3.6'`), so the `sys.version_info` branches guarding `pathlib.Path.read_text()` and `subprocess.run()` are dead code on every supported interpreter.

**`sarracenia/sr.py`** — three identical guards around `p.read_text()` collapse to just the `read_text()` call. The `else` fallback (`with p.open() as f: t = f.read().strip()`) was only for 3.4 and older.

**`sarracenia/rabbitmq_admin.py`** — removes the `subprocess.getstatusoutput()` branch in `exec_rabbitmqadmin()` and the matching guard in its exception handler. The `subprocess.run()` path is what has actually executed since 3.5.

One thing worth flagging: in the `except` handler the remaining log line uses `' '.join(cmdlst)`, and `cmdlst` is unbound if the exception fires before it is assigned. That is pre-existing behaviour on Python >= 3.5 — this PR does not change it — but happy to add a guard here if you'd like it fixed in the same pass.

Left alone deliberately: the `< 3.7` / `< 3.8` checks in `config/__init__.py`, `moth/__init__.py` and `flow/__init__.py` are outside the scope of this issue.

**Testing:** `pytest -c tests/pytest.ini` on Python 3.12 — 348 passed. The three failures (`test_fromFileInfo`, `test_get_no_fd_leak_over_many_transfers`, and the `azure_test` docker errors) reproduce identically on an unmodified checkout, so they are pre-existing / environmental.
