### PR TITLE
Restore the working directory after Flow work

### DIFF
--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1280,6 +1280,14 @@ class Flow:
 
     def work(self) -> None:
 
+        work_dir = os.getcwd()
+        try:
+            self._work()
+        finally:
+            os.chdir(work_dir)
+
+    def _work(self) -> None:
+
         self.do()
 
         # need to acknowledge here, because posting will delete message-id

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1280,48 +1280,76 @@ class Flow:
 
     def work(self) -> None:
 
-        work_dir = os.getcwd()
+        fallback_dir = getattr(self.o, 'cfg_run_dir', None)
+        if not isinstance(fallback_dir, str) or not os.path.isabs(fallback_dir) \
+                or not os.path.isdir(fallback_dir):
+            fallback_dir = os.path.abspath(os.sep)
+
         try:
-            self._work()
+            work_dir = os.getcwd()
+        except OSError as ex:
+            work_dir = None
+            logger.warning("working directory is unavailable before work: %s; using %s", ex, fallback_dir)
+            try:
+                os.chdir(fallback_dir)
+            except OSError as fallback_error:
+                fallback_dir = os.path.abspath(os.sep)
+                logger.warning("failed to use configured working directory: %s; using %s", fallback_error,
+                               fallback_dir)
+                os.chdir(fallback_dir)
+
+        work_succeeded = False
+        try:
+            self.do()
+
+            # need to acknowledge here, because posting will delete message-id
+            self.ack(self.worklist.ok)
+            self.ack(self.worklist.rejected)
+            self.ack(self.worklist.failed)
+
+            # adjust message after action is done, but before 'after_work' so adjustment is possible.
+            post_messages=[]
+
+            for m in self.worklist.ok:
+                if len(self.o.publishers) <= 1: # save creation of new messages (a lot of space & time savings.)
+                    self.work_message_adjust(m)
+                    m['publisher_index'] = 0
+                else: # replace output messages with 1 per publishing destination.
+                    i=0
+                    for p in self.o.publishers:
+                        new_m=sarracenia.Message()
+                        new_m.copyDict(m)
+                        new_m['publisher_index'] = i
+                        new_m.updatePaths( self.o, m['new_dir'], m['new_file'], i )
+                        self.work_message_adjust(new_m)
+                        post_messages.append(new_m)
+                        i += 1
+                m['_deleteOnPost'] |= set(['publisher_index'])
+
+            if len(self.o.publishers) > 1:
+                self.worklist.ok=post_messages
+
+            self._runCallbacksWorklist('after_work')
+
+            self.ack(self.worklist.rejected)
+            self.worklist.rejected = []
+            self.ack(self.worklist.failed)
+            work_succeeded = True
         finally:
-            os.chdir(work_dir)
-
-    def _work(self) -> None:
-
-        self.do()
-
-        # need to acknowledge here, because posting will delete message-id
-        self.ack(self.worklist.ok)
-        self.ack(self.worklist.rejected)
-        self.ack(self.worklist.failed)
-
-        # adjust message after action is done, but before 'after_work' so adjustment is possible.
-        post_messages=[]
-
-        for m in self.worklist.ok:
-            if len(self.o.publishers) <= 1: # save creation of new messages (a lot of space & time savings.)
-                self.work_message_adjust(m)
-                m['publisher_index'] = 0
-            else: # replace output messages with 1 per publishing destination.
-                i=0
-                for p in self.o.publishers:
-                    new_m=sarracenia.Message()
-                    new_m.copyDict(m)
-                    new_m['publisher_index'] = i
-                    new_m.updatePaths( self.o, m['new_dir'], m['new_file'], i )
-                    self.work_message_adjust(new_m)
-                    post_messages.append(new_m) 
-                    i += 1
-            m['_deleteOnPost'] |= set(['publisher_index'])
-                    
-        if len(self.o.publishers) > 1:
-            self.worklist.ok=post_messages
-    
-        self._runCallbacksWorklist('after_work')
-
-        self.ack(self.worklist.rejected)
-        self.worklist.rejected = []
-        self.ack(self.worklist.failed)
+            restore_error = None
+            for restore_dir in [work_dir, fallback_dir, os.path.abspath(os.sep)]:
+                if restore_dir is None:
+                    continue
+                try:
+                    os.chdir(restore_dir)
+                    break
+                except OSError as ex:
+                    restore_error = ex
+                    logger.warning("failed to restore working directory to %s: %s", restore_dir, ex)
+            else:
+                if work_succeeded:
+                    raise restore_error
+                logger.error("failed to restore working directory after work failed: %s", restore_error)
 
 
 

