### PR TITLE
Mail fetch (poll + download) plugin modernization

### DIFF
--- a/sarracenia/flowcb/download/mail_ingest.py
+++ b/sarracenia/flowcb/download/mail_ingest.py
@@ -2,28 +2,24 @@
 
 """
 
-This downloader corresponds to the poll.mail class.
-Fetches emails from a server using the specified protocol,
-either pop3 or imap. The imaplib/poplib implementations in
-Python use the most secure SSL settings by default: 
-PROTOCOL_TLS, OP_NO_SSLv2, and OP_NO_SSLv3.
-Compatible with Python 2.7+.
+Description
+    This downloader corresponds to the poll.mail class.
+    Fetches emails from a server using the specified protocol,
+    either pop3 or imap. The imaplib/poplib implementations in
+    Python use the most secure SSL settings by default:
+    PROTOCOL_TLS, OP_NO_SSLv2, and OP_NO_SSLv3.
 
-download_email_ingest: a sample do_download option for sr_subscribe.
-                        connects to an email server with the provided
-                        credentials and posts all new messages.
+Usage
 
-usage:
-        in an sr_subscribe configuration file:
-
-        destination [imap|imaps|pop|pops]://[user[:password]@]host[:port]/
-        do_download download_email_ingest
-
+    In ``credentials.conf``
+        [imap|imaps|pop|pops]://[user[:password]@]host[:port]/
         IMAP over SSL uses 993, POP3 over SSL uses 995
         IMAP unsecured uses 143, POP3 unsecured uses 110
-
         Full credentials must be in credentials.conf.
         If port is not specified it'll default to the ones above based on protocol/ssl setting.
+
+    In a configuration file
+        callback download.mail_ingest
 
 """
 
@@ -33,15 +29,13 @@ import sarracenia
 from sarracenia.flowcb import FlowCB
 import sarracenia.identity
 
-
 logger = logging.getLogger(__name__)
 
 class Mail_ingest(FlowCB):
 
         def download(self, msg) -> bool:
 
-                #ok, details = self.o.credentials.get(parent.msg.notice.split()[1])
-                ok, details = self.o.credentials.get(msg.baseUrl)
+                ok, details = self.o.credentials.get(msg['baseUrl'])
                 if ok: 
                         setting         = details.url
                         user            = setting.username
@@ -50,7 +44,7 @@ class Mail_ingest(FlowCB):
                         protocol        = setting.scheme.lower() 
                         port            = setting.port
                 else:
-                        logger.error(f"download_email_ingest: destination has invalid credentials: {msg['baseUrl']}")
+                        logger.error(f"destination has invalid credentials: {msg['baseUrl']}")
                         return False
 
                 if not port:
@@ -69,7 +63,7 @@ class Mail_ingest(FlowCB):
                                         mailman = imaplib.IMAP4_SSL(server, port=port)
                                         mailman.login(user, password)
                                 except imaplib.IMAP4.error as e:
-                                        logger.error(f"download_email_ingest imaplib connection error: {e}")
+                                        logger.error(f"imaplib connection error: {e}")
                                         return False
 
                         elif protocol == "imap":
@@ -77,7 +71,7 @@ class Mail_ingest(FlowCB):
                                         mailman = imaplib.IMAP4(server, port=port)
                                         mailman.login(user, password)
                                 except imaplib.IMAP4.error as e:
-                                        logger.error(f"download_email_ingest imaplib connection error: {e}")
+                                        logger.error(f"imaplib connection error: {e}")
                                         return False
                         else: return False
 
@@ -86,7 +80,7 @@ class Mail_ingest(FlowCB):
                         for index in data[0].split():
                                 r, d = mailman.fetch(index, '(RFC822)')
                                 msg = d[0][1].decode("utf-8", "ignore") + "\n"
-                                logger.info(f"download_email_ingest downloaded file: {msg['new_dir']}"+'/'+msg['new_file'])
+                                logger.info(f"downloaded file: {msg['new_dir']}"+'/'+msg['new_file'])
                                 with open(msg['new_dir']+'/'+msg['new_file'], 'w') as f:
                                        f.write(msg)
                                        f.close()
