### PR TITLE
Issue1196 - Add default.inc entry point in configuration parsing

### DIFF
--- a/docs/source/How2Guides/UPGRADING.rst
+++ b/docs/source/How2Guides/UPGRADING.rst
@@ -39,6 +39,13 @@ Installation Instructions
 git
 ---
 
+3.04.00
+-------
+
+*CHANGE*: For #1196, we've added the ``default.inc`` functionality where if a ``default.inc`` is defined inside a component
+directory (i.e. ``poll/default.inc``) the settings will get propogated to all of the configurations in that components' directory.
+
+
 3.03.00
 -------
 

--- a/docs/source/Reference/sr3.1.rst
+++ b/docs/source/Reference/sr3.1.rst
@@ -112,13 +112,16 @@ It is actually building the effective configuration from:
 
  2. admin.conf
 
- 3. <component>.conf (subscribe.conf, audit.conf, etc...)
+ 3. <component>/default.inc
 
  4. <component>/<config>.conf
 
-Settings in an individual .conf file are read in after the default.conf
-file, and so can override defaults. Options specified on
-the command line override configuration files.
+Settings in a default.inc include file (from the parent <component> directory)
+are read in after the default.conf and prior to <component>/<config>.conf.
+So this allows to override the values for the component chosen.
+Options specified in the configuration file override values in the components' default.inc.
+
+Options specified on the command line override configuration files.
 
 While one can manage configuration files using the *add*, *remove*,
 *list*, *edit*, *disable*, and *enable* actions, one can also do all

--- a/docs/source/fr/CommentFaire/MiseANiveau.rst
+++ b/docs/source/fr/CommentFaire/MiseANiveau.rst
@@ -38,6 +38,12 @@ Instructions d’installation
 git
 ---
 
+3.04.00
+-------
+
+*CHANGEMENT* : Pour le ticket #1196, nous avons ajouté la fonctionnalité ``default.inc`` : si un fichier ``default.inc`` est défini dans le répertoire 
+d'un component (par ex. ``poll/default.inc``), ses paramètres sont propagés à toutes les configurations situées dans ce même répertoire.
+
 3.03.00
 -------
 

--- a/docs/source/fr/Reference/sr3.1.rst
+++ b/docs/source/fr/Reference/sr3.1.rst
@@ -116,10 +116,12 @@ la configuration se fait construire a partir de:
 
  4. <component>/<config>.conf
 
-Les paramètres d'un fichier .conf sont lu après le fichier default.conf,
-et les valeurs initiales choisi par défaut peuvent éventuellement être replacer.
-Les options spécifiées sur la ligne de commande remplacent les options spécifiées dans le
-fichier de configuration.
+
+Les paramètres du fichier d'inclusion default.inc (situé dans le répertoire parent <component>)
+sont lus après default.conf et avant <component>/<config>.conf.
+Cela permet donc de remplacer les valeurs par défaut du component sélectionné.
+Les options spécifiées dans le fichier de configuration remplacent les valeurs du fichier default.inc du component.
+Les options spécifiées en ligne de commande remplacent ceux des fichiers de configuration.
 
 Les fichiers de configurations peuvent être gérer en utilisant les actions *add*, *remove*,
 *list*, *edit*, *disable*, et *enable*. Il est également possible de faire

--- a/docs/source/fr/Reference/sr3.1.rst
+++ b/docs/source/fr/Reference/sr3.1.rst
@@ -1,12 +1,12 @@
 =====
- SR3 
+ SR3
 =====
 
 ------------------
 sr3 Sarracenia CLI
 ------------------
 
-:Manual section: 1 
+:Manual section: 1
 :Date: |today|
 :Version: |release|
 :Manual group: MetPX-Sarracenia
@@ -112,7 +112,7 @@ la configuration se fait construire a partir de:
 
  2. admin.conf
 
