### PR TITLE
fix(flow): resolve sender path and inflight staging

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -3,6 +3,7 @@ import glob
 import importlib
 import logging
 import os
+import posixpath
 import re
 
 # v3 plugin architecture...
@@ -2531,11 +2532,11 @@ class Flow:
         """
 
         self.o = options
-        sendTo=self.o.sendTo 
-        start_time=time.perf_counter()
+        sendTo = self.o.sendTo
+        start_time = time.perf_counter()
         logger.debug('%s_transport sendTo: %s', self.scheme, sendTo)
         logger.debug('%s_transport send %s %s', self.scheme, msg['new_dir'], msg['new_file'])
- 
+
         if len(self.plugins['send']) > 0:
             ok = False
             for plugin in self.plugins['send']:
@@ -2553,37 +2554,87 @@ class Flow:
             return 1
 
         if self.o.baseDir:
-            local_path = self.o.variableExpansion(self.o.baseDir,
-                                                msg) + '/' + msg['relPath']
+            base_dir = os.path.realpath(self.o.variableExpansion(self.o.baseDir, msg))
+            candidate = os.path.join(base_dir, msg['relPath'].lstrip('/'))
+            if 'fileOp' in msg:
+                local_path = os.path.join(
+                    os.path.realpath(os.path.dirname(candidate)),
+                    os.path.basename(candidate)
+                )
+            else:
+                local_path = os.path.realpath(candidate)
+            try:
+                if os.path.commonpath([base_dir, local_path]) != base_dir:
+                    logger.error(
+                        "path traversal detected: %s escapes baseDir %s",
+                        msg['relPath'], base_dir
+                    )
+                    return -1
+            except ValueError:
+                logger.error(
+                    "path traversal detected: %s escapes baseDir %s",
+                    msg['relPath'], base_dir
+                )
+                return -1
         else:
-            local_path = '/' + msg['relPath']
+            if 'fileOp' in msg:
+                candidate = '/' + msg['relPath']
+                local_path = os.path.join(
+                    os.path.realpath(os.path.dirname(candidate)),
+                    os.path.basename(candidate)
+                )
+            else:
+                local_path = os.path.realpath('/' + msg['relPath'])
 
         # older versions don't include the contentType, so patch it here.
         if features['filetypes']['present'] and \
-           ('contentType' not in msg) and (not 'fileOp' in msg):
+           ('contentType' not in msg) and ('fileOp' not in msg):
             try:
-                msg['contentType'] = magic.from_file(local_path,mime=True)
+                msg['contentType'] = magic.from_file(local_path, mime=True)
             except Exception as e:
                 logger.warning(f"could not set contentType from local file {local_path} because {e}")
 
-        local_dir = os.path.dirname(local_path).replace('\\', '/')
-        local_file = os.path.basename(local_path).replace('\\', '/')
+        local_dir = os.path.dirname(local_path)
+        local_file = os.path.basename(local_path)
         new_dir = msg['new_dir'].replace('\\', '/')
         new_file = msg['new_file'].replace('\\', '/')
 
-        new_inflight_path = None
+        if 'fileOp' not in msg and not os.path.exists(local_path):
+            logger.error(
+                f"file {local_file} does not exist in local dir {local_dir}, can't send (baseDir not set?)"
+            )
+            time.sleep(0.01)
+            return 0
 
+        new_inflight_path = None
+        upload_started = False
+
+        curdir = None
+        saved_cwd_fd = None
+        cwd_changed = False
         try:
             curdir = os.getcwd()
-        except:
-            curdir = None
+        except Exception:
+            pass
 
-        if (curdir != local_dir) and not self.o.dry_run:
+        if not self.o.dry_run:
+            try:
+                saved_cwd_fd = os.open('.', os.O_RDONLY | os.O_DIRECTORY)
+            except (OSError, AttributeError):
+                saved_cwd_fd = None
+
+        if ('fileOp' not in msg) and (curdir != local_dir) and not self.o.dry_run:
             try:
                 os.chdir(local_dir)
+                cwd_changed = True
             except Exception as ex:
                 logger.error(f"could not chdir locally to {local_dir}: {ex}")
-                return -1
+                if saved_cwd_fd is not None:
+                    try:
+                        os.close(saved_cwd_fd)
+                    except Exception:
+                        pass
+                return 0
         try:
 
             if not self.o.dry_run:
@@ -2607,42 +2658,77 @@ class Flow:
 
             elif not (self.scheme in self.proto) or self.proto[self.scheme] is None:
                 logger.debug('dry_run %s_transport send connects', self.scheme)
-                self.proto[self.scheme] = sarracenia.transfer.Transfer.factory( self.scheme, options)
+                self.proto[self.scheme] = sarracenia.transfer.Transfer.factory(self.scheme, options)
                 self.cdir = None
                 self.metrics['flow']['transferConnected'] = True
-                self.metrics['flow']['transferConnectStart'] = time.time() 
+                self.metrics['flow']['transferConnectStart'] = time.time()
 
-            #=================================
+            # =================================
             # if parts, check that the protocol supports it
-            #=================================
+            # =================================
 
-            if not self.o.dry_run and not hasattr(self.proto[self.scheme],
-                           'seek') and ('blocks' in msg) and (
-                               msg['blocks']['method'] == 'inplace'):
+            if not hasattr(self.proto[self.scheme], 'seek') and ('blocks' in msg) and (
+                    msg['blocks']['method'] == 'inplace'):
                 logger.error(f"{self.scheme}, inplace part file not supported")
                 return -1
 
-            #=================================
-            # if umask, check that the protocol supports it ...
-            #=================================
+            # =================================
+            # inflight mode classification and capability checks
+            # =================================
 
             inflight = options.inflight
-            if not hasattr(self.proto[self.scheme],
-                           'umask') and options.inflight == 'umask':
-                logger.warning(f"{self.scheme}, umask not supported")
-                inflight = None
+            requires_rename = False
+            inflight_dir = None
 
-            #=================================
-            # if renaming used, check that the protocol supports it ...
-            #=================================
+            if inflight is not None and not isinstance(inflight, str):
+                logger.error("unsupported sender inflight mode: %r", inflight)
+                return -1
 
-            if not hasattr(self.proto[self.scheme], 'rename') and options.inflight:
-                logger.warning(f"{self.scheme}, rename not supported")
-                inflight = None
+            if inflight is None:
+                pass
+            elif inflight == 'umask':
+                if not hasattr(self.proto[self.scheme], 'umask'):
+                    logger.warning("%s, umask not supported", self.scheme)
+                    inflight = None
+            elif inflight == '.':
+                requires_rename = True
+                new_inflight_path = '.' + new_file
+            elif inflight.endswith('/') or inflight.startswith('/'):
+                requires_rename = True
+                inflight_dir = inflight.rstrip('/') or '/'
+                new_inflight_path = posixpath.join(inflight_dir, new_file)
+            elif inflight.startswith('.'):
+                requires_rename = True
+                new_inflight_path = new_file + inflight
+            else:
+                logger.error("unsupported inflight mode: %r", inflight)
+                return -1
 
-            #=================================
+            if (
+                inflight_dir is not None
+                and posixpath.isabs(inflight_dir)
+                and self.scheme in {'s3', 'azure', 'azblob'}
+            ):
+                logger.error(
+                    "%s does not implement absolute inflight paths", self.scheme
+                )
+                return -1
+
+            if 'blocks' in msg:
+                requires_rename = False
+                inflight_dir = None
+                new_inflight_path = None
+
+            if requires_rename and (new_inflight_path == new_file):
+                logger.error(
+                    "inflight staging path %r aliases destination file %r",
+                    new_inflight_path, new_file
+                )
+                return -1
+
+            # =================================
             # remote set to new_dir
-            #=================================
+            # =================================
 
             cwd = None
             if hasattr(self.proto[self.scheme], 'getcwd'):
@@ -2763,157 +2849,171 @@ class Flow:
                     logger.error(f"{self.scheme}, symlink not supported")
                     return -1
 
-            #=================================
+            # =================================
             # send event
-            #=================================
+            # =================================
 
             # the file does not exist... warn, sleep and return false for the next attempt
-            if not os.path.exists(local_file):
+            if not os.path.exists(local_path):
                 logger.error(
                     f"file {local_file} does not exist in local dir {local_dir}, can't send (baseDir not set?)")
                 time.sleep(0.01)
                 return 0
             elif 'size' not in msg:
-                msg['size'] = os.path.getsize(local_file)
+                msg['size'] = os.path.getsize(local_path)
 
             offset = 0
             if ('blocks' in msg) and (msg['blocks']['method'] == 'inplace'):
-                offset = msg['offset']
+                blk = msg['blocks']
+                if 'offset' in msg:
+                    offset = msg['offset']
+                elif 'number' in blk and 'manifest' in blk:
+                    blkno = blk['number']
+                    offset = sum(blk['manifest'][i]['size'] for i in range(blkno))
+                else:
+                    offset = 0
 
-            new_offset = msg['local_offset']
+            if ('blocks' in msg) and (msg['blocks']['method'] == 'inplace'):
+                new_offset = offset
+            else:
+                new_offset = msg.get('local_offset', 0)
 
-            if 'size' in msg:
+            if ('blocks' in msg) and (msg['blocks']['method'] == 'inplace'):
+                blk = msg['blocks']
+                if 'number' in blk and 'manifest' in blk:
+                    block_length = blk['manifest'][blk['number']]['size']
+                elif 'size' in msg:
+                    block_length = msg['size']
+                elif 'size' in blk:
+                    block_length = blk['size']
+                else:
+                    block_length = 0
+            elif 'size' in msg:
                 block_length = msg['size']
-                str_range = ''
-                if ('blocks' in msg) and (
-                        msg['blocks']['method'] == 'inplace'):
-                    block_length = msg['blocks']['size']
-                    str_range = 'bytes=%d-%d' % (new_offset, new_offset +
-                                                 block_length - 1)
+            else:
+                block_length = 0
 
             str_range = ''
             if ('blocks' in msg) and (msg['blocks']['method'] == 'inplace'):
-                str_range = 'bytes=%d-%d' % (offset, offset + msg['size'] - 1)
+                str_range = 'bytes=%d-%d' % (offset, offset + block_length - 1)
 
-            #upload file
+            if requires_rename and not hasattr(self.proto[self.scheme], 'rename'):
+                logger.error(
+                    "%s does not support rename for configured inflight %r",
+                    self.scheme, inflight
+                )
+                return -1
 
-            logger.debug('hasattr=%s, thresh=%d, len=%d, remote_off=%d, local_off=%d ', hasattr(self.proto[self.scheme], 'putAccelerated'), self.o.accelThreshold, block_length, new_offset, msg['local_offset'])
-
-            accelerated = hasattr( self.proto[self.scheme], 'putAccelerated') and \
-                (self.o.accelThreshold > 0 ) and (block_length > self.o.accelThreshold) and \
-                (new_offset == 0) and ( msg['local_offset'] == 0)
-
-            if inflight == None or (('blocks' in msg) and
-                                    (msg['blocks']['method'] != 'inplace')):
+            if requires_rename and inflight_dir is not None and not self.o.dry_run:
                 try:
-                    if not self.o.dry_run:
-                        if accelerated:
-                            len_written = self.proto[self.scheme].putAccelerated( msg, local_file, new_file)
-                        else:
-                            len_written = self.proto[self.scheme].put( msg, local_file, new_file)
+                    if inflight_dir.startswith('/'):
+                        staging_dir = inflight_dir
+                    else:
+                        staging_dir = posixpath.join(new_dir, inflight_dir)
+                    if posixpath.normpath(staging_dir) == posixpath.normpath(new_dir):
+                        logger.error(
+                            "inflight directory %s must differ from destination directory %s",
+                            staging_dir, new_dir
+                        )
+                        return -1
+                    self.proto[self.scheme].cd_forced(staging_dir)
+                    self.proto[self.scheme].cd_forced(new_dir)
                 except Exception as ex:
-                    logger.error( f"could not send {local_dir}{os.sep}{local_file} to inflight=None {sendTo} {msg['new_dir']} ... {new_file}: {ex}" )
+                    logger.error(
+                        "could not prepare inflight directory %s on %s: %s",
+                        inflight_dir, sendTo, ex
+                    )
                     return 0
-                
-            elif (('blocks' in msg)
-                  and (msg['blocks']['method'] == 'inplace')):
-                if not self.o.dry_run:
-                    try:
-                        self.proto[self.scheme].put(msg, local_file, new_file, offset,
-                                            new_offset, msg['size'])
-                    except Exception as ex:
-                        logger.error( f"could not send {local_dir}{os.sep}{local_file} inplace {sendTo} {msg['new_dir']} ... {new_file}: {ex}" )
-                        return 0
 
-            elif inflight == '.':
-                new_inflight_path = '.' + new_file
-                if not self.o.dry_run:
-                    try:
+            # upload file
+
+            logger.debug(
+                'hasattr=%s, thresh=%d, len=%d, remote_off=%d, local_off=%d ',
+                hasattr(self.proto[self.scheme], 'putAccelerated'), self.o.accelThreshold,
+                block_length, new_offset, msg.get('local_offset', 0))
+
+            accelerated = hasattr(self.proto[self.scheme], 'putAccelerated') and \
+                (self.o.accelThreshold > 0) and (block_length > self.o.accelThreshold) and \
+                (new_offset == 0) and (msg.get('local_offset', 0) == 0) and \
+                (inflight != 'umask') and \
+                not (new_inflight_path and posixpath.isabs(new_inflight_path))
+
+            len_written = 0
+            is_inplace = ('blocks' in msg) and (msg['blocks'].get('method') == 'inplace')
+
+            if not self.o.dry_run:
+                upload_started = True
+                try:
+                    if is_inplace:
+                        len_written = self.proto[self.scheme].put(
+                            msg, local_file, new_file, offset, offset, block_length
+                        )
+
+                    elif inflight is None or ('blocks' in msg):
                         if accelerated:
                             len_written = self.proto[self.scheme].putAccelerated(
-                                msg, local_file, new_inflight_path)
+                                msg, local_file, new_file
+                            )
                         else:
                             len_written = self.proto[self.scheme].put(
-                                msg, local_file, new_inflight_path)
-                    except Exception as ex:
-                        logger.error( f"could not send {local_dir}{os.sep}{local_file} inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                    try:
-                        self.proto[self.scheme].rename(new_inflight_path, new_file)
-                    except Exception as ex:
-                        logger.error( f"could not rename inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                else:
-                    len_written = msg['size']
+                                msg, local_file, new_file
+                            )
 
-            elif inflight[0] == '.':
-                new_inflight_path = new_file + inflight
-                if not self.o.dry_run:
-                    try:
+                    elif inflight == 'umask':
+                        self.proto[self.scheme].umask()
                         if accelerated:
                             len_written = self.proto[self.scheme].putAccelerated(
-                                msg, local_file, new_inflight_path)
-                        else:
-                            len_written = self.proto[self.scheme].put(msg, local_file, new_inflight_path)
-                    except Exception as ex:
-                        logger.error( f"could not send {local_dir}{os.sep}{local_file} inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                    try:
-                        self.proto[self.scheme].rename(new_inflight_path, new_file)
-                    except Exception as ex:
-                        logger.error( f"could not rename inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-            elif options.inflight[-1] == '/':
-                if not self.o.dry_run:
-                    try:
-                        self.proto[self.scheme].cd_forced(
-                            new_dir + '/' + options.inflight)
-                        self.proto[self.scheme].cd_forced(new_dir)
-                    except:
-                        pass
-                new_inflight_path = options.inflight + new_file
-                if not self.o.dry_run:
-                    try:
-                        if accelerated:
-                            len_written = self.proto[self.scheme].putAccelerated(
-                                msg, local_file, new_inflight_path)
+                                msg, local_file, new_file
+                            )
                         else:
                             len_written = self.proto[self.scheme].put(
-                                msg, local_file, new_inflight_path)
-                    except Exception as ex:
-                        logger.error( f"could not send {local_dir}{os.sep}{local_file} inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                    try:
-                        self.proto[self.scheme].rename(new_inflight_path, new_file)
-                    except Exception as ex:
-                        logger.error( f"could not rename inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                else:
-                    len_written = msg['size']
-            elif inflight == 'umask':
-                if not self.o.dry_run:
-                    self.proto[self.scheme].umask()
-                    try:
+                                msg, local_file, new_file
+                            )
+
+                    else:
                         if accelerated:
                             len_written = self.proto[self.scheme].putAccelerated(
-                                msg, local_file, new_file)
+                                msg, local_file, new_inflight_path
+                            )
                         else:
                             len_written = self.proto[self.scheme].put(
-                                msg, local_file, new_file)
-                    except Exception as ex:
-                        logger.error( f"could not send {local_dir}{os.sep}{local_file} inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                    try:
-                        self.proto[self.scheme].put(msg, local_file, new_file)
-                    except Exception as ex:
-                        logger.error( f"could not rename inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}: {ex}" )
-                        return 0
-                else:
-                    len_written = msg['size']
+                                msg, local_file, new_inflight_path
+                            )
+                except Exception as ex:
+                    logger.error(
+                        "could not send %s inflight=%s %s %s/%s: %s",
+                        local_path, inflight, sendTo, new_dir, new_file, ex
+                    )
+                    return 0
+            else:
+                len_written = block_length if is_inplace else msg['size']
 
-            if msg['size'] > 0 and len_written == 0:
-                logger.error( f"failed to send inflight={inflight} {sendTo} {msg['new_dir']}/{new_file}" )
+            expected_length = block_length if is_inplace else msg['size']
+
+            if not isinstance(len_written, int) or isinstance(len_written, bool) or len_written < 0:
+                logger.error(
+                    "failed to send %s inflight=%s %s %s/%s (invalid bytes written: %r)",
+                    local_path, inflight, sendTo, new_dir, new_file, len_written
+                )
                 return 0
+
+            if expected_length > 0 and len_written < expected_length:
+                logger.error(
+                    "incomplete transfer for %s: wrote %d of %d bytes",
+                    local_path, len_written, expected_length
+                )
+                return 0
+
+            if requires_rename and new_inflight_path is not None:
+                if not self.o.dry_run:
+                    try:
+                        self.proto[self.scheme].rename(new_inflight_path, new_file)
+                    except Exception as ex:
+                        logger.error(
+                            "could not rename inflight=%s %s %s/%s: %s",
+                            inflight, sendTo, new_dir, new_file, ex
+                        )
+                        return 0
 
             msg.setReport(201, 'file sent')
             self.metrics['flow']['transferTxBytes'] += len_written
@@ -2940,26 +3040,26 @@ class Flow:
 
         except Exception as err:
 
-            #removing lock if left over
-            if new_inflight_path != None and hasattr(self.proto[self.scheme],
-                                                     'delete'):
+            # removing lock if left over
+            if upload_started and new_inflight_path is not None and hasattr(
+                    self.proto[self.scheme], 'delete'):
                 if not self.o.dry_run:
                     try:
                         self.proto[self.scheme].delete(new_inflight_path)
-                    except:
+                    except Exception:
                         pass
 
-            #closing on problem
+            # closing on problem
             if not self.o.dry_run:
                 try:
                     self.proto[self.scheme].close()
-                except:
+                except Exception:
                     pass
 
             now = nowflt()
             self.metrics['flow']['transferConnectTime'] += now - self.metrics['flow']['transferConnectStart']
-            self.metrics['flow']['transferConnectStart']=0
-            self.metrics['flow']['transferConnected']=False
+            self.metrics['flow']['transferConnectStart'] = 0
+            self.metrics['flow']['transferConnected'] = False
             self.cdir = None
             self.proto[self.scheme] = None
 
@@ -2968,6 +3068,22 @@ class Flow:
             logger.debug('Exception details: ', exc_info=True)
 
             return 0
+        finally:
+            if saved_cwd_fd is not None:
+                try:
+                    os.fchdir(saved_cwd_fd)
+                except Exception as ex:
+                    logger.error("could not restore local cwd via fd: %s", ex)
+                finally:
+                    try:
+                        os.close(saved_cwd_fd)
+                    except Exception:
+                        pass
+            elif cwd_changed and curdir:
+                try:
+                    os.chdir(curdir)
+                except Exception as ex:
+                    logger.error("could not restore local cwd to %s: %s", curdir, ex)
 
     # set_local_file_attributes
     def set_local_file_attributes(self, local_file, msg):

--- a/sarracenia/transfer/sftp.py
+++ b/sarracenia/transfer/sftp.py
@@ -524,15 +524,7 @@ class Sftp(Transfer):
             rw_length = self.readlocal_write(local_file, local_offset,
                                              length, rfp)
 
-            # no sparse file... truncate where we are at
-
             self.fpos = remote_offset + rw_length
-            if not self.o.nofsetstat and length != 0:
-                try:
-                    rfp.truncate(self.fpos)
-                except Exception as ex:
-                    logger.warning(f"truncate {remote_file} failed: {ex}")
-                    logging.debug("Exception details:", exc_info=True)
         finally:
             alarm_set(self.o.timeout)
             try:

--- a/tests/sarracenia/flow/__flow___test.py
+++ b/tests/sarracenia/flow/__flow___test.py
@@ -68,6 +68,499 @@ def test_msg_rejected_when_sundew_extension_already_present():
     flow.filter()
 
     # worklist.rejected gets acked and set to [] at the end of filter
-    assert(len(flow.worklist.incoming) == 0)
-    assert(len(flow.worklist.rejected) == 0)
-    assert(msg not in flow.worklist.incoming)
+    assert len(flow.worklist.incoming) == 0
+    assert len(flow.worklist.rejected) == 0
+    assert msg not in flow.worklist.incoming
+
+
+def test_sender_dry_run_with_different_cwd_and_inflight():
+    """
+    Regression test for https://github.com/robjarawan/sarracenia/issues/137
+    Flow.send with dry_run True must work when process cwd != local_dir,
+    must not mutate cwd or perform remote i/o, and must handle all inflight modes.
+    """
+    import tempfile
+    import os
+    import sarracenia.transfer
+    from sarracenia.flow.sender import Sender
+
+    class DummyTransfer:
+        def __init__(self, proto, options):
+            self.proto = proto
+            self.o = options
+
+        def check_is_connected(self):
+            return True
+
+        def seek(self, *args, **kwargs):
+            raise AssertionError("seek should not be called in dry_run")
+
+        def rename(self, *args, **kwargs):
+            raise AssertionError("rename should not be called in dry_run")
+
+        def umask(self, *args, **kwargs):
+            raise AssertionError("umask should not be called in dry_run")
+
+        def cd_forced(self, *args, **kwargs):
+            raise AssertionError("cd_forced should not be called in dry_run")
+
+        def put(self, *args, **kwargs):
+            raise AssertionError("put should not be called in dry_run")
+
+        def putAccelerated(self, *args, **kwargs):
+            raise AssertionError("putAccelerated should not be called in dry_run")
+
+        def close(self):
+            pass
+
+    orig_cwd = os.getcwd()
+    orig_factory = sarracenia.transfer.Transfer.factory
+    sarracenia.transfer.Transfer.factory = staticmethod(lambda proto, opts: DummyTransfer(proto, opts))
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            base_dir = os.path.join(td, 'local_base')
+            os.makedirs(base_dir)
+            file_path = os.path.join(base_dir, 'sample.txt')
+            test_content = b'test dry run payload'
+            with open(file_path, 'wb') as f:
+                f.write(test_content)
+
+            dest_dir = os.path.join(td, 'dest')
+            os.makedirs(dest_dir)
+
+            for inflight_val in [None, '.', '.tmp', 'umask', 'dest_sub/', '.hidden/', '/absolute']:
+                options = copy.deepcopy(sarracenia.config.default_config())
+                options.component = 'sender'
+                options.config = 'test_sender_dry_run'
+                options.action = 'start'
+                options.parse_line(
+                    'sender', 'test_sender_dry_run', 'sender/test_sender_dry_run', 1, f'baseDir {base_dir}')
+                options.parse_line(
+                    'sender', 'test_sender_dry_run', 'sender/test_sender_dry_run', 2, f'sendTo file://{dest_dir}')
+                options.parse_line(
+                    'sender', 'test_sender_dry_run', 'sender/test_sender_dry_run', 3, 'dry_run True')
+                if inflight_val is not None:
+                    options.parse_line(
+                        'sender', 'test_sender_dry_run', 'sender/test_sender_dry_run', 4, f'inflight {inflight_val}')
+                else:
+                    options.parse_line(
+                        'sender', 'test_sender_dry_run', 'sender/test_sender_dry_run', 4, 'inflight None')
+                options.metricsFilename = os.path.join(td, 'metrics')
+                options.novipFilename = options.metricsFilename
+                options.acceptUnmatched = False
+                options.finalize()
+
+                sender = Sender(options)
+                msg = sarracenia.Message()
+                msg['relPath'] = 'sample.txt'
+                msg['new_dir'] = dest_dir
+                msg['new_file'] = 'sample.txt'
+                msg['local_offset'] = 0
+
+                # Ensure process cwd is outside base_dir
+                os.chdir(td)
+                assert os.getcwd() != base_dir
+                cwd_before = os.getcwd()
+
+                ret = sender.send(msg, options)
+                assert ret > 0, f"send failed for inflight={inflight_val}"
+                assert msg['report']['code'] == 201
+                assert sender.metrics['flow']['transferTxFiles'] >= 1
+                assert sender.metrics['flow']['transferTxBytes'] >= len(test_content)
+                assert os.getcwd() == cwd_before
+                assert os.listdir(dest_dir) == []
+
+            # Inplace block transfer branch test
+            inplace_options = copy.deepcopy(options)
+            inplace_options.inflight = '.'
+            inplace_sender = Sender(inplace_options)
+            inplace_msg = sarracenia.Message()
+            inplace_msg['relPath'] = 'sample.txt'
+            inplace_msg['new_dir'] = dest_dir
+            inplace_msg['new_file'] = 'sample.txt'
+            inplace_msg['local_offset'] = 0
+            inplace_msg['offset'] = 0
+            inplace_msg['size'] = len(test_content)
+            inplace_msg['blocks'] = {'method': 'inplace', 'size': len(test_content)}
+            os.chdir(td)
+            cwd_before = os.getcwd()
+            ret = inplace_sender.send(inplace_msg, inplace_options)
+            assert ret > 0
+            assert inplace_msg['report']['code'] == 201
+            assert os.getcwd() == cwd_before
+            assert os.listdir(dest_dir) == []
+
+            # Negative test: missing local file returns 0
+            missing_msg = sarracenia.Message()
+            missing_msg['relPath'] = 'nonexistent.txt'
+            missing_msg['new_dir'] = dest_dir
+            missing_msg['new_file'] = 'nonexistent.txt'
+            missing_msg['local_offset'] = 0
+            os.chdir(td)
+            cwd_before = os.getcwd()
+            ret = sender.send(missing_msg, options)
+            assert ret == 0
+            assert os.getcwd() == cwd_before
+
+            # Negative test: unsupported inflight returns -1
+            invalid_options = copy.deepcopy(options)
+            invalid_options.inflight = 'unsupported_mode'
+            invalid_sender = Sender(invalid_options)
+            valid_msg = sarracenia.Message()
+            valid_msg['relPath'] = 'sample.txt'
+            valid_msg['new_dir'] = dest_dir
+            valid_msg['new_file'] = 'sample.txt'
+            valid_msg['local_offset'] = 0
+            ret = invalid_sender.send(valid_msg, invalid_options)
+            assert ret == -1
+
+            # Negative test: empty inflight string returns -1 without IndexError
+            empty_options = copy.deepcopy(options)
+            empty_options.inflight = ''
+            empty_sender = Sender(empty_options)
+            ret = empty_sender.send(valid_msg, empty_options)
+            assert ret == -1
+
+            # Negative test: non-string numeric inflight interval returns -1
+            numeric_options = copy.deepcopy(options)
+            numeric_options.inflight = 300
+            numeric_sender = Sender(numeric_options)
+            ret = numeric_sender.send(valid_msg, numeric_options)
+            assert ret == -1
+
+            # Negative test: path traversal escaping baseDir returns -1
+            traversal_msg = sarracenia.Message()
+            traversal_msg['relPath'] = '../../etc/passwd'
+            traversal_msg['new_dir'] = dest_dir
+            traversal_msg['new_file'] = 'passwd'
+            traversal_msg['local_offset'] = 0
+            ret = sender.send(traversal_msg, options)
+            assert ret == -1
+
+            # Negative test: inplace block without seek capability in dry_run returns -1
+            noseek_options = copy.deepcopy(options)
+
+            class NoSeekDummyTransfer:
+                def __init__(self, proto, options):
+                    pass
+
+                def check_is_connected(self):
+                    return True
+
+                def connect(self):
+                    return True
+
+                def cd_forced(self, path):
+                    pass
+
+            sarracenia.transfer.Transfer.factory = staticmethod(lambda proto, opts: NoSeekDummyTransfer(proto, opts))
+            noseek_sender = Sender(noseek_options)
+            inplace_fail_msg = sarracenia.Message()
+            inplace_fail_msg['relPath'] = 'sample.txt'
+            inplace_fail_msg['new_dir'] = dest_dir
+            inplace_fail_msg['new_file'] = 'sample.txt'
+            inplace_fail_msg['blocks'] = {'method': 'inplace', 'size': 100}
+            ret = noseek_sender.send(inplace_fail_msg, noseek_options)
+            assert ret == -1
+            sarracenia.transfer.Transfer.factory = orig_factory
+    finally:
+        sarracenia.transfer.Transfer.factory = orig_factory
+        os.chdir(orig_cwd)
+
+
+def test_sender_live_inflight_and_error_handling():
+    """
+    Test live sender transfer execution across inflight modes, verifying temporary
+    paths, rename operations, process CWD restoration, and rejection of negative
+    or partial write results.
+    """
+    import tempfile
+    import os
+    import sarracenia.transfer
+    from sarracenia.flow.sender import Sender
+
+    class RecordingTransfer:
+        def __init__(self, proto, options):
+            self.proto = proto
+            self.o = options
+            self.put_calls = []
+            self.rename_calls = []
+            self.cd_forced_calls = []
+            self.put_result = None
+
+        def check_is_connected(self):
+            return True
+
+        def connect(self):
+            return True
+
+        def cd_forced(self, path):
+            self.cd_forced_calls.append(path)
+
+        def rename(self, old_path, new_path):
+            self.rename_calls.append((old_path, new_path))
+
+        def put(self, msg, local_file, remote_file, *args):
+            if args:
+                self.put_calls.append((local_file, remote_file, *args))
+            else:
+                self.put_calls.append((local_file, remote_file))
+            if self.put_result is not None:
+                return self.put_result
+            return msg['size']
+
+        def seek(self, offset):
+            pass
+
+        def close(self):
+            pass
+
+    class NoRenameTransfer:
+        def __init__(self, proto, options):
+            self.proto = proto
+            self.o = options
+            self.put_calls = []
+
+        def check_is_connected(self):
+            return True
+
+        def connect(self):
+            return True
+
+        def put(self, msg, local_file, remote_file, *args):
+            self.put_calls.append((local_file, remote_file))
+            return msg['size']
+
+        def close(self):
+            pass
+
+    orig_cwd = os.getcwd()
+    orig_factory = sarracenia.transfer.Transfer.factory
+    active_transfer = [None]
+    sarracenia.transfer.Transfer.factory = staticmethod(lambda proto, opts: active_transfer[0])
+
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            base_dir = os.path.join(td, 'local_base')
+            os.makedirs(base_dir)
+            file_path = os.path.join(base_dir, 'sample.txt')
+            test_content = b'sample test data payload'
+            with open(file_path, 'wb') as f:
+                f.write(test_content)
+
+            dest_dir = os.path.join(td, 'dest')
+            os.makedirs(dest_dir)
+
+            test_cases = [
+                ('.', '.sample.txt'),
+                ('.tmp', 'sample.txt.tmp'),
+                ('dest_sub/', 'dest_sub/sample.txt'),
+                ('.hidden/', '.hidden/sample.txt'),
+                ('/absolute', '/absolute/sample.txt'),
+            ]
+
+            for inflight_val, expected_tmp in test_cases:
+                options = copy.deepcopy(sarracenia.config.default_config())
+                options.component = 'sender'
+                options.config = 'test_live_sender'
+                options.action = 'start'
+                options.parse_line('sender', 'test_live_sender', 'sender/test', 1, f'baseDir {base_dir}')
+                options.parse_line('sender', 'test_live_sender', 'sender/test', 2, f'sendTo file://{dest_dir}')
+                options.parse_line('sender', 'test_live_sender', 'sender/test', 3, f'inflight {inflight_val}')
+                options.metricsFilename = os.path.join(td, 'metrics')
+                options.novipFilename = options.metricsFilename
+                options.acceptUnmatched = False
+                options.finalize()
+
+                rec = RecordingTransfer('file', options)
+                active_transfer[0] = rec
+                sender = Sender(options)
+                msg = sarracenia.Message()
+                msg['relPath'] = 'sample.txt'
+                msg['new_dir'] = dest_dir
+                msg['new_file'] = 'sample.txt'
+                msg['local_offset'] = 0
+
+                os.chdir(td)
+                cwd_before = os.getcwd()
+
+                ret = sender.send(msg, options)
+                assert ret == 1
+                assert rec.put_calls == [('sample.txt', expected_tmp)]
+                assert rec.rename_calls == [(expected_tmp, 'sample.txt')]
+                assert msg['report']['code'] == 201
+                assert sender.metrics['flow']['transferTxFiles'] == 1
+                assert sender.metrics['flow']['transferTxBytes'] == len(test_content)
+                assert os.getcwd() == cwd_before
+                if inflight_val == 'dest_sub/':
+                    assert rec.cd_forced_calls == [dest_dir, os.path.join(dest_dir, 'dest_sub'), dest_dir]
+                elif inflight_val == '/absolute':
+                    assert rec.cd_forced_calls == [dest_dir, '/absolute', dest_dir]
+
+            # Inplace block transfer with inflight=None verifies offsets and method precedence
+            inplace_options = copy.deepcopy(options)
+            inplace_options.inflight = None
+            inplace_rec = RecordingTransfer('file', inplace_options)
+            active_transfer[0] = inplace_rec
+            inplace_sender = Sender(inplace_options)
+            inplace_msg = sarracenia.Message()
+            inplace_msg['relPath'] = 'sample.txt'
+            inplace_msg['new_dir'] = dest_dir
+            inplace_msg['new_file'] = 'sample.txt'
+            inplace_msg['local_offset'] = 50
+            inplace_msg['offset'] = 100
+            inplace_msg['size'] = 20
+            inplace_msg['blocks'] = {'method': 'inplace', 'size': 100}
+            ret = inplace_sender.send(inplace_msg, inplace_options)
+            assert ret == 1
+            assert inplace_rec.put_calls == [('sample.txt', 'sample.txt', 100, 100, 20)]
+            assert inplace_rec.rename_calls == []
+            assert inplace_msg['report']['code'] == 201
+
+            # Native SR3 block transfer with manifest and block number
+            native_rec = RecordingTransfer('file', inplace_options)
+            active_transfer[0] = native_rec
+            native_sender = Sender(inplace_options)
+            native_msg = sarracenia.Message()
+            native_msg['relPath'] = 'sample.txt'
+            native_msg['new_dir'] = dest_dir
+            native_msg['new_file'] = 'sample.txt'
+            native_msg['size'] = 14
+            native_msg['blocks'] = {
+                'method': 'inplace',
+                'number': 1,
+                'manifest': {
+                    0: {'size': 10},
+                    1: {'size': 14}
+                }
+            }
+            ret = native_sender.send(native_msg, inplace_options)
+            assert ret == 1
+            assert native_rec.put_calls == [('sample.txt', 'sample.txt', 10, 10, 14)]
+            assert native_rec.rename_calls == []
+            assert native_msg['report']['code'] == 201
+
+            # Inplace short final block (msg['size'] < blocks['size']) succeeds
+            short_rec = RecordingTransfer('file', inplace_options)
+            active_transfer[0] = short_rec
+            short_sender = Sender(inplace_options)
+            short_msg = sarracenia.Message()
+            short_msg['relPath'] = 'sample.txt'
+            short_msg['new_dir'] = dest_dir
+            short_msg['new_file'] = 'sample.txt'
+            short_msg['local_offset'] = 0
+            short_msg['offset'] = 500
+            short_msg['size'] = 20
+            short_msg['blocks'] = {'method': 'inplace', 'size': 100}
+            ret = short_sender.send(short_msg, inplace_options)
+            assert ret == 1
+            assert short_msg['report']['code'] == 201
+
+            # Partitioned block transfer uploads directly to new_file without rename
+            part_options = copy.deepcopy(options)
+            part_options.inflight = '.tmp'
+            part_rec = RecordingTransfer('file', part_options)
+            active_transfer[0] = part_rec
+            part_sender = Sender(part_options)
+            part_msg = sarracenia.Message()
+            part_msg['relPath'] = 'sample.txt'
+            part_msg['new_dir'] = dest_dir
+            part_msg['new_file'] = 'sample.txt'
+            part_msg['local_offset'] = 0
+            part_msg['size'] = 20
+            part_msg['blocks'] = {'method': 'append', 'size': 100}
+            ret = part_sender.send(part_msg, part_options)
+            assert ret == 1
+            assert part_rec.put_calls == [('sample.txt', 'sample.txt')]
+            assert part_rec.rename_calls == []
+            assert part_msg['report']['code'] == 201
+
+            # Negative test: put() returns -1 (e.g. S3 / Azure transfer failure)
+            rec = RecordingTransfer('file', options)
+            rec.put_result = -1
+            active_transfer[0] = rec
+            sender = Sender(options)
+            fail_msg = sarracenia.Message()
+            fail_msg['relPath'] = 'sample.txt'
+            fail_msg['new_dir'] = dest_dir
+            fail_msg['new_file'] = 'sample.txt'
+            fail_msg['local_offset'] = 0
+            ret = sender.send(fail_msg, options)
+            assert ret == 0
+            assert rec.rename_calls == []
+            assert 'report' not in fail_msg or fail_msg['report']['code'] != 201
+
+            # Negative test: put() writes partial bytes
+            rec = RecordingTransfer('file', options)
+            rec.put_result = len(test_content) // 2
+            active_transfer[0] = rec
+            sender = Sender(options)
+            partial_msg = sarracenia.Message()
+            partial_msg['relPath'] = 'sample.txt'
+            partial_msg['new_dir'] = dest_dir
+            partial_msg['new_file'] = 'sample.txt'
+            partial_msg['local_offset'] = 0
+            ret = sender.send(partial_msg, options)
+            assert ret == 0
+            assert rec.rename_calls == []
+            assert 'report' not in partial_msg or partial_msg['report']['code'] != 201
+
+            # Negative test: backend lacking rename when inflight requires rename
+            no_rename_rec = NoRenameTransfer('file', options)
+            active_transfer[0] = no_rename_rec
+            sender = Sender(options)
+            no_ren_msg = sarracenia.Message()
+            no_ren_msg['relPath'] = 'sample.txt'
+            no_ren_msg['new_dir'] = dest_dir
+            no_ren_msg['new_file'] = 'sample.txt'
+            no_ren_msg['local_offset'] = 0
+            ret = sender.send(no_ren_msg, options)
+            assert ret == -1
+            assert no_rename_rec.put_calls == []
+
+            # Negative test: staging directory equals destination directory returns -1
+            alias_options = copy.deepcopy(options)
+            alias_options.inflight = './'
+            alias_rec = RecordingTransfer('file', alias_options)
+            active_transfer[0] = alias_rec
+            alias_sender = Sender(alias_options)
+            alias_msg = sarracenia.Message()
+            alias_msg['relPath'] = 'sample.txt'
+            alias_msg['new_dir'] = dest_dir
+            alias_msg['new_file'] = 'sample.txt'
+            alias_msg['local_offset'] = 0
+            ret = alias_sender.send(alias_msg, alias_options)
+            assert ret == -1
+
+            # Negative test: absolute inflight path on S3 returns -1
+            s3_options = copy.deepcopy(options)
+            s3_options.inflight = '/absolute'
+            s3_options.sendTo = 's3://bucket/dest'
+            s3_rec = RecordingTransfer('s3', s3_options)
+            active_transfer[0] = s3_rec
+            s3_sender = Sender(s3_options)
+            s3_msg = sarracenia.Message()
+            s3_msg['relPath'] = 'sample.txt'
+            s3_msg['new_dir'] = 'dest'
+            s3_msg['new_file'] = 'sample.txt'
+            s3_msg['local_offset'] = 0
+            ret = s3_sender.send(s3_msg, s3_options)
+            assert ret == -1
+
+            # Test fileOp symlink metadata creation succeeds even if target points outside baseDir
+            link_msg = sarracenia.Message()
+            link_msg['relPath'] = 'symlink_test'
+            link_msg['new_dir'] = dest_dir
+            link_msg['new_file'] = 'symlink_test'
+            link_msg['fileOp'] = {'link': '/outside/absolute/target'}
+            link_rec = RecordingTransfer('file', options)
+            link_rec.symlink_calls = []
+            link_rec.symlink = lambda target, linkname: link_rec.symlink_calls.append((target, linkname))
+            active_transfer[0] = link_rec
+            link_sender = Sender(options)
+            ret = link_sender.send(link_msg, options)
+            assert ret == 1
+            assert link_rec.symlink_calls == [('/outside/absolute/target', 'symlink_test')]
+    finally:
+        sarracenia.transfer.Transfer.factory = orig_factory
+        os.chdir(orig_cwd)


### PR DESCRIPTION
When running sender with dry_run enabled, Flow.send skipped changing directory to local_dir. Relative path existence checks against local_file failed when the daemon working directory differed from local_dir, preventing test executions from completing successfully. Furthermore, staging directories were prepared during fileOp events, partitioned block transfers triggered invalid renames of non-existent temporary paths, short final blocks were rejected during inplace transfers, and non-string inflight values caused unhandled exceptions.

Fixes: https://github.com/MetPX/sarracenia/issues/1772
Refs: https://github.com/robjarawan/sarracenia/pull/138

#### What this adds

Flow.send resolves local_path using os.path.realpath and verifies that os.path.commonpath([base_dir, local_path]) == base_dir. Any attempted path traversal outside base_dir logs an error and returns -1.

Flow.send preserves the original process working directory file descriptor prior to directory modification and restores it in a finally: block across live and dry run modes.

Inflight options enforce string validation. Directory staging paths starting with / or ending in / take precedence over file suffixes. Absolute staging paths disable accelerated transfer and are rejected on object storage backends. Staging directory creation and rename capability checks are deferred to the payload transfer section so fileOp events (remove, rename, directory, link) bypass staging operations.

Partitioned block transfers bypass staging and temporary rename steps. Inplace block transfers extract offsets and lengths from msg['blocks'] manifests, take precedence over inflight is None, and use msg['size'] as the expected written length for short final blocks. In sarracenia/transfer/sftp.py, file truncation during partial block writes is removed so out-of-order block assembly succeeds.

Written byte counts returned by transfer backends are validated against expected_length before executing renames or writing success report codes.

#### Blast radius and rollback

This change modifies transfer staging, directory switching, and write validation logic in sarracenia/flow/__init__.py and sarracenia/transfer/sftp.py.

Destructive operations:
- Staging directory preparation creates remote directories using cd_forced when configured with inflight directory paths.
- Temporary files are renamed to final destination paths upon payload transfer completion.
- Files and directories are removed during remove fileOp events.

If transfer validation fails, files remain in temporary staging paths without replacing existing target files. Rollback is accomplished by reverting the commit on the branch. Reviewers should focus on the staging directory preparation placement in sarracenia/flow/__init__.py lines 2735-2755 and block transfer precedence in lines 2820-2850.

#### How to verify

Execute the flow test suite:

    python3 -m pytest tests/sarracenia/flow/

Verify formatting and line length:

    git diff origin/development..HEAD | pycodestyle --diff --max-line-length=119

#### Evidence

<details><summary>Platform results</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /net/local/home/jarawanr/src/sarracenia/tests
configfile: pytest.ini
plugins: mock-3.15.1, depends-1.0.1, anyio-4.13.0
collected 13 items

tests/sarracenia/flow/__flow___test.py ....                              [ 30%]
tests/sarracenia/flow/callback_dispatch_test.py ........                 [ 92%]
tests/sarracenia/flow/metrics_leak_test.py .                             [100%]

======================== 13 passed, 2 warnings in 1.65s ========================
```

</details>