### PR TITLE
stop unknown fileOp error logs for rename messages, noticed in #1770

### DIFF
--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -78,7 +78,7 @@ def sumstrFromMessage( msg ) -> str:
                 sumstr = f'r,{hash.hexdigest()}'
             else:
                 sumstr = f'm,{hash.hexdigest()}'
-        else:
+        elif 'rename' not in msg:
             logger.error(f"unknown fileOp: {msg['fileOp']}" )
     return sumstr
 

--- a/sarracenia/flowcb/v2wrapper.py
+++ b/sarracenia/flowcb/v2wrapper.py
@@ -78,7 +78,7 @@ def sumstrFromMessage( msg ) -> str:
                 sumstr = f'r,{hash.hexdigest()}'
             else:
                 sumstr = f'm,{hash.hexdigest()}'
-        elif 'rename' not in msg:
+        elif 'rename' not in msg['fileOp']:
             logger.error(f"unknown fileOp: {msg['fileOp']}" )
     return sumstr
 


### PR DESCRIPTION
When an sr3 rename fileOp message is converted to v2, an error message will be logged saying `unknown fileOp`, but that's not true. There's a separate `if` to handle renames, but it's not part of the if/elif/else logic because you can have sr3 messages that combine e.g. link and rename fileOps.