- 3. <component>.conf (subscribe.conf, audit.conf, etc...)
+ 3. <component>/default.inc
 
  4. <component>/<config>.conf
 

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -976,6 +976,14 @@ class Config:
             if hasattr(component_module, 'default_options'):
                 self.override(component_module.default_options)
 
+    def addComponentDefaultInc( self , component ):
+        """
+        Added from issue 1196
+        Parse and add component/default.inc options if the file exists.
+        """
+        if os.path.exists(get_user_config_dir() + os.sep + component + os.sep + 'default.inc'):
+            self.parse_file(get_user_config_dir() + os.sep + component + os.sep + 'default.inc', component)
+
     @property
     def admin(self):
         return self.__admin
@@ -2884,6 +2892,8 @@ def one_config(component, config, action, isPost=False, hostDir=None):
         cfg.hostdir = hostDir
 
     cfg.applyComponentDefaults( component )
+
+    cfg.addComponentDefaultInc( component )
 
     store_pwd = os.getcwd()
 

--- a/sarracenia/config/__init__.py
+++ b/sarracenia/config/__init__.py
@@ -2893,12 +2893,12 @@ def one_config(component, config, action, isPost=False, hostDir=None):
 
     cfg.applyComponentDefaults( component )
 
-    cfg.addComponentDefaultInc( component )
-
     store_pwd = os.getcwd()
 
     os.chdir(get_user_config_dir())
     os.chdir(component)
+
+    cfg.addComponentDefaultInc( component )
 
     if config[-5:] != '.conf':
         fname = os.path.expanduser(config + '.conf')

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -336,10 +336,7 @@ class sr_GlobalState:
                         })
                         # Apply component defaults from source
                         cfgbody.applyComponentDefaults( c )
-                        # Added from issue 1196
-                        # Parse and add component/default.inc options if it exists.
-                        if os.path.exists(self.user_config_dir + os.sep + c + os.sep + 'default.inc'):
-                            cfgbody.parse_file(self.user_config_dir + os.sep + c + os.sep + 'default.inc')
+                        cfgbody.addComponentDefaultInc( c )
                         cfgbody.parse_file(cfg,c)
                         cfgbody.finalize(c, cfg)
                         self.configs[c][cbase]['options'] = cfgbody

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -336,6 +336,11 @@ class sr_GlobalState:
                         })
                         cfgbody.applyComponentDefaults( c )
                         cfgbody.parse_file(cfg,c)
+
+                        # Added from issue 1196
+                        # Parse component/default.inc if it exists
+                        if os.path.exists(self.user_config_dir + os.sep + c + os.sep + 'default.inc'):
+                            cfgbody.parse_file(self.user_config_dir + os.sep + c + os.sep + 'default.inc')
                         cfgbody.finalize(c, cfg)
                         self.configs[c][cbase]['options'] = cfgbody
 

--- a/sarracenia/sr.py
+++ b/sarracenia/sr.py
@@ -334,13 +334,13 @@ class sr_GlobalState:
                             'action': self.options.action,
                             'directory': '${PWD}'
                         })
+                        # Apply component defaults from source
                         cfgbody.applyComponentDefaults( c )
-                        cfgbody.parse_file(cfg,c)
-
                         # Added from issue 1196
-                        # Parse component/default.inc if it exists
+                        # Parse and add component/default.inc options if it exists.
                         if os.path.exists(self.user_config_dir + os.sep + c + os.sep + 'default.inc'):
                             cfgbody.parse_file(self.user_config_dir + os.sep + c + os.sep + 'default.inc')
+                        cfgbody.parse_file(cfg,c)
                         cfgbody.finalize(c, cfg)
                         self.configs[c][cbase]['options'] = cfgbody
 

--- a/tests/sarracenia/sr_test.py
+++ b/tests/sarracenia/sr_test.py
@@ -170,6 +170,33 @@ def test_component_default_inc_only_applies_to_its_component():
         _remove_config_tree(tmp_path, "poll")
         _remove_config_tree(tmp_path, "sarra")
 