--- a/sarracenia/flow/__init__.py
+++ b/sarracenia/flow/__init__.py
@@ -1298,7 +1298,6 @@ class Flow:
                                fallback_dir)
                 os.chdir(fallback_dir)
 
-        work_succeeded = False
         try:
             self.do()
 
@@ -1334,22 +1333,25 @@ class Flow:
             self.ack(self.worklist.rejected)
             self.worklist.rejected = []
             self.ack(self.worklist.failed)
-            work_succeeded = True
         finally:
+            restored = False
             restore_error = None
             for restore_dir in [work_dir, fallback_dir, os.path.abspath(os.sep)]:
                 if restore_dir is None:
                     continue
                 try:
                     os.chdir(restore_dir)
+                    restored = True
                     break
                 except OSError as ex:
                     restore_error = ex
                     logger.warning("failed to restore working directory to %s: %s", restore_dir, ex)
-            else:
-                if work_succeeded:
-                    raise restore_error
-                logger.error("failed to restore working directory after work failed: %s", restore_error)
+            if not restored:
+                # Raising here would escape a finally, and run() does not catch
+                # it, so the instance would die without close() and leave its
+                # pidfile behind. Ask for an orderly stop instead.
+                logger.error("failed to restore working directory: %s", restore_error)
+                self.runCallbacksTime('please_stop')
 
 
 

--- a/tests/sarracenia/flow/__flow___test.py
+++ b/tests/sarracenia/flow/__flow___test.py
@@ -1,9 +1,11 @@
+import copy
+import os
+
 import pytest
-from tests.conftest import *
 
 import sarracenia.config
 import sarracenia.flow
-import copy
+from tests.conftest import *
 
 __COMPONENT="subscribe"
 __CONFIG="flow_class_test"
@@ -71,3 +73,46 @@ def test_msg_rejected_when_sundew_extension_already_present():
     assert(len(flow.worklist.incoming) == 0)
     assert(len(flow.worklist.rejected) == 0)
     assert(msg not in flow.worklist.incoming)
+
+
+def test_work_restores_cwd_after_inline_download(tmp_path, monkeypatch):
+    options = __make_fake_config(lines=["download True"])
+    flow = sarracenia.flow.Flow(options)
+    runtime_dir = tmp_path / "runtime"
+    payload_dir = tmp_path / "public_data" / "20260904" / "product" / "19"
+    runtime_dir.mkdir()
+
+    message = sarracenia.Message()
+    message["new_dir"] = str(payload_dir)
+    message["new_file"] = "payload.txt"
+    message["content"] = {"encoding": "utf-8", "value": "test payload\n"}
+    message["identity"] = {"method": "arbitrary", "value": "test"}
+    flow.worklist.incoming.append(message)
+
+    monkeypatch.chdir(runtime_dir)
+    flow.work()
+
+    assert os.getcwd() == str(runtime_dir)
+    assert (payload_dir / "payload.txt").read_text() == "test payload\n"
+
+
+def test_work_restores_cwd_when_work_raises(tmp_path, monkeypatch):
+    options = __make_fake_config()
+    flow = sarracenia.flow.Flow(options)
+    runtime_dir = tmp_path / "runtime"
+    payload_dir = tmp_path / "public_data" / "20260904"
+    runtime_dir.mkdir()
+    payload_dir.mkdir(parents=True)
+
+    def fail_inside_payload_dir():
+        error = "test failure"
+        os.chdir(payload_dir)
+        raise RuntimeError(error)
+
+    monkeypatch.setattr(flow, "do", fail_inside_payload_dir)
+    monkeypatch.chdir(runtime_dir)
+
+    with pytest.raises(RuntimeError, match="test failure"):
+        flow.work()
+
+    assert os.getcwd() == str(runtime_dir)