@@ -105,7 +99,7 @@ class Mail_ingest(FlowCB):
                                         mailman.user(user)
                                         mailman.pass_(password)
                                 except poplib.error_proto as e:
-                                        logger.error(f"download_email_ingest pop3 connection error: {e}")
+                                        logger.error(f"pop3 connection error: {e}")
                                         return False
 
                         elif protocol == "pop":
@@ -114,7 +108,7 @@ class Mail_ingest(FlowCB):
                                         mailman.user(user)
                                         mailman.pass_(password)
                                 except poplib.error_proto as e:
-                                        logger.error(f"download_email_ingest pop3 connection error: {e}")
+                                        logger.error(f"pop3 connection error: {e}")
                                         return False
                         else: return False
                         # only retrieves msgs that haven't triggered internal pop3 'read' flag
@@ -130,29 +124,30 @@ class Mail_ingest(FlowCB):
 
                                 # if it worked, write it locally, update message as needed.
                                 if msgid == msg['new_file']:                                        
-                                    logger.info(f"download_email_ingest downloaded file: {msg['new_dir']}"+'/'+msg['new_file'])
+                                    logger.info(f"downloaded file: {msg['new_dir']}"+'/'+msg['new_file'])
                                     
-                                    sumalgo = sarracenia.identity.Identity.factory(self.o.identity_method)
-                                    sumalgo.set_path(path)
+                                    sumalgo = sarracenia.identity.Identity.factory(method=self.o.identity_method)
+                                    sumalgo.set_path('')
                                     with open(msg['new_dir']+'/'+msg['new_file'], 'w') as f:
                                         sumalgo.update(email_message)
                                         f.write(email_message)
                                         f.close()
                                 
-                                    message['size'] = len(bytes(email_message,'utf8'))
-                                    message['identity'] = { 'method': self.o.identity_method, 'value': sumalgo.value }
+                                    msg['size'] = len(bytes(email_message,'utf8'))
+                                    msg['identity'] = { 'method': self.o.identity_method, 'value': sumalgo.value }
                                     if self.o.delete :
                                         mailman.dele(index+1)
                                     found=True
                                     break
 
+                        mailman.quit()
                         if not found:
                            logger.error('message not found on server, giving up')
+                           # If mail is not found on target server, we should append to the retry queue.
+                           return False
 
-                        mailman.quit()
-                        #v2 parent.msg.set_parts()-> sr3? msg.updatePaths( self.o, msg['new_dir'], msg['new_file'] )
                         return True
 
                 else:
-                        logger.error("download_email_ingest destination protocol must be one of 'imap/imaps' or 'pop/pops'.")
+                        logger.error("destination protocol must be one of 'imap/imaps' or 'pop/pops'.")
                         return False

--- a/sarracenia/flowcb/poll/mail.py
+++ b/sarracenia/flowcb/poll/mail.py
@@ -1,32 +1,39 @@
 """
-Posts any new emails from an email server, connected to using 
-the specified protocol, either pop3 or imap. The imaplib/poplib 
-implementations in Python use the most secure SSL settings by 
-default: PROTOCOL_TLS, OP_NO_SSLv2, and OP_NO_SSLv3.
-Compatible with Python 2.7+.
 
-A sample do_poll option for sr_poll.
-connects to an email server with the provided
-credentials and posts all new messages by their msg ID.
+Description
+	Posts any new emails from an email server, connected to using
+	the specified protocol, either pop3 or imap. The imaplib/poplib
+	implementations in Python use the most secure SSL settings by
+	default: PROTOCOL_TLS, OP_NO_SSLv2, and OP_NO_SSLv3.
 
-usage:
-        in an sr_poll configuration file:
+	connects to an email server with the provided
+	credentials and posts all new messages by their msg ID.
 
-        pollUrl [imap|imaps|pop|pops]://[user[:password]@]host[:port]/
+Options
 
+	poll_mail_filename_option
+		Select filename type based on what the email returns.
+		`subject` -> Use the subject in the destination filename
+		`msgid` -> Use the msgid in the destination filename
+
+Usage
+
+    In ``credentials.conf``
+        [imap|imaps|pop|pops]://[user[:password]@]host[:port]/
         IMAP over SSL uses 993, POP3 over SSL uses 995
         IMAP unsecured uses 143, POP3 unsecured uses 110
-
         Full credentials must be in credentials.conf.
         If port is not specified it'll default to the ones above based on protocol/ssl setting.
 
-This posts what messages are available. A separate component is needed to 
-download the message, which would need:
+    In a configuration file
+        callback poll.mail
 
-     callback download.mail_ingest
- 
-to process these posts.
+        This posts what messages are available. A separate component is needed to
+        download the message, which would need:
 
+             callback download.mail_ingest
+
+        to process these posts.
 
 """
 