+def test_component_default_inc_with_two_of_same_component():
+    """
+    A component's default.inc must not leak into another component.
+    """
+    tmp_path = '/tmp/'
+    _make_config_tree(
+        tmp_path,
+        "sarra",
+        default_content="retry_ttl 1h\n",
+        config_content="exchange sarra_exchange1\n",
+    )
+
+    Path(tmp_path + "sarra/test1.conf").write_text("exchange sarra_exchange2\n")
+
+    try:
+        state = _make_global_state(tmp_path, ["sarra"])
+
+        state._read_configs()
+
+        assert state.configs["sarra"]["test"]["options"].retry_ttl == 3600
+        assert state.configs["sarra"]["test"]["options"].exchange == 'sarra_exchange1'
+        assert state.configs["sarra"]["test1"]["options"].retry_ttl == 3600
+        assert state.configs["sarra"]["test1"]["options"].exchange == 'sarra_exchange2'
+    finally:
+        Path(tmp_path + "sarra/test1.conf").unlink()
+        _remove_config_tree(tmp_path, "sarra")
+
 
 def test_default_inc_is_not_a_configuration():
     """

--- a/tests/sarracenia/sr_test.py
+++ b/tests/sarracenia/sr_test.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 from tests.conftest import *
 #from unittest.mock import Mock
 
@@ -358,3 +359,36 @@ def test_default_inc_nested_include_can_be_overridden():
         Path(component_dir + "/nested.inc").unlink()
         _remove_config_tree(tmp_path, "poll")
 
+def test_one_config_applies_component_default_inc(monkeypatch):
+    """
+    one_config() should apply the component's default.inc when a
+    configuration is loaded directly at runtime.
+    """
+    monkeypatch.setattr(sys, "argv", ["sr3 start poll/test"])
+    tmp_path = "/tmp/"
+
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
+    _make_config_tree(
+        tmp_path,
+        "poll",
+        default_content="retry_ttl 3h\n",
+        config_content="exchange my_exchange\n",
+    )
+
+    try:
+        config = sarracenia.config.one_config(
+            "poll",
+            "test",
+            "start"
+        )
+
+        assert config.retry_ttl == 10800
+        assert config.exchange == "my_exchange"
+
+    finally:
+        _remove_config_tree(tmp_path, "poll")

--- a/tests/sarracenia/sr_test.py
+++ b/tests/sarracenia/sr_test.py
@@ -81,6 +81,7 @@ def _make_global_state(tmp_path, components):
         "flow",
         "poll",
         "post",
+        "report",
         "sarra",
         "sender",
         "subscribe",
@@ -285,3 +286,75 @@ def test_default_inc_is_optional(monkeypatch):
         )
     finally:
         _remove_config_tree(tmp_path, "poll")
+
+
+def test_default_inc_nested_include(monkeypatch):
+    """
+    A nested include file inside default.inc should parse properly
+    """
+    tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
+    component_dir = tmp_path + "/poll"
+    Path(component_dir).mkdir()
+
+    Path(component_dir + "/default.inc").write_text(
+        "include nested.inc\n"
+    )
+
+    Path(component_dir + "/nested.inc").write_text(
+        "retry_ttl 3h\n"
+    )
+
+    Path(component_dir + "/test.conf").write_text(
+        "exchange my_exchange\n"
+    )
+
+    try:
+        state = _make_global_state(tmp_path, ["poll"])
+        state._read_configs()
+
+        options = state.configs["poll"]["test"]["options"]
+
+        assert options.retry_ttl == 10800
+        assert options.exchange == "my_exchange"
+    finally:
+        Path(component_dir + "/nested.inc").unlink()
+        _remove_config_tree(tmp_path, "poll")
+
+
+def test_default_inc_nested_include_can_be_overridden():
+    """
+    A nested include file inside default.inc should have its values ignored if the configuration overrides that value
+    """
+    tmp_path = '/tmp'
+    component_dir = tmp_path + "/poll"
+    Path(component_dir).mkdir()
+
+    Path(component_dir + "/default.inc").write_text(
+        "include nested.inc\n"
+    )
+
+    Path(component_dir + "/nested.inc").write_text(
+        "retry_ttl 3h\n"
+    )
+
+    Path(component_dir + "/test.conf").write_text(
+        "retry_ttl 30m\n"
+    )
+
+    try:
+        state = _make_global_state(tmp_path, ["poll"])
+        state._read_configs()
+
+        options = state.configs["poll"]["test"]["options"]
+
+        assert options.retry_ttl == 1800
+    finally:
+        Path(component_dir + "/nested.inc").unlink()
+        _remove_config_tree(tmp_path, "poll")
+

--- a/tests/sarracenia/sr_test.py
+++ b/tests/sarracenia/sr_test.py
@@ -26,7 +26,7 @@ def _make_config_tree(tmp_path, component, default_content=None, config_content=
     Returns the component directory.
     """
     component_dir = tmp_path + '/' + component