--- a/tests/sarracenia/flow/__flow___test.py
+++ b/tests/sarracenia/flow/__flow___test.py
@@ -116,3 +116,82 @@ def test_work_restores_cwd_when_work_raises(tmp_path, monkeypatch):
         flow.work()
 
     assert os.getcwd() == str(runtime_dir)
+
+
+def test_work_recovers_when_cwd_is_unavailable_at_entry(tmp_path, monkeypatch):
+    options = __make_fake_config()
+    fallback_dir = tmp_path / "cache" / "subscribe" / "flow_class_test"
+    unavailable_dir = tmp_path / "unavailable"
+    payload_dir = tmp_path / "public_data" / "20260904"
+    fallback_dir.mkdir(parents=True)
+    unavailable_dir.mkdir()
+    payload_dir.mkdir(parents=True)
+    options.cfg_run_dir = str(fallback_dir)
+    flow = sarracenia.flow.Flow(options)
+    worked = []
+
+    def work_in_payload_dir():
+        os.chdir(payload_dir)
+        worked.append(True)
+
+    monkeypatch.setattr(flow, "do", work_in_payload_dir)
+
+    os.chdir(unavailable_dir)
+    unavailable_dir.rmdir()
+    try:
+        flow.work()
+        assert worked == [True]
+        assert os.getcwd() == str(fallback_dir)
+    finally:
+        os.chdir(fallback_dir)
+
+
+def test_work_uses_fallback_when_saved_cwd_is_renamed(tmp_path, monkeypatch):
+    options = __make_fake_config()
+    fallback_dir = tmp_path / "cache" / "subscribe" / "flow_class_test"
+    runtime_dir = tmp_path / "runtime"
+    renamed_runtime_dir = tmp_path / "runtime-renamed"
+    payload_dir = tmp_path / "public_data" / "20260904"
+    fallback_dir.mkdir(parents=True)
+    runtime_dir.mkdir()
+    payload_dir.mkdir(parents=True)
+    options.cfg_run_dir = str(fallback_dir)
+    flow = sarracenia.flow.Flow(options)
+
+    def rename_saved_cwd():
+        runtime_dir.rename(renamed_runtime_dir)
+        os.chdir(payload_dir)
+
+    monkeypatch.setattr(flow, "do", rename_saved_cwd)
+    monkeypatch.chdir(runtime_dir)
+
+    flow.work()
+
+    assert os.getcwd() == str(fallback_dir)
+
+
+def test_work_preserves_exception_when_saved_cwd_is_removed(tmp_path, monkeypatch):
+    options = __make_fake_config()
+    fallback_dir = tmp_path / "cache" / "subscribe" / "flow_class_test"
+    runtime_dir = tmp_path / "runtime"
+    payload_dir = tmp_path / "public_data" / "20260904"
+    fallback_dir.mkdir(parents=True)
+    runtime_dir.mkdir()
+    payload_dir.mkdir(parents=True)
+    options.cfg_run_dir = str(fallback_dir)
+    flow = sarracenia.flow.Flow(options)
+    work_error = RuntimeError("test failure")
+
+    def fail_after_removing_saved_cwd():
+        os.chdir(payload_dir)
+        runtime_dir.rmdir()
+        raise work_error
+
+    monkeypatch.setattr(flow, "do", fail_after_removing_saved_cwd)
+    monkeypatch.chdir(runtime_dir)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        flow.work()
+
+    assert exc_info.value is work_error
+    assert os.getcwd() == str(fallback_dir)

--- a/tests/sarracenia/flow/__flow___test.py
+++ b/tests/sarracenia/flow/__flow___test.py
@@ -136,7 +136,7 @@ def test_work_recovers_when_cwd_is_unavailable_at_entry(tmp_path, monkeypatch):
 
     monkeypatch.setattr(flow, "do", work_in_payload_dir)
 
