### PR TITLE
Fix issue identified in sr_insects issue 91

### DIFF
--- a/sarracenia/flowcb/gather/file.py
+++ b/sarracenia/flowcb/gather/file.py
@@ -505,7 +505,7 @@ class File(FlowCB):
         else:  ## partstr=i
             return bssetting
 
-    def wakeup(self):
+    def wakeup(self, messages):
         #logger.debug("wakeup")
 
         # FIXME: Tiny potential for events to be dropped during copy.
@@ -525,7 +525,6 @@ class File(FlowCB):
 
         # loop on all events
 
-        messages = []
         for key in self.cur_events:
             event_done=False
             event, src, dst = self.cur_events[key]
@@ -711,7 +710,7 @@ class File(FlowCB):
             messages = []
 
         if self.primed:
-            return (True, self.wakeup())
+            return (True, self.wakeup(messages))
 
         cwd = os.getcwd()
 


### PR DESCRIPTION
Fix the issue with missed messages from the watch when # of queued messages < batch on start.
I think I fully understand the problem now.

## The reason why the restart_server test fails

So the reason why this problem is only triggered during an sr3 start or restart is because **the on_start logic is slightly different from the post on_start logic**.

During an on_start, the watch does its first pass at the directory structure (primed = False) and will **operate on the generated message list via the configured batch**. This gets done via the `self.queued_messages` variable

https://github.com/MetPX/sarracenia/blob/99f2b1f3cd139db6511b27979b8d454dcb2e7942/sarracenia/flowcb/gather/file.py#L742-L748

https://github.com/MetPX/sarracenia/blob/99f2b1f3cd139db6511b27979b8d454dcb2e7942/sarracenia/flowcb/gather/file.py#L698-L710

However, once `self.queued_messages` goes down to 0, it's never operated on again and we simply do a `self.wakeup(messages)` to get the remaining message worklist. This generated messages worklist **does not** get operated on via batch sizes (so if 1000 events are found after the on_start, sarracenia will operate on those 1000 products during the same flow algorithm pass).

So the batch only gets operated on the on_start so the issue doesn't come up other then during an sr3 start or restart.

Our current data pumps don't have high volume traffic (except ca-ops on px-paz). However, ca-ops on px-paz also has `batch 500` set so it likely explains why this problem was never encountered on that flow.

## The fix

Pass the current message while passing `self.wakeup()`. This avoids unoperated messages from being lost.

## Validation

I ran the flow tests on the same RHEL8 server where the problem was reproduced 4 times and all 4 times the tests passed without issues.