@@ -36,18 +43,31 @@ import imaplib
 import logging
 import poplib
 import sarracenia
-from sarracenia.flowcb.poll import Poll
+from sarracenia.flowcb import FlowCB
+
+from urllib.parse import unquote
 
 logger = logging.getLogger(__name__)
 
 
-class Mail(Poll):
+class Mail(FlowCB):
     def __init__(self, options):
 
-        self.o = options
+        super().__init__(options,logger)
         logger.info("poll_email_ingest init")
 
-    def poll(self):
+        self.o.add_option('poll_mail_filename_option', kind='str', default_value='subject')
+
+    def attribute_filename(self, msg):
+        # Attribute filename based on specified option
+        if self.o.poll_mail_filename_option == 'msgid':
+            return email.message_from_string(msg).get('Message-ID').strip('<>')
+        else:
+            msg_subject = email.message_from_string(msg).get('Subject')
+            return msg_subject + datetime.datetime.now().strftime('%Y%m%d_%H%M%s_%f')
+
+
+    def poll(self) -> list:
 
         logger.debug("start")
 
@@ -60,9 +80,10 @@ class Mail(Poll):
             protocol = setting.scheme.lower()
             port = setting.port
             logger.debug("pollUrl valid")
+            logger.warning(f"{setting} {user} {password} {server} {protocol} {port}")
         else:
             logger.error("pollUrl: invalid credentials")
-            return
+            return []
 
         if not port:
             if protocol == "imaps":
@@ -83,7 +104,7 @@ class Mail(Poll):
                 except imaplib.IMAP4.error as e:
                     logger.error(
                         f"poll_email_ingest imaplib connection error: {e}")
-                    return
+                    return []
 
             elif protocol == "imap":
                 try:
@@ -92,19 +113,19 @@ class Mail(Poll):
                 except imaplib.IMAP4.error as e:
                     logger.error(
                         f"poll_email_ingest imaplib connection error: {e}")
-                    return
+                    return []
             else:
-                return
+                logger.error(f"unknown protocol: {protocol}")
+                return []
             # only retrieves unread mail from inbox, change these values as to your preference
             mailman.select(mailbox='INBOX')
             resp, data = mailman.search(None, '(UNSEEN)')
-            self.metrics['transferRxBytes'] += len(data)
+            # self.metrics['transferRxBytes'] += len(data)
             for index in data[0].split():
                 r, d = mailman.fetch(index, '(RFC822)')
                 msg = d[0][1].decode("utf-8", "ignore") + "\n"
-                msg_subject = email.message_from_string(msg).get('Subject')
-                msg_filename = msg_subject + datetime.datetime.now().strftime(
-                    '%Y%m%d_%H%M%s_%f')
+
+                msg_filename = self.attribute_filename(msg)
                 m = sarracenia.Message.fromFileInfo(msg_filename, self.o)
                 gathered_messages.append(m)
 
@@ -121,7 +142,7 @@ class Mail(Poll):
                 except poplib.error_proto as e:
                     logger.error(
                         f"poll_email_ingest pop3 connection error: {e}")
-                    return
+                    return []
 
             elif protocol == "pop":
                 try:
@@ -131,19 +152,17 @@ class Mail(Poll):
                 except poplib.error_proto as e:
                     logger.error(
                         f"poll_email_ingest pop3 connection error: {e}")
-                    return
+                    return []
             else:
-                return
+                return []
             # only retrieves msgs that haven't triggered internal pop3 'read' flag
             numMsgs = len(mailman.list()[1])
             for index in range(numMsgs):
                 msg = ""
                 for line in mailman.retr(index + 1)[1]:
-                    self.metrics['transferRxBytes'] += len(line)
+                    # self.metrics['transferRxBytes'] += len(line)
                     msg += line.decode("utf-8", "ignore") + "\n"
-                msg_subject = email.message_from_string(msg).get('Subject')
-                msg_filename = msg_subject + datetime.datetime.now().strftime(
-                    '%Y%m%d_%H%M%s_%f')
+                msg_filename = self.attribute_filename(msg)
                 m = sarracenia.Message.fromFileInfo(msg_filename, self.o)
                 gathered_messages.append(m)
 

--- a/sarracenia/flowcb/poll/mail.py
+++ b/sarracenia/flowcb/poll/mail.py
@@ -78,7 +78,6 @@ class Mail(FlowCB):
             protocol = setting.scheme.lower()
             port = setting.port
             logger.debug("pollUrl valid")
-            logger.warning(f"{setting} {user} {password} {server} {protocol} {port}")
         else:
             logger.error("pollUrl: invalid credentials")
             return []

--- a/sarracenia/flowcb/poll/mail.py
+++ b/sarracenia/flowcb/poll/mail.py
@@ -45,8 +45,6 @@ import poplib
 import sarracenia
 from sarracenia.flowcb import FlowCB
 
-from urllib.parse import unquote
-
 logger = logging.getLogger(__name__)
 
 

--- a/sarracenia/flowcb/poll/mail.py
+++ b/sarracenia/flowcb/poll/mail.py
@@ -54,7 +54,7 @@ class Mail(FlowCB):
     def __init__(self, options):
 
         super().__init__(options,logger)
-        logger.info("poll_email_ingest init")
+        logger.info("init")
 
         self.o.add_option('poll_mail_filename_option', kind='str', default_value='subject')
 
@@ -103,7 +103,7 @@ class Mail(FlowCB):
                     mailman.login(user, password)
                 except imaplib.IMAP4.error as e:
                     logger.error(
-                        f"poll_email_ingest imaplib connection error: {e}")
+                        f"imaplib connection error: {e}")
                     return []
 
             elif protocol == "imap":
@@ -112,7 +112,7 @@ class Mail(FlowCB):
                     mailman.login(user, password)
                 except imaplib.IMAP4.error as e:
                     logger.error(
-                        f"poll_email_ingest imaplib connection error: {e}")
+                        f"imaplib connection error: {e}")
                     return []
             else:
                 logger.error(f"unknown protocol: {protocol}")
@@ -138,10 +138,10 @@ class Mail(FlowCB):
                     mailman = poplib.POP3_SSL(server, port=port)
                     mailman.user(user)
                     mailman.pass_(password)
-                    logger.debug("poll_email_ingest connection started")
+                    logger.debug("connection started")
                 except poplib.error_proto as e:
                     logger.error(
-                        f"poll_email_ingest pop3 connection error: {e}")
+                        f"pop3 connection error: {e}")
                     return []
 
             elif protocol == "pop":
@@ -151,7 +151,7 @@ class Mail(FlowCB):
                     mailman.pass_(password)
                 except poplib.error_proto as e:
                     logger.error(
-                        f"poll_email_ingest pop3 connection error: {e}")
+                        f"pop3 connection error: {e}")
                     return []
             else:
                 return []
@@ -170,6 +170,6 @@ class Mail(FlowCB):
 
         else:
             logger.error(
-                "poll_email_ingest pollUrl protocol must be one of 'imap/imaps' or 'pop/pops'."
+                "pollUrl protocol must be one of 'imap/imaps' or 'pop/pops'."
             )
         return gathered_messages


### PR DESCRIPTION
Various fixes to the `poll/mail.py` and `download/mail_ingest.py` plugins. All tested on development servers and eventually migrated to operational servers from our internal plugin repository.

@reidsunderland suggested adding the checksum when polling the file so we don't need `nodupe_basis name` to prevent double posts. However, there doesn't seem to be a clear and obvious way to get this value without hashing the checksum from the raw data in the poll plugin. The download plugin also already fetches the checksum from the downloaded file.