-    os.chdir(unavailable_dir)
+    monkeypatch.chdir(unavailable_dir)
     unavailable_dir.rmdir()
     try:
         flow.work()

--- a/tests/sarracenia/flow/__flow___test.py
+++ b/tests/sarracenia/flow/__flow___test.py
@@ -118,6 +118,7 @@ def test_work_restores_cwd_when_work_raises(tmp_path, monkeypatch):
     assert os.getcwd() == str(runtime_dir)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Windows does not permit removing the process cwd")
 def test_work_recovers_when_cwd_is_unavailable_at_entry(tmp_path, monkeypatch):
     options = __make_fake_config()
     fallback_dir = tmp_path / "cache" / "subscribe" / "flow_class_test"
@@ -159,8 +160,8 @@ def test_work_uses_fallback_when_saved_cwd_is_renamed(tmp_path, monkeypatch):
     flow = sarracenia.flow.Flow(options)
 
     def rename_saved_cwd():
-        runtime_dir.rename(renamed_runtime_dir)
         os.chdir(payload_dir)
+        runtime_dir.rename(renamed_runtime_dir)
 
     monkeypatch.setattr(flow, "do", rename_saved_cwd)
     monkeypatch.chdir(runtime_dir)


### PR DESCRIPTION
I changed `Flow.work()` to restore its starting working directory after the work cycle. Transfers currently leave the worker inside the payload directory, so an idle worker can stay attached to an old dated tree and block the retention checks described in #1774.

The existing work and acknowledgement order stays inside a `try/finally`. If the starting directory is no longer available, the worker falls back to `cfg_run_dir`, then filesystem root. Recovery preserves the original processing exception.

The [reproduction config, callback and commands](https://github.com/MetPX/sarracenia/issues/1774#issuecomment-5565675301) launch a real `sr3 foreground` worker, write an inline payload, leave it idle, and rename the dated tree. On base `24de015c`, the worker stays inside that tree and follows the rename. With the fix, it returns to its runtime directory and stays outside the renamed tree.

The [isolated DEV-pump check requested by Andre](https://github.com/robjarawan/sarracenia/pull/171#issuecomment-5591066286) confirmed that behavior at `2b92e2c4`. A second inline message also wrote the correct content, the first payload remained intact, and cleanup completed. This was one worker without a broker; the full migrator and a long-running soak were not tested.

I prepared this submission on upstream `development` at `321272b3`, carrying only the cwd fix and regression tests from robjarawan/sarracenia#171. The Flow implementation and test file are byte-identical to the DEV-tested fork head. No subscription or CI changes from the fork are included.

The seven focused Flow tests pass on this submission branch. The combined Flow, v2wrapper, logging and retry test selection reports 16 passed and 9 skipped. The earlier fork unit run recorded 378 passed and 1 skipped; [fork PR #171](https://github.com/robjarawan/sarracenia/pull/171) retains the broader flow results and outstanding CI failures. Those earlier results are not a claim that upstream CI on this new branch has passed.

For an already-affected worker, start from a stable directory outside payload storage and use a full `sr3 stop` / `sr3 start`. The in-place resource restart preserves its working directory, so a package upgrade alone does not clear an existing attachment.

#### Update, 8cb27aa

Reworked the restore loop after review. The `for`/`else` is replaced with a plain `restored` flag, and the `raise` is gone: `run()` does not catch exceptions from `work()`, so raising out of a `finally` would have killed the instance without `close()` and left its pidfile behind. An unrestorable working directory now logs and calls `runCallbacksTime('please_stop')`, matching how `run()` already handles `messageCountMax`. `work_succeeded` only existed to gate that raise and is removed.

The `restore_error is None` case that prompted the review was not reachable — `fallback_dir` is never None, since a `cfg_run_dir` that is not an absolute existing directory is replaced by the filesystem root, so at least two candidates are always attempted and the failure branch is only reached when every one raised. The block was hard to read regardless.

Focused Flow tests: 7 passed, and they still fail 5 of 7 when the restore is disabled.

Fixes #1774