-    
+
     Path(component_dir).mkdir(parents=True, exist_ok=True)
 
     if default_content is not None:
@@ -64,6 +64,7 @@ def _make_global_state(tmp_path, components):
     )
 
     state.user_config_dir = str(tmp_path)
+
     state.components = components
 
     # _read_configs() uses options.action when building each cfgbody.
@@ -75,28 +76,36 @@ def _make_global_state(tmp_path, components):
 @pytest.mark.parametrize(
     "component",
     [
+        "cpost",
+        "cpump",
         "flow",
         "poll",
         "post",
         "sarra",
-        "watch",
         "sender",
         "subscribe",
         "shovel",
         "watch",
-        "winnow",
+        "winnow"
     ],
 )
-def test_component_default_inc(component):
+def test_component_default_inc(component, monkeypatch):
     """
     default.inc should be loaded for every supported flow component.
     """
+
     tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
     _make_config_tree(
         tmp_path,
         component,
-        default_content="exchange default_exchange\n",
-        config_content="fileEvents create,modify\n",
+        default_content="fileEvents create,modify\n",
+        config_content="exchange xs_Something\n",
     )
 
     try:
@@ -109,18 +118,24 @@ def test_component_default_inc(component):
 
         options = state.configs[component]["test"]["options"]
 
-        assert options.exchange == "default_exchange"
+        assert options.exchange == "xs_Something"
         assert options.fileEvents == {'modify', 'create'}
     finally:
         _remove_config_tree(tmp_path, component)
 
 
-def test_component_default_inc_can_be_overridden_by_config():
+def test_component_default_inc_can_be_overridden_by_config(monkeypatch):
     """
     Values from <component>/default.inc are defaults and must be overridden
     by values explicitly specified in the component configuration.
     """
     tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
     _make_config_tree(
         tmp_path,
         "poll",
@@ -140,11 +155,17 @@ def test_component_default_inc_can_be_overridden_by_config():
         _remove_config_tree(tmp_path, "poll")
 
 
-def test_component_default_inc_only_applies_to_its_component():
+def test_component_default_inc_only_applies_to_its_component(monkeypatch):
     """
     A component's default.inc must not leak into another component.
     """
     tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
     _make_config_tree(
         tmp_path,
         "poll",
@@ -170,11 +191,17 @@ def test_component_default_inc_only_applies_to_its_component():
         _remove_config_tree(tmp_path, "poll")
         _remove_config_tree(tmp_path, "sarra")
 
-def test_component_default_inc_with_two_of_same_component():
+def test_component_default_inc_with_two_of_same_component(monkeypatch):
     """
     A component's default.inc must not leak into another component.
     """
     tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
     _make_config_tree(
         tmp_path,
         "sarra",
@@ -198,16 +225,22 @@ def test_component_default_inc_with_two_of_same_component():
         _remove_config_tree(tmp_path, "sarra")
 
 
-def test_default_inc_is_not_a_configuration():
+def test_default_inc_is_not_a_configuration(monkeypatch):
     """
     default.inc is an include/default file and must not itself appear as a
     configuration.
     """
     tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
     _make_config_tree(
         tmp_path,
         "poll",
-        default_content="exchange default_exchange\n",
+        default_content="exchange xs_Something\n",
         config_content="accept .*\n",
     )
 
@@ -222,11 +255,17 @@ def test_default_inc_is_not_a_configuration():
         _remove_config_tree(tmp_path, "poll")
 
 
-def test_default_inc_is_optional():
+def test_default_inc_is_optional(monkeypatch):
     """
     A component without a default.inc must continue to load normally.
     """
     tmp_path = '/tmp/'
+    monkeypatch.setattr(
+        sarracenia.config,
+        "get_user_config_dir",
+        lambda: str(tmp_path)
+    )
+
     _make_config_tree(
         tmp_path,
         "poll",

--- a/tests/sarracenia/sr_test.py
+++ b/tests/sarracenia/sr_test.py
@@ -4,3 +4,218 @@ from tests.conftest import *
 
 import sarracenia.config
 import sarracenia.sr
+
+import copy
+import os
+import shutil
+import pytest
+from pathlib import Path
+
+import sarracenia
+import sarracenia.config
+import sarracenia.sr
+
+
+def _make_config_tree(tmp_path, component, default_content=None, config_content=None):
+    """
+    Create:
+
+        <tmp_path>/<component>/default.inc
+        <tmp_path>/<component>/test.conf
+
+    Returns the component directory.
+    """
+    component_dir = tmp_path + '/' + component
+    
+    Path(component_dir).mkdir(parents=True, exist_ok=True)
+
+    if default_content is not None:
+        Path(component_dir + "/default.inc").write_text(default_content)
+
+    if config_content is not None:
+        Path(component_dir + "/test.conf").write_text(config_content)
+
+    return component_dir
+
+
+def _remove_config_tree(tmp_path, component):
+    """
+    Remove the entire temporary Sarracenia configuration tree.
+    """
+    component_dir = tmp_path + "/" + component
+
+    for filename in ["default.inc", "test.conf"]:
+        filepath = component_dir + "/" + filename
+
+        if Path(filepath).exists():
+            Path(filepath).unlink()
+
+    if Path(component_dir).exists():
+        Path(component_dir).rmdir()
+
+
+def _make_global_state(tmp_path, components):
+    """
+    Create a minimal sr_GlobalState suitable for exercising _read_configs()
+    without invoking the normal sr3 command-line startup machinery.
+    """
+    state = sarracenia.sr.sr_GlobalState.__new__(
+        sarracenia.sr.sr_GlobalState
+    )
+
+    state.user_config_dir = str(tmp_path)
+    state.components = components
+
+    # _read_configs() uses options.action when building each cfgbody.
+    state.options = copy.deepcopy(sarracenia.config.default_config())
+    state.options.action = "start"
+
+    return state
+
+@pytest.mark.parametrize(
+    "component",
+    [
+        "flow",
+        "poll",
+        "post",
+        "sarra",
+        "watch",
+        "sender",
+        "subscribe",
+        "shovel",
+        "watch",
+        "winnow",
+    ],
+)
+def test_component_default_inc(component):
+    """
+    default.inc should be loaded for every supported flow component.
+    """
+    tmp_path = '/tmp/'
+    _make_config_tree(
+        tmp_path,
+        component,
+        default_content="exchange default_exchange\n",
+        config_content="fileEvents create,modify\n",
+    )
+
+    try:
+        state = _make_global_state(tmp_path, [component])
+
+        state._read_configs()
+
+        assert component in state.configs
+        assert "test" in state.configs[component]
+
+        options = state.configs[component]["test"]["options"]
+
+        assert options.exchange == "default_exchange"
+        assert options.fileEvents == {'modify', 'create'}
+    finally:
+        _remove_config_tree(tmp_path, component)
+
+
+def test_component_default_inc_can_be_overridden_by_config():
+    """
+    Values from <component>/default.inc are defaults and must be overridden
+    by values explicitly specified in the component configuration.
+    """
+    tmp_path = '/tmp/'
+    _make_config_tree(
+        tmp_path,
+        "poll",
+        default_content="retry_ttl 1d\n",
+        config_content="retry_ttl 1h\n",
+    )
+
+    try:
+        state = _make_global_state(tmp_path, ["poll"])
+
+        state._read_configs()
+
+        options = state.configs["poll"]["test"]["options"]
+
+        assert options.retry_ttl == 3600
+    finally:
+        _remove_config_tree(tmp_path, "poll")
+
+
+def test_component_default_inc_only_applies_to_its_component():
+    """
+    A component's default.inc must not leak into another component.
+    """
+    tmp_path = '/tmp/'
+    _make_config_tree(
+        tmp_path,
+        "poll",
+        default_content="retry_ttl 1h\n",
+        config_content="exchange poll_exchange\n",
+    )
+
+    _make_config_tree(
+        tmp_path,
+        "sarra",
+        default_content="retry_ttl 2h\n",
+        config_content="exchange sarra_exchange\n",
+    )
+
+    try:
+        state = _make_global_state(tmp_path, ["poll", "sarra"])
+
+        state._read_configs()
+
+        assert state.configs["poll"]["test"]["options"].retry_ttl == 3600
+        assert state.configs["sarra"]["test"]["options"].retry_ttl == 7200
+    finally:
+        _remove_config_tree(tmp_path, "poll")
+        _remove_config_tree(tmp_path, "sarra")
+
+
+def test_default_inc_is_not_a_configuration():
+    """
+    default.inc is an include/default file and must not itself appear as a
+    configuration.
+    """
+    tmp_path = '/tmp/'
+    _make_config_tree(
+        tmp_path,
+        "poll",
+        default_content="exchange default_exchange\n",
+        config_content="accept .*\n",
+    )
+
+    try:
+        state = _make_global_state(tmp_path, ["poll"])
+
+        state._read_configs()
+
+        assert "test" in state.configs["poll"]
+        assert "default" not in state.configs["poll"]
+    finally:
+        _remove_config_tree(tmp_path, "poll")
+
+
+def test_default_inc_is_optional():
+    """
+    A component without a default.inc must continue to load normally.
+    """
+    tmp_path = '/tmp/'
+    _make_config_tree(
+        tmp_path,
+        "poll",
+        default_content=None,
+        config_content="exchange configured_exchange\n",
+    )
+
+    try:
+        state = _make_global_state(tmp_path, ["poll"])
+
+        state._read_configs()
+
+        assert "test" in state.configs["poll"]
+        assert (
+            state.configs["poll"]["test"]["options"].exchange
+            == "configured_exchange"
+        )
+    finally:
+        _remove_config_tree(tmp_path, "poll")


### PR DESCRIPTION
This PR adds

- An entry point to parse `<component>/default.inc`  **prior** to parsing the configuration file.
   - This enables `<component>/default.inc` to override `default.conf` and;
   - This enables the configuration file to override what is in `default.conf` + `<component>/default.inc`
- I opted with `default.inc` instead of `default.conf` because
   1. Any `.conf` entry gets parsed and treated as a configuration file and;
   2. Adding component parsing in `def default_config` seemed like more work. `default.inc` does the same job and doesn't need refactoring of the code to adapt. 

- Add unit tests that test out this new entry point. Unit tests were manually ran on my VM  + GitHub actions. Both passed.
- Update documentation to reflect changes. Remove `<component>.conf` entry in documentation as I tested it and it doesn't work. I believe @reidsunderland confirmed this is a v2 specific feature.